### PR TITLE
feat: add a replay option

### DIFF
--- a/memote/suite/runner.py
+++ b/memote/suite/runner.py
@@ -313,7 +313,6 @@ def new(ctx, replay):
     new directory will be placed in the current directory or respect the given
     --directory option.
     """
-
     directory = ctx.obj["directory"]
     if directory is None:
         directory = os.getcwd()

--- a/memote/suite/runner.py
+++ b/memote/suite/runner.py
@@ -297,8 +297,14 @@ def report(ctx, one_time, index):
 
 @cli.command()
 @click.help_option("--help", "-h")
+@click.option("--replay", is_flag=True, default=False,
+              description="Create a memote repository using the same values as "
+              "before by default.")
+@click.option("--overwrite", is_flag=True, default=False,
+              description="Whether to overwrite existing files and "
+              "directories.")
 @click.pass_context
-def new(ctx):
+def new(ctx, replay, overwrite):
     """
     Create a suitable model repository structure from a template.
 
@@ -310,7 +316,8 @@ def new(ctx):
     directory = ctx.obj["directory"]
     if directory is None:
         directory = os.getcwd()
-    cookiecutter("gh:opencobra/cookiecutter-memote", output_dir=directory)
+    cookiecutter("gh:opencobra/cookiecutter-memote", output_dir=directory,
+                 replay=replay, overwrite_if_exists=overwrite)
 
 
 @cli.command()

--- a/memote/suite/runner.py
+++ b/memote/suite/runner.py
@@ -35,7 +35,7 @@ import git
 from click_configfile import (
     ConfigFileReader, Param, SectionSchema, matches_section)
 from colorama import init, Fore
-from cookiecutter.main import cookiecutter
+from cookiecutter.main import cookiecutter, get_user_config
 
 from memote import __version__
 from memote.suite.collect import ResultCollectionPlugin
@@ -297,14 +297,14 @@ def report(ctx, one_time, index):
 
 @cli.command()
 @click.help_option("--help", "-h")
-@click.option("--replay", is_flag=True, default=False,
-              description="Create a memote repository using the same values as "
-              "before by default.")
-@click.option("--overwrite", is_flag=True, default=False,
-              description="Whether to overwrite existing files and "
-              "directories.")
+@click.option("--replay", is_flag=True,
+              help="Create a memote repository using the exact same answers "
+              "as before. This will not overwrite existing directories. If "
+              "you want to adjust the answers, edit the template "
+              "'{}'.".format(join(get_user_config()["replay_dir"],
+                                  "cookiecutter-memote.json")))
 @click.pass_context
-def new(ctx, replay, overwrite):
+def new(ctx, replay):
     """
     Create a suitable model repository structure from a template.
 
@@ -313,11 +313,12 @@ def new(ctx, replay, overwrite):
     new directory will be placed in the current directory or respect the given
     --directory option.
     """
+
     directory = ctx.obj["directory"]
     if directory is None:
         directory = os.getcwd()
     cookiecutter("gh:opencobra/cookiecutter-memote", output_dir=directory,
-                 replay=replay, overwrite_if_exists=overwrite)
+                 replay=replay)
 
 
 @cli.command()


### PR DESCRIPTION
`memote new` now acccepts a `--replay`` option that will create a repository from the template with the exact answers as before. Should make playing with this feature a little more convenient.
