### PR TITLE
fix: swap all links to rtd/stable with rtd/latest

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -4,6 +4,8 @@ History
 Next Release
 ------------
 
+* Temporarily change the links to readthedocs to point to latest instead of stable.
+
 0.4.5 (2017-10-09)
 ------------------
 

--- a/README.rst
+++ b/README.rst
@@ -50,7 +50,7 @@ at via GitHub pages for your repository.
 
 .. summary-end
 
-* Documentation: https://memote.readthedocs.io/en/latest/.
+* Documentation: https://memote.readthedocs.io/.
 
 Installation
 ============

--- a/README.rst
+++ b/README.rst
@@ -8,8 +8,8 @@ memote - the genome-scale metabolic model test suite
 .. image:: https://img.shields.io/travis/opencobra/memote.svg
         :target: https://travis-ci.org/opencobra/memote
 
-.. image:: https://readthedocs.org/projects/memote/badge/?version=stable
-        :target: https://memote.readthedocs.io/en/stable/?badge=stable
+.. image:: https://readthedocs.org/projects/memote/badge/?version=latest
+        :target: https://memote.readthedocs.io/en/latest/?badge=latest
         :alt: Documentation Status
 
 .. image:: https://codecov.io/gh/opencobra/memote/branch/master/graph/badge.svg
@@ -50,7 +50,7 @@ at via GitHub pages for your repository.
 
 .. summary-end
 
-* Documentation: https://memote.readthedocs.io.
+* Documentation: https://memote.readthedocs.io/en/latest/.
 
 Installation
 ============
@@ -77,7 +77,7 @@ For comments and questions get in touch via
 * or our `mailing list <https://groups.google.com/forum/#!forum/memote>`_.
 
 Are you excited about this project? Consider `contributing
-<https://memote.readthedocs.io/en/stable/contributing.html>`_ by adding novel
+<https://memote.readthedocs.io/en/latest/contributing.html>`_ by adding novel
 tests, reporting or fixing bugs, and generally help us make this a better
 software for everyone.
 


### PR DESCRIPTION
* [x] fix #225
* [x] I changed the links to read to docs to point to `latest` instead of `stable`. We've removed public access to `stable` due to issues with getting the most recent version rendered correctly.
* [x] add an entry to the [next release](../HISTORY.rst)
