### PR TITLE
refactor: make pytest more verbose

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -4,7 +4,9 @@ History
 Next Release
 ------------
 
-* Temporarily remove ``test_find_stoichiometrically_balanced_cycles``
+* Make the command line output of pytest more verbose until the report is up to
+  speed.
+* Temporarily skip ``test_find_stoichiometrically_balanced_cycles``
 * Catch errors when testing for compartments and loops.
 
 0.4.2 (2017-08-22)

--- a/memote/suite/api.py
+++ b/memote/suite/api.py
@@ -61,9 +61,9 @@ def test_model(model, filename=None, results=False, pytest_args=None):
 
     """
     if pytest_args is None:
-        pytest_args = ["--tb", "line", TEST_DIRECTORY]
-    elif "--tb" not in pytest_args:
-        pytest_args.extend(["--tb", "line"])
+        pytest_args = ["--tb", "short", TEST_DIRECTORY]
+    elif not any(a.startswith("--tb") for a in pytest_args):
+        pytest_args.extend(["--tb", "short"])
     if TEST_DIRECTORY not in pytest_args:
         pytest_args.append(TEST_DIRECTORY)
     plugin = ResultCollectionPlugin(model)

--- a/memote/suite/cli/reports.py
+++ b/memote/suite/cli/reports.py
@@ -54,8 +54,10 @@ def snapshot(model, filename, pytest_args):
     MODEL: Path to model file. Can also be supplied via the environment variable
     MEMOTE_MODEL or configured in 'setup.cfg' or 'memote.ini'.
     """
-    if "--tb" not in pytest_args:
-        pytest_args = ["--tb", "no"] + pytest_args
+    if not any(a.startswith("--tb") for a in pytest_args):
+        pytest_args = ["--tb", "short"] + pytest_args
+    if not any(a.startswith("-v") for a in pytest_args):
+        pytest_args.append("-vv")
     _, results = api.test_model(model, results=True, pytest_args=pytest_args)
     api.basic_report(results, filename)
 

--- a/memote/suite/cli/runner.py
+++ b/memote/suite/cli/runner.py
@@ -98,8 +98,10 @@ def run(model, collect, filename, directory, ignore_git, pytest_args):
         repo = None
     else:
         repo = callbacks.probe_git()
-    if "--tb" not in pytest_args:
-        pytest_args = ["--tb", "line"] + pytest_args
+    if not any(a.startswith("--tb") for a in pytest_args):
+        pytest_args = ["--tb", "short"] + pytest_args
+    if not any(a.startswith("-v") for a in pytest_args):
+        pytest_args.append("-vv")
     if collect:
         if repo is not None and directory is not None:
             filename = join(directory,


### PR DESCRIPTION
We make the command line output of pytest more verbose until the report
output is more informative and nicely presented.