### PR TITLE
Bug fixes

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -4,6 +4,10 @@ History
 Next Release
 ------------
 
+* Fix a bunch of bugs:
+    - Remove false positive detection of Biocyc annotation
+    - Allow memote to identify CTP or GTP driven transport reactions
+    - Refactor how memote detects GAM in the biomass reaction
 * Add tests to find deadend, orphan and disconnected metabolites.
 * Extend and improve algorithm to find energy-generating cycles
 * Remove the ``print`` statement from ``memote.support.annotation

--- a/docs/getting_started.rst
+++ b/docs/getting_started.rst
@@ -120,7 +120,7 @@ file. Automatic draft reconstruction tools such as `Pathway Tools`_,
 this format. Model repositories such as `BiGG`_ or `BioModels`_ further serve
 as a great resource for models in the correct format.
 
-.. _Pathway Tools: http://bioinformatics.ai.sri.com/ptools/
+.. _Pathway Tools: http://www.pathwaytools.org/
 .. _Model SEED: http://modelseed.org
 .. _The RAVEN Toolbox: https://github.com/SysBioChalmers/RAVEN
 .. _others: http://www.secondarymetabolites.org/sysbio/

--- a/memote/suite/tests/test_annotation.py
+++ b/memote/suite/tests/test_annotation.py
@@ -127,12 +127,10 @@ def test_metabolite_id_namespace_consistency(read_only_model, store):
     overview = annotation.generate_component_id_namespace_overview(
         read_only_model, "metabolites")
     store['met_ids_in_each_namespace'] = dict(
-        (key, int(val)) for key, val in distribution.iteritems())
+        (key, int(val)) for key, val in overview.iteritems())
     distribution = overview.sum()
     cols = list(distribution.index)
-    largest =  distribution[cols].idxmax()
-    if distribution[largest] == 0:
-        largest = 'biocyc'
+    largest = distribution[cols].idxmax()
     if largest != 'bigg.metabolite':
         warn(
             'memote currently only supports syntax checks for BiGG identifiers.'
@@ -141,7 +139,7 @@ def test_metabolite_id_namespace_consistency(read_only_model, store):
         )
     assert distribution[largest] == len(read_only_model.metabolites), \
         "Metabolite IDs that don't belong to the largest fraction: {}"\
-        "".format(met_id_ns.loc[~met_id_ns[largest], largest].index)
+        "".format(overview.loc[~overview[largest], largest].index)
 
 
 def test_reaction_id_namespace_consistency(read_only_model, store):
@@ -149,10 +147,10 @@ def test_reaction_id_namespace_consistency(read_only_model, store):
     overview = annotation.generate_component_id_namespace_overview(
         read_only_model, "reactions")
     store['rxn_ids_in_each_namespace'] = dict(
-        (key, int(val)) for key, val in distribution.iteritems())
+        (key, int(val)) for key, val in overview.iteritems())
     distribution = overview.sum()
     cols = list(distribution.index)
-    largest =  distribution[cols].idxmax()
+    largest = distribution[cols].idxmax()
     if largest != 'bigg.reaction':
         warn(
             'memote currently only supports syntax checks for BiGG identifiers.'
@@ -161,4 +159,4 @@ def test_reaction_id_namespace_consistency(read_only_model, store):
         )
     assert distribution[largest] == len(read_only_model.metabolites), \
         "Reaction IDs that don't belong to the largest fraction: {}" \
-        "".format(rxn_id_ns.loc[~rxn_id_ns[largest], largest].index)
+        "".format(overview.loc[~overview[largest], largest].index)

--- a/memote/suite/tests/test_annotation.py
+++ b/memote/suite/tests/test_annotation.py
@@ -124,15 +124,13 @@ def test_reaction_annotation_wrong_ids(read_only_model, store):
 
 def test_metabolite_id_namespace_consistency(read_only_model, store):
     """Expect metabolite IDs to be from the same namespace."""
-    met_id_ns = annotation.generate_component_id_namespace_overview(
+    overview = annotation.generate_component_id_namespace_overview(
         read_only_model, "metabolites")
-    distribution = met_id_ns.sum()
     store['met_ids_in_each_namespace'] = dict(
         (key, int(val)) for key, val in distribution.iteritems())
-    # The BioCyc regex is extremely general, we ignore it here.
+    distribution = overview.sum()
     cols = list(distribution.index)
-    cols.remove('biocyc')
-    largest = distribution[cols].idxmax()
+    largest =  distribution[cols].idxmax()
     if distribution[largest] == 0:
         largest = 'biocyc'
     if largest != 'bigg.metabolite':
@@ -148,17 +146,13 @@ def test_metabolite_id_namespace_consistency(read_only_model, store):
 
 def test_reaction_id_namespace_consistency(read_only_model, store):
     """Expect reaction IDs to be from the same namespace."""
-    rxn_id_ns = annotation.generate_component_id_namespace_overview(
+    overview = annotation.generate_component_id_namespace_overview(
         read_only_model, "reactions")
-    distribution = rxn_id_ns.sum()
     store['rxn_ids_in_each_namespace'] = dict(
         (key, int(val)) for key, val in distribution.iteritems())
-    # The BioCyc regex is extremely general, we ignore it here.
+    distribution = overview.sum()
     cols = list(distribution.index)
-    cols.remove('biocyc')
-    largest = distribution[cols].idxmax()
-    if distribution[largest] == 0:
-        largest = 'biocyc'
+    largest =  distribution[cols].idxmax()
     if largest != 'bigg.reaction':
         warn(
             'memote currently only supports syntax checks for BiGG identifiers.'

--- a/memote/suite/tests/test_biomass.py
+++ b/memote/suite/tests/test_biomass.py
@@ -115,7 +115,7 @@ def test_gam_in_biomass(model, reaction_id, store):
     store["gam_in_biomass"] = store.get(
         "gam_in_biomass", list())
     reaction = model.reactions.get_by_id(reaction_id)
-    present = biomass.gam_in_biomass(reaction, model)
+    present = biomass.gam_in_biomass(reaction)
     store["gam_in_biomass"].append(present)
     assert present, \
         "{} does not contain a term for growth-associated maintenance." \

--- a/memote/support/annotation.py
+++ b/memote/support/annotation.py
@@ -44,6 +44,7 @@ LOGGER = logging.getLogger(__name__)
 # 'BioCyc'  ['rxn','met'] 'http://biocyc.org'
 # 'Reactome'    ['met'] 'http://www.reactome.org/'
 # 'BiGG'    ['rxn','met']   'http://bigg.ucsd.edu/universal/'
+# 'PubChem' ['met'] 'https://pubchem.ncbi.nlm.nih.gov/'
 
 REACTION_ANNOTATIONS = [('rhea', re.compile(r"^\d{5}$")),
                         ('kegg.reaction', re.compile(r"^R\d+$")),
@@ -67,7 +68,8 @@ REACTION_ANNOTATIONS = [('rhea', re.compile(r"^\d{5}$")),
 REACTION_ANNOTATIONS = OrderedDict(REACTION_ANNOTATIONS)
 
 
-METABOLITE_ANNOTATIONS = [('kegg.compound', re.compile(r"^C\d+$")),
+METABOLITE_ANNOTATIONS = [('pubchem.compound', re.compile(r"^\d+$")),
+                          ('kegg.compound', re.compile(r"^C\d+$")),
                           ('seed.compound', re.compile(r"^cpd\d+$")),
                           ('inchikey', re.compile(r"^[A-Z]{14}\-"
                                                   r"[A-Z]{10}(\-[A-Z])?")),

--- a/memote/support/annotation.py
+++ b/memote/support/annotation.py
@@ -182,7 +182,7 @@ def generate_component_annotation_miriam_match(model, components):
 
 def generate_component_id_namespace_overview(model, components):
     """
-    Tabulate which MIRIAM databases the component's ID matches.
+    Tabulate which MIRIAM databases the component's identifier matches.
 
     Parameters
     ----------
@@ -217,15 +217,14 @@ def generate_component_id_namespace_overview(model, components):
         # DB pattern AND the Biocyc pattern we have to assume that this is a
         # false positive.
         # First determine all rows in which 'biocyc' and other entries are
-        # True simulatenously and use this boolean series to create another
+        # True simultaneously and use this Boolean series to create another
         # column temporarily.
-        df['duplicate'] = df[df['biocyc'] == 1].sum(axis=1) >= 2
+        df['duplicate'] = df[df['biocyc']].sum(axis=1) >= 2
         # Replace all nan values with False
-        df = df.fillna(False)
+        df['duplicate'].fillna(False, inplace=True)
         # Use the additional column to index the original dataframe to identify
         # false positive biocyc hits and set them to False.
-        df.set_value(df['duplicate'], 'biocyc', False)
+        df.loc[df['duplicate'], 'biocyc'] = False
         # Delete the additional column
         del df['duplicate']
-        # Return the cleaned up dataframe.
     return df

--- a/memote/support/annotation.py
+++ b/memote/support/annotation.py
@@ -227,7 +227,3 @@ def generate_component_id_namespace_overview(model, components):
         del df['duplicate']
         # Return the cleaned up dataframe.
     return df
-
-
-def calculate_distribution():
-    pass

--- a/memote/support/basic.py
+++ b/memote/support/basic.py
@@ -104,7 +104,9 @@ def find_ngam(model):
           http://doi.org/10.1038/nprot.2009.203
 
     """
-    atp_adp_conv_rxns = helpers.find_atp_adp_converting_reactions(model)
+    atp_adp_conv_rxns = helpers.find_converting_reactions(
+        model, ["atp", "adp"]
+    )
     return [rxn for rxn in atp_adp_conv_rxns
             if rxn.build_reaction_string() == 'atp_c + h2o_c --> '
                                               'adp_c + h_c + pi_c' and not

--- a/memote/support/basic.py
+++ b/memote/support/basic.py
@@ -104,9 +104,7 @@ def find_ngam(model):
           http://doi.org/10.1038/nprot.2009.203
 
     """
-    atp_adp_conv_rxns = helpers.find_converting_reactions(
-        model, ["atp", "adp"]
-    )
+    atp_adp_conv_rxns = helpers.find_converting_reactions(model, ("atp", "adp"))
     return [rxn for rxn in atp_adp_conv_rxns
             if rxn.build_reaction_string() == 'atp_c + h2o_c --> '
                                               'adp_c + h_c + pi_c' and not
@@ -171,8 +169,7 @@ def find_enzyme_complexes(model):
     for rxn in model.reactions:
         if rxn.gene_reaction_rule:
             for candidate in helpers.find_functional_units(
-                rxn.gene_reaction_rule
-            ):
+                    rxn.gene_reaction_rule):
                 if len(candidate) >= 2:
                     enzyme_complexes.add(tuple(candidate))
     return enzyme_complexes
@@ -180,7 +177,7 @@ def find_enzyme_complexes(model):
 
 def find_pure_metabolic_reactions(model):
     """
-    Return list of reactions neither transporters, exchanges nor pseudo rxns.
+    Return reactions that are neither transporters, exchanges, nor pseudo.
 
     Parameters
     ----------
@@ -190,13 +187,10 @@ def find_pure_metabolic_reactions(model):
     """
     exchanges = set(model.exchanges)
     transporters = set(helpers.find_transport_reactions(model))
-    biomass_rxns = set(helpers.find_biomass_reaction(model))
-    return [rxn for rxn in model.reactions
-            if rxn not in exchanges
-            if rxn not in transporters
-            if rxn not in biomass_rxns]
+    biomass = set(helpers.find_biomass_reaction(model))
+    return set(model.reactions) - (exchanges | transporters | biomass)
 
 
 def find_unique_metabolites(model):
     """Return set of metabolite IDs without duplicates from compartments."""
-    return set([met.id[:-2] for met in model.metabolites])
+    return set(met.id.split("_", 1)[0] for met in model.metabolites)

--- a/memote/support/biomass.py
+++ b/memote/support/biomass.py
@@ -23,7 +23,7 @@ import logging
 
 from six import iteritems
 from cobra.exceptions import Infeasible
-from memote.support.helpers import find_atp_adp_converting_reactions
+import memote.support.helpers as helpers
 
 __all__ = (
     "sum_biomass_weight", "find_biomass_precursors",
@@ -105,5 +105,7 @@ def gam_in_biomass(reaction, model):
         The metabolic model under investigation.
 
     """
-    atp_adp_reactions = find_atp_adp_converting_reactions(model)
+    atp_adp_reactions = helpers.find_converting_reactions(
+        model, ["atp", "adp"]
+    )
     return reaction in set(atp_adp_reactions)

--- a/memote/support/biomass.py
+++ b/memote/support/biomass.py
@@ -103,9 +103,6 @@ def gam_in_biomass(reaction):
     """
     left = set(["atp_c", "h2o_c"])
     right = set(["adp_c", "pi_c", "h_c"])
-    if left.issubset(
-        set(met.id for met in reaction.reactants)
-    ) and right.issubset(set(met.id for met in reaction.products)):
-        return True
-    else:
-        return False
+    return (
+        left.issubset(met.id for met in reaction.reactants) and
+        right.issubset(met.id for met in reaction.products))

--- a/memote/support/biomass.py
+++ b/memote/support/biomass.py
@@ -92,7 +92,7 @@ def find_blocked_biomass_precursors(reaction, model):
     return blocked_precursors
 
 
-def gam_in_biomass(reaction, model):
+def gam_in_biomass(reaction):
     """
     Return boolean if biomass reaction includes growth-associated maintenance.
 
@@ -101,11 +101,11 @@ def gam_in_biomass(reaction, model):
     reaction : cobra.core.reaction.Reaction
         The biomass reaction of the model under investigation.
 
-    model : cobra.Model
-        The metabolic model under investigation.
-
     """
-    atp_adp_reactions = helpers.find_converting_reactions(
-        model, ["atp", "adp"]
-    )
-    return reaction in set(atp_adp_reactions)
+    left = set(["atp_c", "h2o_c"])
+    right = set(["adp_c", "pi_c", "h_c"])
+    if left.issubset(set(met.id for met in reaction.reactants))  \
+        and right.issubset(set(met.id for met in reaction.products)):
+        return True
+    else:
+        return False

--- a/memote/support/biomass.py
+++ b/memote/support/biomass.py
@@ -23,7 +23,6 @@ import logging
 
 from six import iteritems
 from cobra.exceptions import Infeasible
-import memote.support.helpers as helpers
 
 __all__ = (
     "sum_biomass_weight", "find_biomass_precursors",
@@ -104,8 +103,9 @@ def gam_in_biomass(reaction):
     """
     left = set(["atp_c", "h2o_c"])
     right = set(["adp_c", "pi_c", "h_c"])
-    if left.issubset(set(met.id for met in reaction.reactants))  \
-        and right.issubset(set(met.id for met in reaction.products)):
+    if left.issubset(
+        set(met.id for met in reaction.reactants)
+    ) and right.issubset(set(met.id for met in reaction.products)):
         return True
     else:
         return False

--- a/memote/support/helpers.py
+++ b/memote/support/helpers.py
@@ -122,30 +122,33 @@ def find_transport_reactions(model):
     return transport_reactions
 
 
-def find_atp_adp_converting_reactions(model):
+def find_converting_reactions(model, met_pair):
     """
-    Find reactions which interact with ATP and ADP.
+    Find reactions which convert a given metabolite pair.
 
     Parameters
     ----------
     model : cobra.Model
         The metabolic model under investigation.
+    met_pair: list
+        List of metabolite IDs (string) without compartment suffix where one
+        metabolite gets converted into the other by an enzymatic reaction.
 
     """
-    atp_all_comp_rxn_list = []
+    met1_all_comp_rxn_list = []
     for met in model.metabolites:
-        if re.match('^atp_.*', met.id):
-            atp_all_comp_rxn_list.append(met.reactions)
+        if re.match('^{}_.*'.format(met_pair[0]), met.id):
+            met1_all_comp_rxn_list.append(met.reactions)
 
-    adp_all_comp_rxn_list = []
+    met2_all_comp_rxn_list = []
     for met in model.metabolites:
-        if re.match('^adp_.*', met.id):
-            adp_all_comp_rxn_list.append(met.reactions)
+        if re.match('^{}_.*'.format(met_pair[1]), met.id):
+            met2_all_comp_rxn_list.append(met.reactions)
 
-    atp_union = set().union(*atp_all_comp_rxn_list)
-    adp_union = set().union(*adp_all_comp_rxn_list)
+    met1_union = set().union(*met1_all_comp_rxn_list)
+    met2_union = set().union(*met2_all_comp_rxn_list)
 
-    return atp_union.intersection(adp_union)
+    return met1_union.intersection(met2_union)
 
 
 def find_biomass_reaction(model):

--- a/memote/support/syntax.py
+++ b/memote/support/syntax.py
@@ -146,7 +146,7 @@ def find_reaction_tag_transporter(model):
 
     """
     transport_rxns = helpers.find_transport_reactions(model)
-    atp_adp_rxns = helpers.find_atp_adp_converting_reactions(model)
+    atp_adp_rxns = helpers.find_converting_reactions(model, ["atp", "adp"])
 
     non_abc_transporters = set(transport_rxns).difference(set(atp_adp_rxns))
 
@@ -179,9 +179,12 @@ def find_abc_tag_transporter(model):
 
     """
     transport_rxns = helpers.find_transport_reactions(model)
-    atp_adp_rxns = helpers.find_atp_adp_converting_reactions(model)
+    atp_adp_rxns = helpers.find_converting_reactions(model, ["atp", "adp"])
+    gtp_gdp_rxns = helpers.find_converting_reactions(model, ["gtp", "gdp"])
+    ctp_cdp_rxns = helpers.find_converting_reactions(model, ["ctp", "cdp"])
+    energy_requiring = set().union(*[atp_adp_rxns, gtp_gdp_rxns, ctp_cdp_rxns])
 
-    abc_transporters = set(transport_rxns).intersection(set(atp_adp_rxns))
+    abc_transporters = set(transport_rxns).intersection(energy_requiring)
 
     return [rxn for rxn in abc_transporters
             if not re.match("[A-Z0-9]+\w*?abc\w*?", rxn.id)]

--- a/memote/support/syntax.py
+++ b/memote/support/syntax.py
@@ -149,7 +149,7 @@ def find_reaction_tag_transporter(model):
     atp_adp_rxns = helpers.find_converting_reactions(model, ["atp", "adp"])
     gtp_gdp_rxns = helpers.find_converting_reactions(model, ["gtp", "gdp"])
     ctp_cdp_rxns = helpers.find_converting_reactions(model, ["ctp", "cdp"])
-    energy_requiring = set().union(*[atp_adp_rxns, gtp_gdp_rxns, ctp_cdp_rxns])
+    energy_requiring = set().union(atp_adp_rxns, gtp_gdp_rxns, ctp_cdp_rxns)
 
     non_abc_transporters = set(transport_rxns).difference(energy_requiring)
 
@@ -185,7 +185,7 @@ def find_abc_tag_transporter(model):
     atp_adp_rxns = helpers.find_converting_reactions(model, ["atp", "adp"])
     gtp_gdp_rxns = helpers.find_converting_reactions(model, ["gtp", "gdp"])
     ctp_cdp_rxns = helpers.find_converting_reactions(model, ["ctp", "cdp"])
-    energy_requiring = set().union(*[atp_adp_rxns, gtp_gdp_rxns, ctp_cdp_rxns])
+    energy_requiring = set().union(atp_adp_rxns, gtp_gdp_rxns, ctp_cdp_rxns)
 
     abc_transporters = set(transport_rxns).intersection(energy_requiring)
 

--- a/memote/support/syntax.py
+++ b/memote/support/syntax.py
@@ -147,8 +147,11 @@ def find_reaction_tag_transporter(model):
     """
     transport_rxns = helpers.find_transport_reactions(model)
     atp_adp_rxns = helpers.find_converting_reactions(model, ["atp", "adp"])
+    gtp_gdp_rxns = helpers.find_converting_reactions(model, ["gtp", "gdp"])
+    ctp_cdp_rxns = helpers.find_converting_reactions(model, ["ctp", "cdp"])
+    energy_requiring = set().union(*[atp_adp_rxns, gtp_gdp_rxns, ctp_cdp_rxns])
 
-    non_abc_transporters = set(transport_rxns).difference(set(atp_adp_rxns))
+    non_abc_transporters = set(transport_rxns).difference(energy_requiring)
 
     return [rxn for rxn in non_abc_transporters
             if not re.match("[A-Z0-9]+\w*?t\w*?", rxn.id)

--- a/tests/test_for_suite/test_for_cli/test_for_reports.py
+++ b/tests/test_for_suite/test_for_cli/test_for_reports.py
@@ -19,10 +19,7 @@
 
 from __future__ import absolute_import
 
-from builtins import str
 from os.path import exists
-
-import pytest
 
 from memote.suite.cli.reports import report
 

--- a/tests/test_for_support/test_for_annotation.py
+++ b/tests/test_for_support/test_for_annotation.py
@@ -57,7 +57,8 @@ def rxn_annotations(base):
 
 def met_each_present(base):
     met = cobra.Metabolite(id='met_c', name="Met")
-    met.annotation = {'metanetx.chemical': "MNXM23",
+    met.annotation = {'pubchem.compound' : "107735",
+                      'metanetx.chemical': "MNXM23",
                       'kegg.compound': "C00022",
                       'seed.compound': "cpd00020",
                       'inchikey': "LCTONWCANYUPML-UHFFFAOYSA-M",

--- a/tests/test_for_support/test_for_annotation.py
+++ b/tests/test_for_support/test_for_annotation.py
@@ -167,7 +167,11 @@ def inconsistent_ids(base):
     rxn2.add_metabolites({met1: -1, met2: 1})
     rxn3 = cobra.Reaction(id='4.1.1.3', name="Oxaloacetate decarboxylase")
     rxn3.add_metabolites({met2: -1, met: 1})
-    base.add_reactions([rxn, rxn2, rxn3])
+    rxn4 = cobra.Reaction(
+        id='KETOGLUCOSE-REDUCTASE-RXN', name="Reaction: 1.1.1.-"
+    )
+    rxn4.add_metabolites({met2: -1, met: 1})
+    base.add_reactions([rxn, rxn2, rxn3, rxn4])
     return base
 
 

--- a/tests/test_for_support/test_for_basic.py
+++ b/tests/test_for_support/test_for_basic.py
@@ -379,4 +379,3 @@ def test_find_pure_metabolic_reactions(model, num):
 def test_find_unique_metabolites(model, num):
     """Expect amount of metabolic reactions to be identified correctly."""
     assert len(basic.find_unique_metabolites(model)) == num
-

--- a/tests/test_for_support/test_for_biomass.py
+++ b/tests/test_for_support/test_for_biomass.py
@@ -294,7 +294,7 @@ def test_gam_in_biomass(model, boolean):
     """Expect the biomass reactions to contain atp and adp."""
     biomass_rxns = helpers.find_biomass_reaction(model)
     for rxn in biomass_rxns:
-        assert biomass.gam_in_biomass(rxn, model) is boolean
+        assert biomass.gam_in_biomass(rxn) is boolean
 
 
 @pytest.mark.parametrize("model, boolean", [

--- a/tests/test_for_support/test_for_helpers.py
+++ b/tests/test_for_support/test_for_helpers.py
@@ -98,6 +98,23 @@ def energy_transfer(base):
     return base
 
 
+def converting_reactions(base):
+    """Provide a model with a couple of converting reaction."""
+    a = cobra.Metabolite("a_c")
+    b = cobra.Metabolite("b_c")
+    c = cobra.Metabolite("c_c")
+    c2 = cobra.Metabolite("c_e")
+    c3 = cobra.Metabolite("c_p")
+    rxn1 = cobra.Reaction("R1")
+    rxn1.add_metabolites({a: -1, b: 1})
+    rxn2 = cobra.Reaction("R2")
+    rxn2.add_metabolites({a: -1, c: -1, b: 1, c2: 1})
+    rxn3 = cobra.Reaction("R3")
+    rxn3.add_metabolites({a: -1, c3: 1, c2: 1})
+    base.add_reactions([rxn1, rxn2, rxn3])
+    return base
+
+
 def model_builder(name):
     """Return an empty cobra.model object."""
     choices = {
@@ -106,6 +123,7 @@ def model_builder(name):
         "proton_pump": proton_pump,
         "energy_transfer": energy_transfer,
         "phosphotransferase_system": phosphotransferase_system,
+        "converting_reactions": converting_reactions,
     }
     model = cobra.Model(id_or_model=name, name=name)
     return choices[name](model)
@@ -129,5 +147,15 @@ def test_find_transport_reactions(model, num):
     ("gene1 and (gene2 or gene3)", [["gene1", "gene2"], ["gene1", "gene3"]])
 ])
 def test_find_functional_units(gpr_str, expected):
-    """Expect amount of enzyme complexes to be identified correctly."""
+    """Expect type of enzyme complexes to be identified correctly."""
     assert list(helpers.find_functional_units(gpr_str)) == expected
+
+
+@pytest.mark.parametrize("met_pair, expected", [
+    (["a", "b"], 2),
+    (["c", "c"], 2)
+])
+def test_find_converting_reactions(met_pair, expected):
+    """Expect amount of converting reactions to be identified correctly."""
+    model = model_builder("converting_reactions")
+    assert len(helpers.find_converting_reactions(model, met_pair)) == expected

--- a/tests/test_for_support/test_for_helpers.py
+++ b/tests/test_for_support/test_for_helpers.py
@@ -151,11 +151,10 @@ def test_find_functional_units(gpr_str, expected):
     assert list(helpers.find_functional_units(gpr_str)) == expected
 
 
-@pytest.mark.parametrize("met_pair, expected", [
-    (["a", "b"], 2),
-    (["c", "c"], 2)
-])
-def test_find_converting_reactions(met_pair, expected):
+@pytest.mark.parametrize("model, met_pair, expected", [
+    ("converting_reactions", ("a", "b"), 2),
+    ("converting_reactions", ("c", "c"), 1)
+], indirect=["model"])
+def test_find_converting_reactions(model, met_pair, expected):
     """Expect amount of converting reactions to be identified correctly."""
-    model = model_builder("converting_reactions")
     assert len(helpers.find_converting_reactions(model, met_pair)) == expected

--- a/tests/test_for_support/test_for_syntax.py
+++ b/tests/test_for_support/test_for_syntax.py
@@ -174,7 +174,39 @@ def trxn_correct_atp_driven(base):
          cobra.Metabolite(id="m_c", formula='C7H13NO2',
                           compartment='c'): 1}
     )
-    base.add_reaction(rxn)
+    # GTP-driven
+    rxn2 = cobra.Reaction('R2abc')
+    rxn2.add_metabolites(
+        {cobra.Metabolite(id="gtp_c", formula='C10H12N5O14P3',
+                          compartment='c'): -1,
+         cobra.Metabolite(id="gdp_c", formula='C10H12N5O11P2',
+                          compartment='c'): 1,
+         cobra.Metabolite(id="p_c", formula='HO4P',
+                          compartment='c'): 1,
+         cobra.Metabolite(id="h_c", formula='H',
+                          compartment='c'): 1,
+         cobra.Metabolite(id="m_m", formula='C7H13NO2',
+                          compartment='m'): -1,
+         cobra.Metabolite(id="m_c", formula='C7H13NO2',
+                          compartment='c'): 1}
+    )
+    # CTP-driven
+    rxn3 = cobra.Reaction('R3abc')
+    rxn3.add_metabolites(
+        {cobra.Metabolite(id="ctp_c", formula='C9H12N3O14P3',
+                          compartment='c'): -1,
+         cobra.Metabolite(id="cdp_c", formula='C9H12N3O11P2',
+                          compartment='c'): 1,
+         cobra.Metabolite(id="p_c", formula='HO4P',
+                          compartment='c'): 1,
+         cobra.Metabolite(id="h_c", formula='H',
+                          compartment='c'): 1,
+         cobra.Metabolite(id="m_m", formula='C7H13NO2',
+                          compartment='m'): -1,
+         cobra.Metabolite(id="m_c", formula='C7H13NO2',
+                          compartment='c'): 1}
+    )
+    base.add_reactions([rxn, rxn2, rxn3])
     return base
 
 
@@ -195,7 +227,39 @@ def trxn_no_tag_atp_driven(base):
          cobra.Metabolite(id="m_c", formula='C7H13NO2',
                           compartment='c'): 1}
     )
-    base.add_reaction(rxn)
+    # GTP-driven
+    rxn2 = cobra.Reaction('R2')
+    rxn2.add_metabolites(
+        {cobra.Metabolite(id="gtp_c", formula='C10H12N5O14P3',
+                          compartment='c'): -1,
+         cobra.Metabolite(id="gdp_c", formula='C10H12N5O11P2',
+                          compartment='c'): 1,
+         cobra.Metabolite(id="p_c", formula='HO4P',
+                          compartment='c'): 1,
+         cobra.Metabolite(id="h_c", formula='H',
+                          compartment='c'): 1,
+         cobra.Metabolite(id="m_m", formula='C7H13NO2',
+                          compartment='m'): -1,
+         cobra.Metabolite(id="m_c", formula='C7H13NO2',
+                          compartment='c'): 1}
+    )
+    # CTP-driven
+    rxn3 = cobra.Reaction('R3')
+    rxn3.add_metabolites(
+        {cobra.Metabolite(id="ctp_c", formula='C9H12N3O14P3',
+                          compartment='c'): -1,
+         cobra.Metabolite(id="cdp_c", formula='C9H12N3O11P2',
+                          compartment='c'): 1,
+         cobra.Metabolite(id="p_c", formula='HO4P',
+                          compartment='c'): 1,
+         cobra.Metabolite(id="h_c", formula='H',
+                          compartment='c'): 1,
+         cobra.Metabolite(id="m_m", formula='C7H13NO2',
+                          compartment='m'): -1,
+         cobra.Metabolite(id="m_c", formula='C7H13NO2',
+                          compartment='c'): 1}
+    )
+    base.add_reactions([rxn, rxn2, rxn3])
     return base
 
 
@@ -426,7 +490,7 @@ def test_non_abc_transp_rxn_tag_match(model, num):
 
 @pytest.mark.parametrize("model, num", [
     ("trxn_correct_atp_driven", 0),
-    ("trxn_no_tag_atp_driven", 1)
+    ("trxn_no_tag_atp_driven", 3)
 ], indirect=["model"])
 def test_abc_transp_rxn_tag_match(model, num):
     """Expect all abc transport rxns to be tagged with 'abc'."""


### PR DESCRIPTION
* [x] fix #140, fix #137, fix #134, fix #154 
* [x] With this pull-request I tried to address the bugs and requests we've had in some of the issues:
- The biocyc identifier regex is very general and thus matches any of the other databases. I've implemented a filter for biocyc values in `generate_component_id_namespace_overview` such that whenever an annotation ID matches agains the biocyc regex and any other regex the biocyc match will be removed.
- Previously, memote did not consider abc-transporters to be driven by energy from the hydrolysis of NTPs other than ATP. This was fixed by allowing CTP and GTP as possible driving factors.
- The check for GAM in biomass was made more precise by specifically looking for "atp_c" and "h2o_c" on the reactant side and for "adp_c", "pi_c" and "h_c" on the product side of the bionass reaction. Like with the previous check, I am aware that this favours models with BiGG IDs.
- Expand the required metabolite annotations to include PubChem IDs.
* [x] add an entry to the [next release](../HISTORY.rst)
