### PR TITLE
Numpydoc style docstrings

### DIFF
--- a/memote/support/basic.py
+++ b/memote/support/basic.py
@@ -74,7 +74,7 @@ def find_ngam(model):
     """
     Return a the non growth-associated maintenance reaction.
 
-    From the list of all reactions that convert atp to adp select the reactions
+    From the list of all reactions that convert ATP to ADP select the reactions
     that match a defined reaction string and whose lower bound is constrained
     to be larger than zero.
 
@@ -90,7 +90,18 @@ def find_ngam(model):
 
     Notes
     -----
+    [1]_ define the non-growth associated maintenance (NGAM) as the energy
+    required to maintain all constant processes such as turgor pressure and
+    other housekeeping activities. In metabolic models this is expressed by
+    requiring a simple ATP hydrolysis reaction to always have a fixed minimal
+    amount of flux. This value can be measured as described by [1]_ .
 
+    References
+    ----------
+    .. [1] Thiele, I., & Palsson, B. Ø. (2010, January). A protocol for
+          generating a high-quality genome-scale metabolic reconstruction.
+          Nature protocols. Nature Publishing Group.
+          http://doi.org/10.1038/nprot.2009.203
 
     """
     atp_adp_conv_rxns = find_atp_adp_converting_reactions(model)
@@ -134,9 +145,9 @@ def calculate_metabolic_coverage(model):
 
     References
     ----------
-    ..[1] Monk, J., Nogales, J., & Palsson, B. O. (2014). Optimizing
-    genome-scale network reconstructions. Nature Biotechnology, 32(5), 447–452.
-    http://doi.org/10.1038/nbt.2870
+    .. [1] Monk, J., Nogales, J., & Palsson, B. O. (2014). Optimizing
+          genome-scale network reconstructions. Nature Biotechnology, 32(5),
+          447–452. http://doi.org/10.1038/nbt.2870
 
     """
     if len(model.reactions) == 0 or len(model.genes) == 0:

--- a/memote/support/basic.py
+++ b/memote/support/basic.py
@@ -74,10 +74,23 @@ def find_ngam(model):
     """
     Return a the non growth-associated maintenance reaction.
 
+    From the list of all reactions that convert atp to adp select the reactions
+    that match a defined reaction string and whose lower bound is constrained
+    to be larger than zero.
+
     Parameters
     ----------
     model : cobra.Model
         The metabolic model under investigation.
+
+    Returns
+    -------
+    list
+        Reactions that qualify as non-growth associated maintenance reactions.
+
+    Notes
+    -----
+
 
     """
     atp_adp_conv_rxns = find_atp_adp_converting_reactions(model)
@@ -91,7 +104,27 @@ def calculate_metabolic_coverage(model):
     """
     Return the ratio of reactions and genes included in the model.
 
-    According to [1] this is a good quality indicator expressing the degree of
+    Determine whether the amount of reactions and genes in model not equal to
+    zero, then return the ratio.
+
+    Parameters
+    ----------
+    model : cobra.Model
+        The metabolic model under investigation.
+
+    Returns
+    -------
+    float
+        The ratio of reactions to genes also called metabolic coverage.
+
+    Raises
+    ------
+    ValueError
+        If the model does not contain either reactions or genes.
+
+    Notes
+    -----
+    According to [1]_ this is a good quality indicator expressing the degree of
     metabolic coverage i.e. modeling detail of a given reconstruction. The
     authors explain that models with a 'high level of modeling detail have
     ratios >1, and [models] with low level of detail have ratios <1'. They
@@ -101,8 +134,8 @@ def calculate_metabolic_coverage(model):
 
     References
     ----------
-    [1] Monk, J., Nogales, J., & Palsson, B. O. (2014). Optimizing genome-scale
-    network reconstructions. Nature Biotechnology, 32(5), 447–452.
+    ..[1] Monk, J., Nogales, J., & Palsson, B. O. (2014). Optimizing
+    genome-scale network reconstructions. Nature Biotechnology, 32(5), 447–452.
     http://doi.org/10.1038/nbt.2870
 
     """

--- a/memote/support/consistency.py
+++ b/memote/support/consistency.py
@@ -225,9 +225,11 @@ def find_elementary_leakage_modes(model, atol=1e-13):
     -----
     See [1]_ section 3.4 for a complete description of the algorithm.
 
-
+    References
+    ----------
     .. [1] Gevorgyan, A., M. G Poolman, and D. A Fell.
-           "Detection of Stoichiometric Inconsistencies in Biomolecular Models."
+           "Detection of Stoichiometric Inconsistencies in Biomolecular
+           Models."
            Bioinformatics 24, no. 19 (2008): 2245.
 
     """
@@ -286,13 +288,15 @@ def find_blocked_reactions(model):
     """
     Find metabolic reactions that are blocked.
 
-    Blocked reactions are those reactions that when optimized for cannot carry
-    any flux while all exchanges are open.
-
     Parameters
     ----------
     model : cobra.Model
         The metabolic model under investigation.
+
+    Notes
+    -----
+    Blocked reactions are those reactions that when optimized for cannot carry
+    any flux while all exchanges are open.
 
     """
     with model:
@@ -330,9 +334,9 @@ def find_stoichiometrically_balanced_cycles(model):
     References
     ----------
     .. [1] Thiele, I., & Palsson, B. Ø. (2010, January). A protocol for
-       generating a high-quality genome-scale metabolic reconstruction. Nature
-       protocols. Nature Publishing Group.
-       http://doi.org/10.1038/nprot.2009.203
+           generating a high-quality genome-scale metabolic reconstruction.
+           Nature protocols. Nature Publishing Group.
+           http://doi.org/10.1038/nprot.2009.203
 
     """
     fva_result = flux_variability_analysis(model, loopless=False)

--- a/memote/support/consistency_helpers.py
+++ b/memote/support/consistency_helpers.py
@@ -171,8 +171,11 @@ def create_milp_problem(kernel, metabolites, Model, Variable, Constraint,
     Objective : optlang.Objective
         Objective class for a specific optlang interface.
 
+    References
+    ----------
     .. [1] Gevorgyan, A., M. G Poolman, and D. A Fell.
-           "Detection of Stoichiometric Inconsistencies in Biomolecular Models."
+           "Detection of Stoichiometric Inconsistencies in Biomolecular
+           Models."
            Bioinformatics 24, no. 19 (2008): 2245.
 
     """
@@ -226,8 +229,11 @@ def add_cut(problem, indicators, bound, Constraint):
     Constraint : optlang.Constraint
         Constraint class for a specific optlang interface.
 
+    References
+    ----------
     .. [1] Gevorgyan, A., M. G Poolman, and D. A Fell.
-           "Detection of Stoichiometric Inconsistencies in Biomolecular Models."
+           "Detection of Stoichiometric Inconsistencies in Biomolecular
+           Models."
            Bioinformatics 24, no. 19 (2008): 2245.
 
     """

--- a/memote/support/helpers.py
+++ b/memote/support/helpers.py
@@ -30,17 +30,19 @@ def find_transport_reactions(model):
     """
     Return a list of all transport reactions.
 
+    Parameters
+    ----------
+    model : cobra.Model
+        The metabolic model under investigation.
+
+    Notes
+    -----
     A transport reaction is defined as follows:
     1. It contains metabolites from at least 2 compartments and
     2. at least 1 metabolite undergoes no chemical reaction, i.e.,
     the formula stays the same on both sides of the equation.
 
-    Will not identify transport via the PTS System.
-
-    Parameters
-    ----------
-    model : cobra.Model
-        The metabolic model under investigation.
+    This function will not identify transport via the PTS System.
 
     """
     compartment_spanning_rxns = \
@@ -116,6 +118,13 @@ def find_demand_reactions(model):
     """
     Return a list of demand reactions.
 
+    Parameters
+    ----------
+    model : cobra.Model
+            A cobrapy metabolic model
+
+    Notes
+    -----
     [1] defines demand reactions as:
     -- 'unbalanced network reactions that allow the accumulation of a compound'
     -- reactions that are chiefly added during the gap-filling process
@@ -129,16 +138,12 @@ def find_demand_reactions(model):
     are not removed from the extracellular environment, but from any of the
     organism's compartments.
 
-    Parameters
-    ----------
-    model : cobra.Model
-            A cobrapy metabolic model
-
     References
     ----------
-    [1] Thiele, I., & Palsson, B. Ø. (2010, January). A protocol for generating
-    a high-quality genome-scale metabolic reconstruction. Nature protocols.
-    Nature Publishing Group. http://doi.org/10.1038/nprot.2009.203
+    .. [1] Thiele, I., & Palsson, B. Ø. (2010, January). A protocol for
+           generating a high-quality genome-scale metabolic reconstruction.
+           Nature protocols. Nature Publishing Group.
+           http://doi.org/10.1038/nprot.2009.203
 
     """
     demand_and_exchange_rxns = set(model.exchanges)
@@ -151,6 +156,13 @@ def find_sink_reactions(model):
     """
     Return a list of sink reactions.
 
+    Parameters
+    ----------
+    model : cobra.Model
+             A cobrapy metabolic model
+
+    Notes
+    -----
     [1] defines sink reactions as:
     -- 'similar to demand reactions' but reversible, thus able to supply the
     model with metabolites
@@ -163,16 +175,12 @@ def find_sink_reactions(model):
     are not removed from the extracellular environment, but from any of the
     organism's compartments.
 
-    Parameters
-    ----------
-    model : cobra.Model
-             A cobrapy metabolic model
-
     References
     ----------
-    [1] Thiele, I., & Palsson, B. Ø. (2010, January). A protocol for generating
-    a high-quality genome-scale metabolic reconstruction. Nature protocols.
-    Nature Publishing Group. http://doi.org/10.1038/nprot.2009.203
+    .. [1] Thiele, I., & Palsson, B. Ø. (2010, January). A protocol for
+           generating a high-quality genome-scale metabolic reconstruction.
+           Nature protocols. Nature Publishing Group.
+           http://doi.org/10.1038/nprot.2009.203
 
     """
     demand_and_exchange_rxns = set(model.exchanges)
@@ -185,6 +193,13 @@ def find_exchange_rxns(model):
     """
     Return a list of exchange reactions.
 
+    Parameters
+    ----------
+    model : cobra.Model
+            A cobrapy metabolic model
+
+    Notes
+    -----
     [1] defines exchange reactions as:
     -- reactions that 'define the extracellular environment'
     -- 'unbalanced, extra-organism reactions that represent the supply to or
@@ -196,16 +211,12 @@ def find_exchange_rxns(model):
     are removed from or added to the extracellular environment only. With this
     the uptake or secretion of a metabolite is modeled, respectively.
 
-    Parameters
-    ----------
-    model : cobra.Model
-            A cobrapy metabolic model
-
     References
     ----------
-    [1] Thiele, I., & Palsson, B. Ø. (2010, January). A protocol for generating
-    a high-quality genome-scale metabolic reconstruction. Nature protocols.
-    Nature Publishing Group. http://doi.org/10.1038/nprot.2009.203
+    .. [1] Thiele, I., & Palsson, B. Ø. (2010, January). A protocol for
+           generating a high-quality genome-scale metabolic reconstruction.
+           Nature protocols. Nature Publishing Group.
+           http://doi.org/10.1038/nprot.2009.203
 
     """
     demand_and_exchange_rxns = set(model.exchanges)

--- a/memote/support/helpers.py
+++ b/memote/support/helpers.py
@@ -121,7 +121,7 @@ def find_demand_reactions(model):
     Parameters
     ----------
     model : cobra.Model
-            A cobrapy metabolic model
+        A cobrapy metabolic model
 
     Notes
     -----
@@ -159,7 +159,7 @@ def find_sink_reactions(model):
     Parameters
     ----------
     model : cobra.Model
-             A cobrapy metabolic model
+        A cobrapy metabolic model
 
     Notes
     -----
@@ -196,7 +196,7 @@ def find_exchange_rxns(model):
     Parameters
     ----------
     model : cobra.Model
-            A cobrapy metabolic model
+        A cobrapy metabolic model
 
     Notes
     -----

--- a/memote/support/syntax.py
+++ b/memote/support/syntax.py
@@ -128,7 +128,7 @@ def find_reaction_tag_transporter(model):
     Parameters
     ----------
     model : cobra.Model
-            A cobrapy metabolic model
+        A cobrapy metabolic model
 
     Notes
     -----
@@ -158,7 +158,7 @@ def find_abc_tag_transporter(model):
     Parameters
     ----------
     model : cobra.Model
-            A cobrapy metabolic model
+        A cobrapy metabolic model
 
     Notes
     -----
@@ -190,7 +190,7 @@ def find_upper_case_mets(model):
     Parameters
     ----------
     model : cobra.Model
-            A cobrapy metabolic model
+        A cobrapy metabolic model
 
     Notes
     -----
@@ -214,7 +214,7 @@ def find_untagged_demand_rxns(model):
     Parameters
     ----------
     model : cobra.Model
-            A cobrapy metabolic model
+        A cobrapy metabolic model
 
     """
     demand_rxns = helpers.find_demand_reactions(model)
@@ -230,7 +230,7 @@ def find_false_demand_rxns(model):
     Parameters
     ----------
     model : cobra.Model
-            A cobrapy metabolic model
+        A cobrapy metabolic model
 
     """
     true_demand_rxns = helpers.find_demand_reactions(model)
@@ -248,7 +248,7 @@ def find_untagged_sink_rxns(model):
     Parameters
     ----------
     model : cobra.Model
-            A cobrapy metabolic model
+        A cobrapy metabolic model
 
     """
     sink_rxns = helpers.find_sink_reactions(model)
@@ -264,7 +264,7 @@ def find_false_sink_rxns(model):
     Parameters
     ----------
     model : cobra.Model
-            A cobrapy metabolic model
+        A cobrapy metabolic model
 
     """
     true_sink_rxns = helpers.find_sink_reactions(model)
@@ -282,7 +282,7 @@ def find_untagged_exchange_rxns(model):
     Parameters
     ----------
     model : cobra.Model
-            A cobrapy metabolic model
+        A cobrapy metabolic model
 
     """
     exchange_rxns = helpers.find_exchange_rxns(model)
@@ -298,7 +298,7 @@ def find_false_exchange_rxns(model):
     Parameters
     ----------
     model : cobra.Model
-            A cobrapy metabolic model
+        A cobrapy metabolic model
 
     """
     true_exchange_rxns = helpers.find_exchange_rxns(model)

--- a/memote/support/syntax.py
+++ b/memote/support/syntax.py
@@ -211,7 +211,7 @@ def find_untagged_demand_rxns(model):
     """
     Find demand reactions whose IDs do not begin with ``DM_``.
 
-        Parameters
+    Parameters
     ----------
     model : cobra.Model
             A cobrapy metabolic model
@@ -227,7 +227,7 @@ def find_false_demand_rxns(model):
     """
     Find reactions which are tagged with ``DM_`` but which are not demand rxns.
 
-        Parameters
+    Parameters
     ----------
     model : cobra.Model
             A cobrapy metabolic model
@@ -261,7 +261,7 @@ def find_false_sink_rxns(model):
     """
     Find reactions which are tagged with ``SK_`` but which are not sink rxns.
 
-        Parameters
+    Parameters
     ----------
     model : cobra.Model
             A cobrapy metabolic model
@@ -295,7 +295,7 @@ def find_false_exchange_rxns(model):
     """
     Find reactions that are tagged with ``EX_`` but are not exchange reactions.
 
-        Parameters
+    Parameters
     ----------
     model : cobra.Model
             A cobrapy metabolic model

--- a/memote/support/syntax.py
+++ b/memote/support/syntax.py
@@ -125,6 +125,13 @@ def find_reaction_tag_transporter(model):
     """
     Return incorrectly tagged transport reactions.
 
+    Parameters
+    ----------
+    model : cobra.Model
+            A cobrapy metabolic model
+
+    Notes
+    -----
     A transport reaction is defined as follows:
     1. It contains metabolites from at least 2 compartments and
     2. at least 1 metabolite undergoes no chemical reaction, i.e.,
@@ -133,11 +140,6 @@ def find_reaction_tag_transporter(model):
     Reactions that only transport protons ('H') across the membrane are
     excluded, as well as reactions with redox cofactors whose formula is
     either 'X' or 'XH2'
-
-    Parameters
-    ----------
-    model : cobra.Model
-            A cobrapy metabolic model
 
     """
     transport_rxns = helpers.find_transport_reactions(model)
@@ -153,6 +155,13 @@ def find_abc_tag_transporter(model):
     """
     Find Atp-binding cassette transport rxns without 'abc' tag.
 
+    Parameters
+    ----------
+    model : cobra.Model
+            A cobrapy metabolic model
+
+    Notes
+    -----
     An ABC transport reaction is defined as follows:
     1. It contains metabolites from at least 2 compartments,
     2. at least 1 metabolite undergoes no chemical reaction, i.e.,
@@ -163,11 +172,6 @@ def find_abc_tag_transporter(model):
     Reactions that only transport protons ('H') across the membrane are
     excluded, as well as reactions with redox cofactors whose formula is
     either 'X' or 'XH2'
-
-    Parameters
-    ----------
-    model : cobra.Model
-            A cobrapy metabolic model
 
     """
     transport_rxns = helpers.find_transport_reactions(model)
@@ -183,17 +187,19 @@ def find_upper_case_mets(model):
     """
     Find metabolites whose ID roots contain uppercase characters.
 
+    Parameters
+    ----------
+    model : cobra.Model
+            A cobrapy metabolic model
+
+    Notes
+    -----
     In metabolite names, individual uppercase exceptions are allowed:
     -- Dextorotary prefix: 'D'
     -- Levorotary prefix: 'L'
     -- Prefixes for the absolute configuration of a stereocenter: 'R' and 'S'
     -- Prefixes for the absolute stereochemistry of double bonds 'E' and 'Z'
     -- Acyl carrier proteins can be labeled as 'ACP'
-
-    Parameters
-    ----------
-    model : cobra.Model
-            A cobrapy metabolic model
 
     """
     comp_pattern = "^([a-z0-9]|Z|E|L|D|ACP|S|R)+_\w+"


### PR DESCRIPTION
* [x] fix #121 
* [X] add numpydoc styled notes and references sections to find_ngam and calculate_metabolic_coverage in basic.py
* [X] add numpydoc styled notes and references sections to find_elementary_leakage_modes, find_blocked_reactions, and find_stoichiometrically_balanced_cycles  in consistency.py
* [X] add numpydoc styled reference sections to create_milp_problem and add_cut  in consistency_helpers.py
* [X] add numpydoc styled notes and references sections to find_transport_rxns, find_demand_rxns, find_sink_rxns and find_exchange_rxns in helpers.py
* [X] add numpydoc styled notes and references sections to find_reaction_tag_transporter, find_abc_tag_transporter and find_uppercase_mets in syntax.py
