### PR TITLE
fix: catch errors where they have been reported

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -4,10 +4,8 @@ History
 Next Release
 ------------
 
-0.4.3 (2017-08-26)
-------------------
-
 * Temporarily remove ``test_find_stoichiometrically_balanced_cycles``
+* Catch errors when testing for compartments and loops.
 
 0.4.2 (2017-08-22)
 ------------------

--- a/memote/suite/tests/test_syntax.py
+++ b/memote/suite/tests/test_syntax.py
@@ -32,10 +32,10 @@ def non_cytosolic(read_only_model, store):
         store["non_cytosolic"] = compartments.remove('c')
         return compartments
     except ValueError:
-        print ("The model does not contain a compartment ID "
-               "labeled ``c`` for the cytosol which is an essential"
-               "compartment. Many syntax tests depend on this being labeled"
-               "accordingly.")
+        print("The model does not contain a compartment ID "
+              "labeled ``c`` for the cytosol which is an essential"
+              "compartment. Many syntax tests depend on this being labeled"
+              "accordingly.")
         store["non_cytosolic"] = []
         return []
 

--- a/memote/suite/tests/test_syntax.py
+++ b/memote/suite/tests/test_syntax.py
@@ -28,9 +28,16 @@ import memote.support.syntax as syntax
 def non_cytosolic(read_only_model, store):
     """Provide all non-cytosolic compartments."""
     compartments = sorted(read_only_model.compartments)
-    compartments.remove('c')
-    store["non_cytosolic"] = compartments
-    return compartments
+    try:
+        store["non_cytosolic"] = compartments.remove('c')
+        return compartments
+    except ValueError:
+        print ("The model does not contain a compartment ID "
+               "labeled ``c`` for the cytosol which is an essential"
+               "compartment. Many syntax tests depend on this being labeled"
+               "accordingly.")
+        store["non_cytosolic"] = []
+        return []
 
 
 def test_non_transp_rxn_id_compartment_suffix_match(read_only_model, store,

--- a/memote/suite/tests/test_syntax.py
+++ b/memote/suite/tests/test_syntax.py
@@ -19,9 +19,13 @@
 
 from __future__ import absolute_import
 
+import logging
+
 import pytest
 
 import memote.support.syntax as syntax
+
+LOGGER = logging.getLogger(__name__)
 
 
 @pytest.fixture(scope="module")
@@ -32,10 +36,10 @@ def non_cytosolic(read_only_model, store):
         store["non_cytosolic"] = compartments.remove('c')
         return compartments
     except ValueError:
-        print("The model does not contain a compartment ID "
-              "labeled ``c`` for the cytosol which is an essential"
-              "compartment. Many syntax tests depend on this being labeled"
-              "accordingly.")
+        LOGGER.error(
+            "The model does not contain a compartment ID labeled 'c' for the "
+            "cytosol which is an essential compartment. Many syntax tests "
+            "depend on this being labeled accordingly.")
         store["non_cytosolic"] = []
         return []
 

--- a/memote/support/consistency.py
+++ b/memote/support/consistency.py
@@ -29,10 +29,6 @@ from cobra.flux_analysis import flux_variability_analysis
 import memote.support.helpers as helpers
 import memote.support.consistency_helpers as con_helpers
 
-__all__ = (
-    "check_stoichiometric_consistency", "find_unconserved_metabolites",
-    "find_inconsistent_min_stoichiometry")
-
 LOGGER = logging.getLogger(__name__)
 
 
@@ -342,14 +338,13 @@ def find_stoichiometrically_balanced_cycles(model):
     try:
         fva_result = flux_variability_analysis(model, loopless=False)
         fva_result_loopless = flux_variability_analysis(model, loopless=True)
-        row_ids_max = fva_result[
-            fva_result.maximum != fva_result_loopless.maximum].index
-        row_ids_min = fva_result[
-            fva_result.minimum != fva_result_loopless.minimum].index
-        differential_fluxes = set(row_ids_min).union(set(row_ids_max))
-        return [model.reactions.get_by_id(id) for id in differential_fluxes]
-    except Exception as e:
-        print("The test to find stoichiometrically balances cycles"
-              "failed with the following exception {}. "
-              "This may be a bug.".format(e))
+    except Infeasible as err:
+        LOGGER.error("Failed to find stoichiometrically balanced cycles "
+                     "because '{}'. This may be a bug.".format(err))
         return []
+    row_ids_max = fva_result[
+        fva_result.maximum != fva_result_loopless.maximum].index
+    row_ids_min = fva_result[
+        fva_result.minimum != fva_result_loopless.minimum].index
+    differential_fluxes = set(row_ids_min).union(set(row_ids_max))
+    return [model.reactions.get_by_id(id) for id in differential_fluxes]

--- a/memote/support/consistency.py
+++ b/memote/support/consistency.py
@@ -351,4 +351,5 @@ def find_stoichiometrically_balanced_cycles(model):
     except Exception as e:
         print("The test to find stoichiometrically balances cycles"
               "failed with the following exception {}. "
-              "This may a bug.".format(e))
+              "This may be a bug.".format(e))
+        return []

--- a/memote/support/consistency.py
+++ b/memote/support/consistency.py
@@ -339,12 +339,16 @@ def find_stoichiometrically_balanced_cycles(model):
            http://doi.org/10.1038/nprot.2009.203
 
     """
-    fva_result = flux_variability_analysis(model, loopless=False)
-    fva_result_loopless = flux_variability_analysis(model, loopless=True)
-    row_ids_max = fva_result[
-        fva_result.maximum != fva_result_loopless.maximum].index
-    row_ids_min = fva_result[
-        fva_result.minimum != fva_result_loopless.minimum].index
-    differential_fluxes = set(row_ids_min).union(set(row_ids_max))
-
-    return [model.reactions.get_by_id(id) for id in differential_fluxes]
+    try:
+        fva_result = flux_variability_analysis(model, loopless=False)
+        fva_result_loopless = flux_variability_analysis(model, loopless=True)
+        row_ids_max = fva_result[
+            fva_result.maximum != fva_result_loopless.maximum].index
+        row_ids_min = fva_result[
+            fva_result.minimum != fva_result_loopless.minimum].index
+        differential_fluxes = set(row_ids_min).union(set(row_ids_max))
+        return [model.reactions.get_by_id(id) for id in differential_fluxes]
+    except Exception as e:
+        print("The test to find stoichiometrically balances cycles"
+              "failed with the following exception {}. "
+              "This may a bug.".format(e))

--- a/tests/test_for_support/test_for_consistency.py
+++ b/tests/test_for_support/test_for_consistency.py
@@ -205,7 +205,6 @@ def infeasible_toy_model(base):
     return base
 
 
-
 def model_builder(name):
     choices = {
         "fig-1": figure_1,


### PR DESCRIPTION
* [x] fix #145, #168
* [x] This quick fix should catch the value error raises when handing memote a model without any compartments or without the compartment 'c' for cytosol. Moreover, this fix now catches errors that might occur when running FVA and loopless FVA, which prohibited the corresponding test to show up.
* [x] All tests passed locally
* [x] Update History.rst