### PR TITLE
refactor: disable test for cycles temporarily

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -4,6 +4,11 @@ History
 Next Release
 ------------
 
+0.4.3 (2017-08-26)
+------------------
+
+* Temporarily remove ``test_find_stoichiometrically_balanced_cycles``
+
 0.4.2 (2017-08-22)
 ------------------
 

--- a/memote/suite/tests/test_consistency.py
+++ b/memote/suite/tests/test_consistency.py
@@ -64,13 +64,13 @@ def test_blocked_reactions(read_only_model, store):
             ", ".join(store["blocked_reactions"]))
 
 
-def test_find_stoichiometrically_balanced_cycles(read_only_model, store):
-    """Expect no stoichiometrically balanced loops to be present."""
-    store["looped_reactions"] = [
-        rxn.id for rxn in consistency.find_stoichiometrically_balanced_cycles(
-            read_only_model
-        )]
-    assert len(store["looped_reactions"]) == 0,\
-        "The following reactions participate in stoichiometrically balanced" \
-        " cycles: {}".format(
-            ", ".join(store["looped_reactions"]))
+# def test_find_stoichiometrically_balanced_cycles(read_only_model, store):
+#     """Expect no stoichiometrically balanced loops to be present."""
+#     store["looped_reactions"] = [
+#         rxn.id for rxn in consistency.find_stoichiometrically_balanced_cycles(
+#             read_only_model
+#         )]
+#     assert len(store["looped_reactions"]) == 0,\
+#         "The following reactions participate in stoichiometrically balanced" \
+#         " cycles: {}".format(
+#             ", ".join(store["looped_reactions"]))

--- a/memote/suite/tests/test_consistency.py
+++ b/memote/suite/tests/test_consistency.py
@@ -19,6 +19,8 @@
 
 from __future__ import absolute_import
 
+import pytest
+
 import memote.support.consistency as consistency
 
 
@@ -64,13 +66,15 @@ def test_blocked_reactions(read_only_model, store):
             ", ".join(store["blocked_reactions"]))
 
 
-# def test_find_stoichiometrically_balanced_cycles(read_only_model, store):
-#     """Expect no stoichiometrically balanced loops to be present."""
-#     store["looped_reactions"] = [
-#         rxn.id for rxn in consistency.find_stoichiometrically_balanced_cycles(
-#             read_only_model
-#         )]
-#     assert len(store["looped_reactions"]) == 0,\
-#         "The following reactions participate in stoichiometrically balanced" \
-#         " cycles: {}".format(
-#             ", ".join(store["looped_reactions"]))
+@pytest.mark.skip(reason="Loopless FVA currently runs too slow for large "
+                         "models.")
+def test_find_stoichiometrically_balanced_cycles(read_only_model, store):
+    """Expect no stoichiometrically balanced loops to be present."""
+    store["looped_reactions"] = [
+        rxn.id for rxn in consistency.find_stoichiometrically_balanced_cycles(
+            read_only_model
+        )]
+    assert len(store["looped_reactions"]) == 0,\
+        "The following reactions participate in stoichiometrically balanced" \
+        " cycles: {}".format(
+            ", ".join(store["looped_reactions"]))

--- a/memote/support/consistency.py
+++ b/memote/support/consistency.py
@@ -309,42 +309,42 @@ def find_blocked_reactions(model):
     return [model.reactions.get_by_id(name) for name in blocked.index]
 
 
-def find_stoichiometrically_balanced_cycles(model):
-    """
-    Find metabolic rxns in stoichiometrically balanced cycles (SBCs).
-
-    The flux distribution of nominal FVA is compared with loopless FVA
-    (loopless=True) to determine reactions that participate in loops, as
-    participation in loops would increase the flux through a given reactions to
-    the maximal bounds. This function then returns reactions where the flux
-    differs between the two FVA calculations.
-
-    Parameters
-    ----------
-    model : cobra.Model
-        The metabolic model under investigation.
-
-    Notes
-    -----
-    "SBCs are artifacts of metabolic reconstructions due to insufficient
-    constraints (e.g., thermodynamic constraints and regulatory
-    constraints) [1]_." They are defined by internal reactions that carry flux
-    in spite of closed exchange reactions.
-
-    References
-    ----------
-    .. [1] Thiele, I., & Palsson, B. Ø. (2010, January). A protocol for
-           generating a high-quality genome-scale metabolic reconstruction.
-           Nature protocols. Nature Publishing Group.
-           http://doi.org/10.1038/nprot.2009.203
-
-    """
-    fva_result = flux_variability_analysis(model, loopless=False)
-    fva_result_loopless = flux_variability_analysis(model, loopless=True)
-    row_ids_max = fva_result[
-        fva_result.maximum != fva_result_loopless.maximum].index
-    row_ids_min = fva_result[
-        fva_result.minimum != fva_result_loopless.minimum].index
-    differential_fluxes = set(row_ids_min).union(set(row_ids_max))
-
-    return [model.reactions.get_by_id(id) for id in differential_fluxes]
+# def find_stoichiometrically_balanced_cycles(model):
+#     """
+#     Find metabolic rxns in stoichiometrically balanced cycles (SBCs).
+#
+#     The flux distribution of nominal FVA is compared with loopless FVA
+#     (loopless=True) to determine reactions that participate in loops, as
+#     participation in loops would increase the flux through a given reactions to
+#     the maximal bounds. This function then returns reactions where the flux
+#     differs between the two FVA calculations.
+#
+#     Parameters
+#     ----------
+#     model : cobra.Model
+#         The metabolic model under investigation.
+#
+#     Notes
+#     -----
+#     "SBCs are artifacts of metabolic reconstructions due to insufficient
+#     constraints (e.g., thermodynamic constraints and regulatory
+#     constraints) [1]_." They are defined by internal reactions that carry flux
+#     in spite of closed exchange reactions.
+#
+#     References
+#     ----------
+#     .. [1] Thiele, I., & Palsson, B. Ø. (2010, January). A protocol for
+#            generating a high-quality genome-scale metabolic reconstruction.
+#            Nature protocols. Nature Publishing Group.
+#            http://doi.org/10.1038/nprot.2009.203
+#
+#     """
+#     fva_result = flux_variability_analysis(model, loopless=False)
+#     fva_result_loopless = flux_variability_analysis(model, loopless=True)
+#     row_ids_max = fva_result[
+#         fva_result.maximum != fva_result_loopless.maximum].index
+#     row_ids_min = fva_result[
+#         fva_result.minimum != fva_result_loopless.minimum].index
+#     differential_fluxes = set(row_ids_min).union(set(row_ids_max))
+#
+#     return [model.reactions.get_by_id(id) for id in differential_fluxes]

--- a/memote/support/consistency.py
+++ b/memote/support/consistency.py
@@ -315,9 +315,9 @@ def find_blocked_reactions(model):
 #
 #     The flux distribution of nominal FVA is compared with loopless FVA
 #     (loopless=True) to determine reactions that participate in loops, as
-#     participation in loops would increase the flux through a given reactions to
-#     the maximal bounds. This function then returns reactions where the flux
-#     differs between the two FVA calculations.
+#     participation in loops would increase the flux through a given reactions
+#     to the maximal bounds. This function then returns reactions where the
+#     flux differs between the two FVA calculations.
 #
 #     Parameters
 #     ----------
@@ -328,8 +328,8 @@ def find_blocked_reactions(model):
 #     -----
 #     "SBCs are artifacts of metabolic reconstructions due to insufficient
 #     constraints (e.g., thermodynamic constraints and regulatory
-#     constraints) [1]_." They are defined by internal reactions that carry flux
-#     in spite of closed exchange reactions.
+#     constraints) [1]_." They are defined by internal reactions that carry
+#     flux in spite of closed exchange reactions.
 #
 #     References
 #     ----------

--- a/memote/support/consistency.py
+++ b/memote/support/consistency.py
@@ -309,42 +309,42 @@ def find_blocked_reactions(model):
     return [model.reactions.get_by_id(name) for name in blocked.index]
 
 
-# def find_stoichiometrically_balanced_cycles(model):
-#     """
-#     Find metabolic rxns in stoichiometrically balanced cycles (SBCs).
-#
-#     The flux distribution of nominal FVA is compared with loopless FVA
-#     (loopless=True) to determine reactions that participate in loops, as
-#     participation in loops would increase the flux through a given reactions
-#     to the maximal bounds. This function then returns reactions where the
-#     flux differs between the two FVA calculations.
-#
-#     Parameters
-#     ----------
-#     model : cobra.Model
-#         The metabolic model under investigation.
-#
-#     Notes
-#     -----
-#     "SBCs are artifacts of metabolic reconstructions due to insufficient
-#     constraints (e.g., thermodynamic constraints and regulatory
-#     constraints) [1]_." They are defined by internal reactions that carry
-#     flux in spite of closed exchange reactions.
-#
-#     References
-#     ----------
-#     .. [1] Thiele, I., & Palsson, B. Ø. (2010, January). A protocol for
-#            generating a high-quality genome-scale metabolic reconstruction.
-#            Nature protocols. Nature Publishing Group.
-#            http://doi.org/10.1038/nprot.2009.203
-#
-#     """
-#     fva_result = flux_variability_analysis(model, loopless=False)
-#     fva_result_loopless = flux_variability_analysis(model, loopless=True)
-#     row_ids_max = fva_result[
-#         fva_result.maximum != fva_result_loopless.maximum].index
-#     row_ids_min = fva_result[
-#         fva_result.minimum != fva_result_loopless.minimum].index
-#     differential_fluxes = set(row_ids_min).union(set(row_ids_max))
-#
-#     return [model.reactions.get_by_id(id) for id in differential_fluxes]
+def find_stoichiometrically_balanced_cycles(model):
+    """
+    Find metabolic rxns in stoichiometrically balanced cycles (SBCs).
+
+    The flux distribution of nominal FVA is compared with loopless FVA
+    (loopless=True) to determine reactions that participate in loops, as
+    participation in loops would increase the flux through a given reactions
+    to the maximal bounds. This function then returns reactions where the
+    flux differs between the two FVA calculations.
+
+    Parameters
+    ----------
+    model : cobra.Model
+        The metabolic model under investigation.
+
+    Notes
+    -----
+    "SBCs are artifacts of metabolic reconstructions due to insufficient
+    constraints (e.g., thermodynamic constraints and regulatory
+    constraints) [1]_." They are defined by internal reactions that carry
+    flux in spite of closed exchange reactions.
+
+    References
+    ----------
+    .. [1] Thiele, I., & Palsson, B. Ø. (2010, January). A protocol for
+           generating a high-quality genome-scale metabolic reconstruction.
+           Nature protocols. Nature Publishing Group.
+           http://doi.org/10.1038/nprot.2009.203
+
+    """
+    fva_result = flux_variability_analysis(model, loopless=False)
+    fva_result_loopless = flux_variability_analysis(model, loopless=True)
+    row_ids_max = fva_result[
+        fva_result.maximum != fva_result_loopless.maximum].index
+    row_ids_min = fva_result[
+        fva_result.minimum != fva_result_loopless.minimum].index
+    differential_fluxes = set(row_ids_min).union(set(row_ids_max))
+
+    return [model.reactions.get_by_id(id) for id in differential_fluxes]

--- a/tests/test_for_support/test_for_consistency.py
+++ b/tests/test_for_support/test_for_consistency.py
@@ -266,11 +266,11 @@ def test_blocked_reactions(model, num):
     assert len(dict_of_blocked_rxns) == num
 
 
-# @pytest.mark.parametrize("model, num", [
-#     ("loopy_toy_model", 3),
-#     ("constrained_toy_model", 0),
-# ], indirect=["model"])
-# def test_find_stoichiometrically_balanced_cycles(model, num):
-#     """Expect no stoichiometrically balanced loops to be present."""
-#     rxns_in_loops = consistency.find_stoichiometrically_balanced_cycles(model)
-#     assert len(rxns_in_loops) == num
+@pytest.mark.parametrize("model, num", [
+    ("loopy_toy_model", 3),
+    ("constrained_toy_model", 0),
+], indirect=["model"])
+def test_find_stoichiometrically_balanced_cycles(model, num):
+    """Expect no stoichiometrically balanced loops to be present."""
+    rxns_in_loops = consistency.find_stoichiometrically_balanced_cycles(model)
+    assert len(rxns_in_loops) == num

--- a/tests/test_for_support/test_for_consistency.py
+++ b/tests/test_for_support/test_for_consistency.py
@@ -266,11 +266,11 @@ def test_blocked_reactions(model, num):
     assert len(dict_of_blocked_rxns) == num
 
 
-@pytest.mark.parametrize("model, num", [
-    ("loopy_toy_model", 3),
-    ("constrained_toy_model", 0),
-], indirect=["model"])
-def test_find_stoichiometrically_balanced_cycles(model, num):
-    """Expect no stoichiometrically balanced loops to be present."""
-    rxns_in_loops = consistency.find_stoichiometrically_balanced_cycles(model)
-    assert len(rxns_in_loops) == num
+# @pytest.mark.parametrize("model, num", [
+#     ("loopy_toy_model", 3),
+#     ("constrained_toy_model", 0),
+# ], indirect=["model"])
+# def test_find_stoichiometrically_balanced_cycles(model, num):
+#     """Expect no stoichiometrically balanced loops to be present."""
+#     rxns_in_loops = consistency.find_stoichiometrically_balanced_cycles(model)
+#     assert len(rxns_in_loops) == num


### PR DESCRIPTION
* [X] The test for stoichiometrically balanced cycles takes forever to run, I'm temporarily disabling it to optimise its performance without it further affecting the functionality of memote.
* [X] I commented out the functions `test_find_stoichiometrically_balanced_cycles` in `test_consistency.py` and `test_for_consistency` respectively.
* [X] add an entry to the [next release](../HISTORY.rst)
