### PR TITLE
Feat/orphans deadends

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -4,6 +4,7 @@ History
 Next Release
 ------------
 
+* Add tests to find deadend, orphan and disconnected metabolites.
 * Extend and improve algorithm to find energy-generating cycles
 * Remove the ``print`` statement from ``memote.support.annotation
   .generate_component_annotation_miriam_match``.

--- a/memote/suite/tests/test_consistency.py
+++ b/memote/suite/tests/test_consistency.py
@@ -108,3 +108,33 @@ def test_find_stoichiometrically_balanced_cycles(read_only_model, store):
         "The following reactions participate in stoichiometrically balanced" \
         " cycles: {}".format(
             ", ".join(store["looped_reactions"]))
+
+
+def test_find_orphans(read_only_model, store):
+    """Expect no orphans to be present."""
+    store["orphan_metabolites"] = [
+        rxn.id for rxn in consistency.find_orphans(read_only_model)]
+    assert len(store["orphan_metabolites"]) == 0,\
+        "The metabolites are no produced by any " \
+        "reaction of the model: {}".format(
+            ", ".join(store["orphan_metabolites"]))
+
+
+def test_find_deadends(read_only_model, store):
+    """Expect no deadends to be present."""
+    store["deadend_metabolites"] = [
+        rxn.id for rxn in consistency.find_deadends(read_only_model)]
+    assert len(store["deadend_metabolites"]) == 0,\
+        "The metabolites are no consumed by any " \
+        "reaction of the model: {}".format(
+            ", ".join(store["deadend_metabolites"]))
+
+
+def test_find_disconnected(read_only_model, store):
+    """Expect no disconnected metabolites to be present."""
+    store["disconnected_metabolites"] = [
+        rxn.id for rxn in consistency.find_disconnected(read_only_model)]
+    assert len(store["disconnected_metabolites"]) == 0,\
+        "The metabolites are not associated with any " \
+        "reaction of the model: {}".format(
+            ", ".join(store["disconnected_metabolites"]))

--- a/memote/suite/tests/test_consistency.py
+++ b/memote/suite/tests/test_consistency.py
@@ -113,7 +113,7 @@ def test_find_stoichiometrically_balanced_cycles(read_only_model, store):
 def test_find_orphans(read_only_model, store):
     """Expect no orphans to be present."""
     store["orphan_metabolites"] = [
-        rxn.id for rxn in consistency.find_orphans(read_only_model)]
+        met.id for met in consistency.find_orphans(read_only_model)]
     assert len(store["orphan_metabolites"]) == 0,\
         "The metabolites are no produced by any " \
         "reaction of the model: {}".format(
@@ -123,7 +123,7 @@ def test_find_orphans(read_only_model, store):
 def test_find_deadends(read_only_model, store):
     """Expect no deadends to be present."""
     store["deadend_metabolites"] = [
-        rxn.id for rxn in consistency.find_deadends(read_only_model)]
+        met.id for met in consistency.find_deadends(read_only_model)]
     assert len(store["deadend_metabolites"]) == 0,\
         "The metabolites are no consumed by any " \
         "reaction of the model: {}".format(
@@ -133,7 +133,7 @@ def test_find_deadends(read_only_model, store):
 def test_find_disconnected(read_only_model, store):
     """Expect no disconnected metabolites to be present."""
     store["disconnected_metabolites"] = [
-        rxn.id for rxn in consistency.find_disconnected(read_only_model)]
+        met.id for met in consistency.find_disconnected(read_only_model)]
     assert len(store["disconnected_metabolites"]) == 0,\
         "The metabolites are not associated with any " \
         "reaction of the model: {}".format(

--- a/memote/support/consistency.py
+++ b/memote/support/consistency.py
@@ -471,7 +471,10 @@ def find_orphans(model):
     df = con_helpers.prep_stoich_matrix(model)
     orphans = list()
     for met in model.metabolites:
-        series = df[met.id].value_counts().drop(0)
+        if 0 in df[met.id].value_counts():
+            series = df[met.id].value_counts().drop(0)
+        else:
+            series = df[met.id].value_counts()
         if -1 in series.keys() and len(series.keys()) == 1:
             orphans.append(met.id)
     return orphans
@@ -490,7 +493,10 @@ def find_deadends(model):
     df = con_helpers.prep_stoich_matrix(model)
     deadends = list()
     for met in model.metabolites:
-        series = df[met.id].value_counts().drop(0)
+        if 0 in df[met.id].value_counts():
+            series = df[met.id].value_counts().drop(0)
+        else:
+            series = df[met.id].value_counts()
         if 1 in series.keys() and len(series.keys()) == 1:
             deadends.append(met.id)
     return deadends
@@ -508,4 +514,5 @@ def find_disconnected(model):
     """
     df = con_helpers.prep_stoich_matrix(model)
     return [met.id for met in model.metabolites
-            if df[met.id].value_counts()[0] == len(model.reactions)]
+            if 0 in df[met.id].value_counts()
+            and df[met.id].value_counts()[0] == len(model.reactions)]

--- a/memote/support/consistency.py
+++ b/memote/support/consistency.py
@@ -456,3 +456,56 @@ def find_stoichiometrically_balanced_cycles(model):
         fva_result.minimum != fva_result_loopless.minimum].index
     differential_fluxes = set(row_ids_min).union(set(row_ids_max))
     return [model.reactions.get_by_id(id) for id in differential_fluxes]
+
+
+def find_orphans(model):
+    """
+    Return list of IDs of metabolites that are only consumed in reactions.
+
+    Parameters
+    ----------
+    model : cobra.Model
+        The metabolic model under investigation.
+
+    """
+    df = con_helpers.prep_stoich_matrix(model)
+    orphans = list()
+    for met in model.metabolites:
+        series = df[met.id].value_counts().drop(0)
+        if -1 in series.keys() and len(series.keys()) == 1:
+            orphans.append(met.id)
+    return orphans
+
+
+def find_deadends(model):
+    """
+    Return list of IDs of metabolites that are only produced in reactions.
+
+    Parameters
+    ----------
+    model : cobra.Model
+        The metabolic model under investigation.
+
+    """
+    df = con_helpers.prep_stoich_matrix(model)
+    deadends = list()
+    for met in model.metabolites:
+        series = df[met.id].value_counts().drop(0)
+        if 1 in series.keys() and len(series.keys()) == 1:
+            deadends.append(met.id)
+    return deadends
+
+
+def find_disconnected(model):
+    """
+    Return list of IDs of metabolites that are not in any of the reactions.
+
+    Parameters
+    ----------
+    model : cobra.Model
+        The metabolic model under investigation.
+
+    """
+    df = con_helpers.prep_stoich_matrix(model)
+    return [met.id for met in model.metabolites
+            if df[met.id].value_counts()[0] == len(model.reactions)]

--- a/memote/support/consistency.py
+++ b/memote/support/consistency.py
@@ -460,7 +460,7 @@ def find_stoichiometrically_balanced_cycles(model):
 
 def find_orphans(model):
     """
-    Return list of IDs of metabolites that are only consumed in reactions.
+    Return metabolites that are only consumed in reactions.
 
     Parameters
     ----------
@@ -468,21 +468,14 @@ def find_orphans(model):
         The metabolic model under investigation.
 
     """
-    df = con_helpers.prep_stoich_matrix(model)
-    orphans = list()
-    for met in model.metabolites:
-        if 0 in df[met.id].value_counts():
-            series = df[met.id].value_counts().drop(0)
-        else:
-            series = df[met.id].value_counts()
-        if -1 in series.keys() and len(series.keys()) == 1:
-            orphans.append(met)
-    return orphans
+    return [met for met in model.metabolites
+            if (len(met.reactions) > 0) and all(
+                rxn.metabolites[met] < 0 for rxn in met.reactions)]
 
 
 def find_deadends(model):
     """
-    Return list of IDs of metabolites that are only produced in reactions.
+    Return metabolites that are only produced in reactions.
 
     Parameters
     ----------
@@ -490,21 +483,14 @@ def find_deadends(model):
         The metabolic model under investigation.
 
     """
-    df = con_helpers.prep_stoich_matrix(model)
-    deadends = list()
-    for met in model.metabolites:
-        if 0 in df[met.id].value_counts():
-            series = df[met.id].value_counts().drop(0)
-        else:
-            series = df[met.id].value_counts()
-        if 1 in series.keys() and len(series.keys()) == 1:
-            deadends.append(met)
-    return deadends
+    return [met for met in model.metabolites
+            if (len(met.reactions) > 0) and all(
+                rxn.metabolites[met] > 0 for rxn in met.reactions)]
 
 
 def find_disconnected(model):
     """
-    Return list of IDs of metabolites that are not in any of the reactions.
+    Return metabolites that are not in any of the reactions.
 
     Parameters
     ----------
@@ -512,7 +498,4 @@ def find_disconnected(model):
         The metabolic model under investigation.
 
     """
-    df = con_helpers.prep_stoich_matrix(model)
-    return [met for met in model.metabolites
-            if 0 in df[met.id].value_counts() and
-            df[met.id].value_counts()[0] == len(model.reactions)]
+    return [met for met in model.metabolites if len(met.reactions) == 0]

--- a/memote/support/consistency.py
+++ b/memote/support/consistency.py
@@ -476,7 +476,7 @@ def find_orphans(model):
         else:
             series = df[met.id].value_counts()
         if -1 in series.keys() and len(series.keys()) == 1:
-            orphans.append(met.id)
+            orphans.append(met)
     return orphans
 
 
@@ -498,7 +498,7 @@ def find_deadends(model):
         else:
             series = df[met.id].value_counts()
         if 1 in series.keys() and len(series.keys()) == 1:
-            deadends.append(met.id)
+            deadends.append(met)
     return deadends
 
 
@@ -513,6 +513,6 @@ def find_disconnected(model):
 
     """
     df = con_helpers.prep_stoich_matrix(model)
-    return [met.id for met in model.metabolites
-            if 0 in df[met.id].value_counts()
-            and df[met.id].value_counts()[0] == len(model.reactions)]
+    return [met for met in model.metabolites
+            if 0 in df[met.id].value_counts() and
+            df[met.id].value_counts()[0] == len(model.reactions)]

--- a/memote/support/consistency_helpers.py
+++ b/memote/support/consistency_helpers.py
@@ -27,6 +27,7 @@ import sympy
 from numpy.linalg import svd
 from six import iteritems, itervalues
 from builtins import zip, dict
+from cobra.util.array import create_stoichiometric_matrix
 
 from memote.support.helpers import find_biomass_reaction
 
@@ -262,3 +263,20 @@ def is_charge_balanced(reaction):
             return False
         charge += coefficient * metabolite.charge
     return charge == 0
+
+
+def prep_stoich_matrix(model):
+    """
+    Return a transposed stoichiometric matrix showing reversible reactions.
+
+    Parameters
+    ----------
+    model : cobra.Model
+        The metabolic model under investigation.
+
+    """
+    df = create_stoichiometric_matrix(model, array_type="DataFrame")
+    for rxn in model.reactions:
+        if rxn.reversibility:
+            df[rxn.id + "{}".format("_rev")] = df[rxn.id] * -1
+    return df.T

--- a/memote/support/consistency_helpers.py
+++ b/memote/support/consistency_helpers.py
@@ -27,7 +27,6 @@ import sympy
 from numpy.linalg import svd
 from six import iteritems, itervalues
 from builtins import zip, dict
-from cobra.util.array import create_stoichiometric_matrix
 
 from memote.support.helpers import find_biomass_reaction
 
@@ -263,20 +262,3 @@ def is_charge_balanced(reaction):
             return False
         charge += coefficient * metabolite.charge
     return charge == 0
-
-
-def prep_stoich_matrix(model):
-    """
-    Return a transposed stoichiometric matrix showing reversible reactions.
-
-    Parameters
-    ----------
-    model : cobra.Model
-        The metabolic model under investigation.
-
-    """
-    df = create_stoichiometric_matrix(model, array_type="DataFrame")
-    for rxn in model.reactions:
-        if rxn.reversibility:
-            df[rxn.id + "{}".format("_rev")] = df[rxn.id] * -1
-    return df.T


### PR DESCRIPTION
* [x] fix #143
* [x] Last set of tests mentioned in the issues (for now). Knowing about disconnected, orphaned or deadend metabolites is great for finding gaps in a reconstruction. This PR implements tests that list possible candidates and thus aid model curation.
* [x] three tests were added, corresponding to the three categories of unwanted metabolites.
* [x] add an entry to the [next release](../HISTORY.rst)
