### PR TITLE
refactor: use a decorator instead of model builder

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -4,6 +4,8 @@ History
 Next Release
 ------------
 
+* Provide a new decorator ``@register_with`` that can be used in all
+  ``test_for*`` modules and replaces the ``model_builder`` function.
 * Temporarily change the links to readthedocs to point to latest instead of stable.
 
 0.4.5 (2017-10-09)

--- a/memote/utils.py
+++ b/memote/utils.py
@@ -15,27 +15,29 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-"""Ensure the expected functioning of ``memote.suite.cli.reports``."""
+"""Utility functions used by memote and its tests."""
 
 from __future__ import absolute_import
 
-from os.path import exists
-
-from memote.suite.cli.reports import report
+__all__ = ("register_with",)
 
 
-def test_report(runner):
-    """Expect a simple memote report invocation to be successful."""
-    result = runner.invoke(report)
-    assert result.exit_code == 0
-    assert result.output.startswith(
-        "Usage: report [OPTIONS] COMMAND [ARGS]...")
+def register_with(registry):
+    """
+    Register a passed in object.
 
+    Intended to be used as a decorator on model building functions with a
+    ``dict`` as a registry.
 
-def test_snapshot(runner, model_file):
-    """Expect the snapshot report to function."""
-    output = model_file.split(".", 1)[0] + ".html"
-    result = runner.invoke(report, [
-        "snapshot", "--filename", output, model_file])
-    assert result.exit_code == 0
-    assert exists(output)
+    Examples
+    --------
+    REGISTRY = dict()
+    @register_with(REGISTRY)
+    def build_empty(base):
+        return base
+
+    """
+    def decorator(func):
+        registry[func.__name__] = func
+        return func
+    return decorator

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -51,8 +51,8 @@ def model(request, solver):
         model = read_sbml_model(join(dirname(__file__), "data",
                                      "EcoliCore.xml.gz"))
     else:
-        builder = getattr(request.module, "model_builder")
-        model = builder(request.param)
+        builder = getattr(request.module, "MODEL_REGISTRY")[request.param]
+        model = builder(Model(id_or_model=request.param, name=request.param))
     model.solver = solver
     return model
 

--- a/tests/test_for_suite/test_for_api.py
+++ b/tests/test_for_suite/test_for_api.py
@@ -15,7 +15,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-"""Test the memote programmatic API."""
+"""Ensure the expected functioning of ``memote.suite.api``."""
 
 from __future__ import absolute_import
 
@@ -26,8 +26,12 @@ import cobra
 import pytest
 
 import memote.suite.api as api
+from memote.utils import register_with
+
+MODEL_REGISTRY = dict()
 
 
+@register_with(MODEL_REGISTRY)
 def complete_failure(base):
     met_a = cobra.Metabolite("atp_c")
     met_b = cobra.Metabolite("A")
@@ -46,23 +50,15 @@ def complete_failure(base):
     return base
 
 
-def model_builder(name):
-    choices = {
-        "complete-failure": complete_failure,
-    }
-    model = cobra.Model(id_or_model=name, name=name)
-    return choices[name](model)
-
-
 @pytest.mark.parametrize("model, code", [
-    ("complete-failure", 1),
+    ("complete_failure", 1),
 ], indirect=["model"])
 def test_test_model_code(model, code):
     assert api.test_model(model) == code
 
 
 @pytest.mark.parametrize("model", [
-    "complete-failure",
+    "complete_failure",
 ], indirect=["model"])
 def test_test_model_result(model):
     _, result = api.test_model(model, results=True)
@@ -71,7 +67,7 @@ def test_test_model_result(model):
 
 
 @pytest.mark.parametrize("model", [
-    "complete-failure",
+    "complete_failure",
 ], indirect=["model"])
 def test_test_model_file(model, tmpdir):
     filename = str(tmpdir.join("result.json"))
@@ -80,7 +76,7 @@ def test_test_model_file(model, tmpdir):
 
 
 @pytest.mark.parametrize("model", [
-    "complete-failure",
+    "complete_failure",
 ], indirect=["model"])
 def test_basic_report_file(model, tmpdir):
     filename = str(tmpdir.join("index.html"))

--- a/tests/test_for_suite/test_for_cli/test_for_callbacks.py
+++ b/tests/test_for_suite/test_for_cli/test_for_callbacks.py
@@ -15,7 +15,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-"""Test the callbacks for the command line interface."""
+"""Ensure the expected functioning of ``memote.suite.cli.callbacks``."""
 
 from __future__ import absolute_import
 

--- a/tests/test_for_suite/test_for_cli/test_for_runner.py
+++ b/tests/test_for_suite/test_for_cli/test_for_runner.py
@@ -15,7 +15,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-"""Test the memote command line interface."""
+"""Ensure the expected functioning of ``memote.suite.cli.runner``."""
 
 from __future__ import absolute_import
 

--- a/tests/test_for_support/test_for_annotation.py
+++ b/tests/test_for_support/test_for_annotation.py
@@ -15,19 +15,22 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+"""Ensure the expected functioning of ``memote.support.annotation``."""
+
 from __future__ import absolute_import
+
+from builtins import dict
 
 import cobra
 import pytest
 
 import memote.support.annotation as annotation
+from memote.utils import register_with
 
-"""
-Tests ensuring that the functions in `memote.support.annotation` work as
-expected.
-"""
+MODEL_REGISTRY = dict()
 
 
+@register_with(MODEL_REGISTRY)
 def no_annotations(base):
     met = cobra.Metabolite(id='met_c', name="Met")
     met1 = cobra.Metabolite(id='met1_c', name="Met1")
@@ -37,6 +40,7 @@ def no_annotations(base):
     return base
 
 
+@register_with(MODEL_REGISTRY)
 def met_annotations(base):
     met = cobra.Metabolite(id='met_c', name="Met")
     met1 = cobra.Metabolite(id='met1_c', name="Met1")
@@ -48,6 +52,7 @@ def met_annotations(base):
     return base
 
 
+@register_with(MODEL_REGISTRY)
 def rxn_annotations(base):
     rxn = cobra.Reaction(id='RXN', name="Rxn")
     rxn.annotation = {'brenda': '1.1.1.1'}
@@ -55,6 +60,7 @@ def rxn_annotations(base):
     return base
 
 
+@register_with(MODEL_REGISTRY)
 def met_each_present(base):
     met = cobra.Metabolite(id='met_c', name="Met")
     met.annotation = {'pubchem.compound' : "107735",
@@ -78,6 +84,7 @@ def met_each_present(base):
     return base
 
 
+@register_with(MODEL_REGISTRY)
 def met_each_absent(base):
     met = cobra.Metabolite(id='met_c', name="Met")
     met.annotation = {'METANETX': "MNXM23",
@@ -88,6 +95,7 @@ def met_each_absent(base):
     return base
 
 
+@register_with(MODEL_REGISTRY)
 def rxn_each_present(base):
     rxn = cobra.Reaction(id='RXN', name="Rxn")
     rxn.annotation = {'metanetx.reaction': "MNXR13125",
@@ -101,6 +109,7 @@ def rxn_each_present(base):
     return base
 
 
+@register_with(MODEL_REGISTRY)
 def rxn_each_absent(base):
     # Old or unknown databases and
     # keys that don't follow the MIRIAM namespaces
@@ -111,6 +120,7 @@ def rxn_each_absent(base):
     return base
 
 
+@register_with(MODEL_REGISTRY)
 def met_broken_id(base):
     met = cobra.Metabolite(id='met_c', name="Met")
     met.annotation = {'metanetx.chemical': "MNXR23",
@@ -131,6 +141,7 @@ def met_broken_id(base):
     return base
 
 
+@register_with(MODEL_REGISTRY)
 def rxn_broken_id(base):
     rxn = cobra.Reaction(id='RXN', name="Rxn")
     rxn.annotation = {'metanetx.reaction': "MNXM13125",
@@ -144,6 +155,7 @@ def rxn_broken_id(base):
     return base
 
 
+@register_with(MODEL_REGISTRY)
 def consistent_ids(base):
     met = cobra.Metabolite(id='pyr_c', name="Pyruvate")
     met1 = cobra.Metabolite(id='pep_c', name="Phosphoenolpyruvate")
@@ -158,6 +170,7 @@ def consistent_ids(base):
     return base
 
 
+@register_with(MODEL_REGISTRY)
 def inconsistent_ids(base):
     met = cobra.Metabolite(id='META:PYRUVATE_c', name="Pyruvate")
     met1 = cobra.Metabolite(id='pep_c', name="Phosphoenolpyruvate")
@@ -174,24 +187,6 @@ def inconsistent_ids(base):
     rxn4.add_metabolites({met2: -1, met: 1})
     base.add_reactions([rxn, rxn2, rxn3, rxn4])
     return base
-
-
-def model_builder(name):
-    choices = {
-        'no_annotations': no_annotations,
-        'met_annotations': met_annotations,
-        'rxn_annotations': rxn_annotations,
-        'met_each_present': met_each_present,
-        'met_each_absent': met_each_absent,
-        'rxn_each_present': rxn_each_present,
-        'rxn_each_absent': rxn_each_absent,
-        'met_broken_id': met_broken_id,
-        'rxn_broken_id': rxn_broken_id,
-        'consistent_ids': consistent_ids,
-        'inconsistent_ids': inconsistent_ids,
-    }
-    model = cobra.Model(id_or_model=name, name=name)
-    return choices[name](model)
 
 
 @pytest.mark.parametrize("model, num, components", [

--- a/tests/test_for_support/test_for_basic.py
+++ b/tests/test_for_support/test_for_basic.py
@@ -15,25 +15,27 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+"""Ensure the expected functioning of ``memote.support.basic``."""
+
 from __future__ import absolute_import
 
 import cobra
 import pytest
 
 import memote.support.basic as basic
+from memote.utils import register_with
+
+MODEL_REGISTRY = dict()
 
 
-"""
-Tests ensuring that the functions in `memote.support.basic` work as expected.
-"""
-
-
+@register_with(MODEL_REGISTRY)
 def three_missing(base):
     base.add_metabolites([cobra.Metabolite(id="M{0:d}".format(i))
                           for i in range(1, 4)])
     return base
 
 
+@register_with(MODEL_REGISTRY)
 def three_present(base):
     base.add_metabolites(
         [cobra.Metabolite(id="M{0:d}".format(i), formula="CH4", charge=-1)
@@ -42,6 +44,7 @@ def three_present(base):
     return base
 
 
+@register_with(MODEL_REGISTRY)
 def gpr_present(base):
     """Provide a model with reactions that all have GPR"""
     rxn_1 = cobra.Reaction("RXN1")
@@ -53,6 +56,7 @@ def gpr_present(base):
     return base
 
 
+@register_with(MODEL_REGISTRY)
 def gpr_present_complex(base):
     """Provide a model with reactions that all have GPR"""
     rxn_1 = cobra.Reaction("RXN1")
@@ -66,6 +70,7 @@ def gpr_present_complex(base):
     return base
 
 
+@register_with(MODEL_REGISTRY)
 def gpr_missing(base):
     """Provide a model reactions that lack GPR"""
     rxn_1 = cobra.Reaction("RXN1")
@@ -76,6 +81,7 @@ def gpr_missing(base):
     return base
 
 
+@register_with(MODEL_REGISTRY)
 def gpr_missing_with_exchange(base):
     """Provide a model reactions that lack GPR"""
     rxn_1 = cobra.Reaction("RXN1")
@@ -89,6 +95,7 @@ def gpr_missing_with_exchange(base):
     return base
 
 
+@register_with(MODEL_REGISTRY)
 def gpr_present_not_lumped(base):
     """Provide a model with reactions that all have GPR"""
     rxn_1 = cobra.Reaction("RXN1")
@@ -100,6 +107,7 @@ def gpr_present_not_lumped(base):
     return base
 
 
+@register_with(MODEL_REGISTRY)
 def unconstrained_rxn(base):
     """Provide a model with one unconstrained reaction"""
     rxn_1 = cobra.Reaction("RXN1")
@@ -111,6 +119,7 @@ def unconstrained_rxn(base):
     return base
 
 
+@register_with(MODEL_REGISTRY)
 def irreversible_rxn(base):
     """Provide a model with one irreversible reaction"""
     rxn_1 = cobra.Reaction("RXN1")
@@ -122,6 +131,7 @@ def irreversible_rxn(base):
     return base
 
 
+@register_with(MODEL_REGISTRY)
 def zero_constrained_rxn(base):
     """Provide a model with one zero-constrained reaction"""
     rxn_1 = cobra.Reaction("RXN1")
@@ -133,6 +143,7 @@ def zero_constrained_rxn(base):
     return base
 
 
+@register_with(MODEL_REGISTRY)
 def nonzero_constrained_rxn(base):
     """Provide a model with one nonzero-constrained reaction"""
     rxn_1 = cobra.Reaction("RXN1")
@@ -147,6 +158,7 @@ def nonzero_constrained_rxn(base):
     return base
 
 
+@register_with(MODEL_REGISTRY)
 def ngam_present(base):
     """Provide a model with a correct NGAM reaction"""
     met_g = cobra.Metabolite("atp_c", "C10H12N5O13P3")
@@ -162,6 +174,7 @@ def ngam_present(base):
     return base
 
 
+@register_with(MODEL_REGISTRY)
 def simple_atp_hydrolysis(base):
     """Provide a model with an ATP hydrolysis reaction"""
     met_g = cobra.Metabolite("atp_c", "C10H12N5O13P3")
@@ -177,6 +190,7 @@ def simple_atp_hydrolysis(base):
     return base
 
 
+@register_with(MODEL_REGISTRY)
 def sufficient_compartments(base):
     """Provide a model with the minimal amount of compartments"""
     met_a = cobra.Metabolite("a_c", compartment="c")
@@ -192,6 +206,7 @@ def sufficient_compartments(base):
     return base
 
 
+@register_with(MODEL_REGISTRY)
 def insufficient_compartments(base):
     """Provide a model with less than the minimal amount of compartments"""
     met_a = cobra.Metabolite("a_c", compartment="c")
@@ -203,6 +218,7 @@ def insufficient_compartments(base):
     return base
 
 
+@register_with(MODEL_REGISTRY)
 def non_metabolic_reactions(base):
     """Provide a model all kinds of reactions that are not purely metabolic"""
     met_a = cobra.Metabolite("a_c", formula='CH4', compartment="c")
@@ -217,33 +233,10 @@ def non_metabolic_reactions(base):
     return base
 
 
-def model_builder(name):
-    choices = {
-        "three-missing": three_missing,
-        "three-present": three_present,
-        "gpr_present": gpr_present,
-        "gpr_present_complex": gpr_present_complex,
-        "gpr_missing": gpr_missing,
-        "gpr_missing_with_exchange": gpr_missing_with_exchange,
-        "gpr_present_not_lumped": gpr_present_not_lumped,
-        "unconstrained_rxn": unconstrained_rxn,
-        "irreversible_rxn": irreversible_rxn,
-        "zero_constrained_rxn": zero_constrained_rxn,
-        "nonzero_constrained_rxn": nonzero_constrained_rxn,
-        "ngam_present": ngam_present,
-        "simple_atp_hydrolysis": simple_atp_hydrolysis,
-        "sufficient_compartments": sufficient_compartments,
-        "insufficient_compartments": insufficient_compartments,
-        "non_metabolic_reactions": non_metabolic_reactions
-    }
-    model = cobra.Model(id_or_model=name, name=name)
-    return choices[name](model)
-
-
 @pytest.mark.parametrize("model, num", [
     ("empty", 0),
-    ("three-missing", 3),
-    ("three-present", 0)
+    ("three_missing", 3),
+    ("three_present", 0)
 ], indirect=["model"])
 def test_metabolites_formula_presence(model, num):
     """Expect all metabolites to have a formula."""
@@ -252,8 +245,8 @@ def test_metabolites_formula_presence(model, num):
 
 @pytest.mark.parametrize("model, num", [
     ("empty", 0),
-    ("three-missing", 3),
-    ("three-present", 0)
+    ("three_missing", 3),
+    ("three_present", 0)
 ], indirect=["model"])
 def test_metabolites_charge_presence(model, num):
     """Expect all metabolites to have a charge."""

--- a/tests/test_for_support/test_for_biomass.py
+++ b/tests/test_for_support/test_for_biomass.py
@@ -15,9 +15,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-"""
-Tests ensuring that the functions in `memote.support.basic` work as expected.
-"""
+"""Ensure the expected functioning of ``memote.support.biomass``."""
 
 from __future__ import absolute_import
 
@@ -28,8 +26,12 @@ from optlang.interface import OPTIMAL
 
 import memote.support.helpers as helpers
 import memote.support.biomass as biomass
+from memote.utils import register_with
+
+MODEL_REGISTRY = dict()
 
 
+@register_with(MODEL_REGISTRY)
 def sum_within_deviation(base):
     """Metabolites for a superficial, simple toy biomass reaction. The
     composition will follow the distribution depicted here:
@@ -66,6 +68,7 @@ def sum_within_deviation(base):
     return base
 
 
+@register_with(MODEL_REGISTRY)
 def sum_outside_of_deviation(base):
     """ Same as above, yet here H2O is on the wrong side of the equation
     which will throw off the balance.
@@ -92,6 +95,7 @@ def sum_outside_of_deviation(base):
     return base
 
 
+@register_with(MODEL_REGISTRY)
 def precursors_producing(base):
     met_a = cobra.Metabolite("lipid_c")
     met_b = cobra.Metabolite("protein_c")
@@ -116,6 +120,7 @@ def precursors_producing(base):
     return base
 
 
+@register_with(MODEL_REGISTRY)
 def precursors_uptake_limited(base):
     met_a = cobra.Metabolite("lipid_c")
     met_b = cobra.Metabolite("protein_c")
@@ -140,6 +145,7 @@ def precursors_uptake_limited(base):
     return base
 
 
+@register_with(MODEL_REGISTRY)
 def precursors_blocked(base):
     met_a = cobra.Metabolite("lipid_c")
     met_b = cobra.Metabolite("protein_c")
@@ -164,6 +170,7 @@ def precursors_blocked(base):
     return base
 
 
+@register_with(MODEL_REGISTRY)
 def precursors_not_in_medium(base):
     met_a = cobra.Metabolite("lipid_c")
     met_b = cobra.Metabolite("protein_c")
@@ -188,6 +195,7 @@ def precursors_not_in_medium(base):
     return base
 
 
+@register_with(MODEL_REGISTRY)
 def no_gam_in_biomass(base):
     met_a = cobra.Metabolite("lipid_c", "H744")
     met_b = cobra.Metabolite("protein_c", "H119")
@@ -203,20 +211,6 @@ def no_gam_in_biomass(base):
                            met_g: -0.032})
     base.add_reactions([rxn_1])
     return base
-
-
-def model_builder(name):
-    choices = {
-        "sum_within_deviation": sum_within_deviation,
-        "sum_outside_of_deviation": sum_outside_of_deviation,
-        "precursors_producing": precursors_producing,
-        "precursors_uptake_limited": precursors_uptake_limited,
-        "precursors_blocked": precursors_blocked,
-        "precursors_not_in_medium": precursors_not_in_medium,
-        "no_gam_in_biomass": no_gam_in_biomass,
-    }
-    model = cobra.Model(id_or_model=name, name=name)
-    return choices[name](model)
 
 
 @pytest.mark.parametrize("model, expected", [

--- a/tests/test_for_support/test_for_consistency.py
+++ b/tests/test_for_support/test_for_consistency.py
@@ -15,9 +15,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-"""
-Tests ensuring that the functions in `memote.support.basic` work as expected.
-"""
+"""Ensure the expected functioning of ``memote.support.consistency``."""
 
 from __future__ import absolute_import
 
@@ -25,8 +23,12 @@ import cobra
 import pytest
 
 import memote.support.consistency as consistency
+from memote.utils import register_with
+
+MODEL_REGISTRY = dict()
 
 
+@register_with(MODEL_REGISTRY)
 def figure_1(base):
     # Example in figure 1 of Gevorgyan et al. (2008) Bioinformatics
     # Metabolites
@@ -47,6 +49,7 @@ def figure_1(base):
     return base
 
 
+@register_with(MODEL_REGISTRY)
 def equation_8(base):
     # Example in equation 8 of Gevorgyan et al. (2008) Bioinformatics
     # Metabolites
@@ -64,6 +67,7 @@ def equation_8(base):
     return base
 
 
+@register_with(MODEL_REGISTRY)
 def figure_2(base):
     # Example in figure 2 of Gevorgyan et al. (2008) Bioinformatics
     # Metabolites
@@ -85,6 +89,7 @@ def figure_2(base):
     return base
 
 
+@register_with(MODEL_REGISTRY)
 def free_reactions(base):
     met_a = cobra.Metabolite("C")
     met_b = cobra.Metabolite("A")
@@ -103,6 +108,7 @@ def free_reactions(base):
     return base
 
 
+@register_with(MODEL_REGISTRY)
 def blocked_reactions(base):
     met_a = cobra.Metabolite("C")
     met_b = cobra.Metabolite("A")
@@ -122,6 +128,7 @@ def blocked_reactions(base):
     return base
 
 
+@register_with(MODEL_REGISTRY)
 def produces_atp(base):
     """Returns a simple model with an EGC producing atp_c"""
     ra = cobra.Reaction('A')
@@ -141,6 +148,7 @@ def produces_atp(base):
     return base
 
 
+@register_with(MODEL_REGISTRY)
 def infeasible(base):
     """Returns an infeasible model with an EGC producing atp_c"""
     ra = cobra.Reaction('A')
@@ -163,6 +171,7 @@ def infeasible(base):
     return base
 
 
+@register_with(MODEL_REGISTRY)
 def maintenance_present(base):
     """Returns a model with an ATPM reaction"""
     ra = cobra.Reaction('A')
@@ -185,6 +194,7 @@ def maintenance_present(base):
     return base
 
 
+@register_with(MODEL_REGISTRY)
 def missing_energy_partner(base):
     """Returns a broken model with a missing energy partner to atp"""
     ra = cobra.Reaction('A')
@@ -197,6 +207,7 @@ def missing_energy_partner(base):
     return base
 
 
+@register_with(MODEL_REGISTRY)
 def produces_nadh(base):
     """Returns a simple model with an EGC producing nadh_c"""
     ra = cobra.Reaction('A')
@@ -214,6 +225,7 @@ def produces_nadh(base):
     return base
 
 
+@register_with(MODEL_REGISTRY)
 def produces_fadh2(base):
     """Returns a simple model with an EGC producing fadh2_c"""
     ra = cobra.Reaction('A')
@@ -231,6 +243,7 @@ def produces_fadh2(base):
     return base
 
 
+@register_with(MODEL_REGISTRY)
 def produces_accoa(base):
     """Returns a simple model with an EGC producing accoa_c"""
     ra = cobra.Reaction('A')
@@ -250,6 +263,7 @@ def produces_accoa(base):
     return base
 
 
+@register_with(MODEL_REGISTRY)
 def produces_glu(base):
     """Returns a simple model with an EGC producing glu__L_c"""
     ra = cobra.Reaction('A')
@@ -269,6 +283,7 @@ def produces_glu(base):
     return base
 
 
+@register_with(MODEL_REGISTRY)
 def produces_h(base):
     """Returns a simple model with an EGC producing h_p"""
     ra = cobra.Reaction('A')
@@ -285,6 +300,7 @@ def produces_h(base):
     return base
 
 
+@register_with(MODEL_REGISTRY)
 def no_atp(base):
     """Returns a simple model without an EGC producing atp_c"""
     ra = cobra.Reaction('A')
@@ -304,6 +320,7 @@ def no_atp(base):
     return base
 
 
+@register_with(MODEL_REGISTRY)
 def all_balanced(base):
     met_a = cobra.Metabolite("A", formula='CHOPNS', charge=1)
     met_b = cobra.Metabolite("B", formula='C2H2O2P2N2S2', charge=2)
@@ -313,6 +330,7 @@ def all_balanced(base):
     return base
 
 
+@register_with(MODEL_REGISTRY)
 def mass_imbalanced(base):
     met_a = cobra.Metabolite("A", formula='CHOPNS', charge=2)
     met_b = cobra.Metabolite("B", formula='C2H2O2P2N2S2', charge=2)
@@ -322,6 +340,7 @@ def mass_imbalanced(base):
     return base
 
 
+@register_with(MODEL_REGISTRY)
 def charge_imbalanced(base):
     met_a = cobra.Metabolite("A", formula='CHOPNS', charge=1)
     met_b = cobra.Metabolite("B", formula='C2H2O2P2N2S2', charge=1)
@@ -331,6 +350,7 @@ def charge_imbalanced(base):
     return base
 
 
+@register_with(MODEL_REGISTRY)
 def met_no_formula(base):
     met_a = cobra.Metabolite("A", formula=None, charge=1)
     met_b = cobra.Metabolite("B", formula='C2H2O2P2N2S2', charge=2)
@@ -340,6 +360,7 @@ def met_no_formula(base):
     return base
 
 
+@register_with(MODEL_REGISTRY)
 def met_no_charge(base):
     met_a = cobra.Metabolite("A", formula='CHOPNS', charge=1)
     met_b = cobra.Metabolite("B", formula='C2H2O2P2N2S2')
@@ -349,6 +370,7 @@ def met_no_charge(base):
     return base
 
 
+@register_with(MODEL_REGISTRY)
 def loopy_toy_model(base):
     base.add_metabolites([cobra.Metabolite(i) for i in "ABC"])
     base.add_reactions([cobra.Reaction(i)
@@ -367,6 +389,7 @@ def loopy_toy_model(base):
     return base
 
 
+@register_with(MODEL_REGISTRY)
 def constrained_toy_model(base):
     base.add_metabolites([cobra.Metabolite(i) for i in "ABC"])
     base.add_reactions([cobra.Reaction(i)
@@ -385,6 +408,7 @@ def constrained_toy_model(base):
     return base
 
 
+@register_with(MODEL_REGISTRY)
 def infeasible_toy_model(base):
     base.add_metabolites([cobra.Metabolite(i) for i in "ABC"])
     base.add_reactions([cobra.Reaction(i)
@@ -405,6 +429,7 @@ def infeasible_toy_model(base):
     return base
 
 
+@register_with(MODEL_REGISTRY)
 def gap_model(base):
     a_c = cobra.Metabolite("a_c")
     a_e = cobra.Metabolite("a_e")
@@ -419,6 +444,7 @@ def gap_model(base):
     return base
 
 
+@register_with(MODEL_REGISTRY)
 def gapfilled_model(base):
     a_c = cobra.Metabolite("a_c")
     a_e = cobra.Metabolite("a_e")
@@ -440,6 +466,7 @@ def gapfilled_model(base):
     return base
 
 
+@register_with(MODEL_REGISTRY)
 def reversible_gap(base):
     a_c = cobra.Metabolite("a_c")
     b_c = cobra.Metabolite("b_c")
@@ -452,44 +479,11 @@ def reversible_gap(base):
     return base
 
 
-def model_builder(name):
-    choices = {
-        "fig-1": figure_1,
-        "eq-8": equation_8,
-        "fig-2": figure_2,
-        "free_reactions": free_reactions,
-        "blocked_reactions": blocked_reactions,
-        "produces_atp": produces_atp,
-        "no_atp": no_atp,
-        "all_balanced": all_balanced,
-        "mass_imbalanced": mass_imbalanced,
-        "charge_imbalanced": charge_imbalanced,
-        "met_no_charge": met_no_charge,
-        "met_no_formula": met_no_formula,
-        "loopy_toy_model": loopy_toy_model,
-        "constrained_toy_model": constrained_toy_model,
-        "infeasible_toy_model": infeasible_toy_model,
-        "produces_accoa": produces_accoa,
-        "produces_fadh2": produces_fadh2,
-        "produces_glu": produces_glu,
-        "produces_h": produces_h,
-        "produces_nadh": produces_nadh,
-        "missing_energy_partner": missing_energy_partner,
-        "maintenance_present": maintenance_present,
-        "infeasible": infeasible,
-        "gap_model": gap_model,
-        "gapfilled_model": gapfilled_model,
-        "reversible_gap": reversible_gap
-    }
-    model = cobra.Model(id_or_model=name, name=name)
-    return choices[name](model)
-
-
 @pytest.mark.parametrize("model, consistent", [
     ("textbook", True),
-    ("fig-1", False),
-    ("eq-8", False),
-    ("fig-2", False),
+    ("figure_1", False),
+    ("equation_8", False),
+    ("figure_2", False),
 ], indirect=["model"])
 def test_check_stoichiometric_consistency(model, consistent):
     assert consistency.check_stoichiometric_consistency(model) is consistent
@@ -497,9 +491,9 @@ def test_check_stoichiometric_consistency(model, consistent):
 
 @pytest.mark.parametrize("model, inconsistent", [
     ("textbook", []),
-    ("fig-1", ["A'", "B'", "C'"]),
-    ("eq-8", ["A", "B", "C"]),
-    ("fig-2", ["X"]),
+    ("figure_1", ["A'", "B'", "C'"]),
+    ("equation_8", ["A", "B", "C"]),
+    ("figure_2", ["X"]),
 ], indirect=["model"])
 def test_find_unconserved_metabolites(model, inconsistent):
     unconserved_mets = consistency.find_unconserved_metabolites(model)
@@ -508,9 +502,9 @@ def test_find_unconserved_metabolites(model, inconsistent):
 
 @pytest.mark.parametrize("model, inconsistent", [
     ("textbook", []),
-    ("fig-1", [("A'",), ("B'",), ("C'",)]),
-    ("eq-8", [("A",), ("B",), ("C",)]),
-    ("fig-2", [("X",)]),
+    ("figure_1", [("A'",), ("B'",), ("C'",)]),
+    ("equation_8", [("A",), ("B",), ("C",)]),
+    ("figure_2", [("X",)]),
 ], indirect=["model"])
 def test_find_inconsistent_min_stoichiometry(model, inconsistent):
     unconserved_sets = consistency.find_inconsistent_min_stoichiometry(model)

--- a/tests/test_for_support/test_for_helpers.py
+++ b/tests/test_for_support/test_for_helpers.py
@@ -15,16 +15,20 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+"""Ensure the expected functioning of ``memote.support.helpers``."""
+
 from __future__ import absolute_import
-import memote.support.helpers as helpers
+
 import cobra
 import pytest
 
-"""
-Tests ensuring that the functions in `memote.support.helpers` work as expected.
-"""
+import memote.support.helpers as helpers
+from memote.utils import register_with
+
+MODEL_REGISTRY = dict()
 
 
+@register_with(MODEL_REGISTRY)
 def uni_anti_symport(base):
     """Provide a model with 3 simple transport reactions."""
     met_a = cobra.Metabolite("co2_c", formula='CO2', compartment="c")
@@ -41,6 +45,7 @@ def uni_anti_symport(base):
     return base
 
 
+@register_with(MODEL_REGISTRY)
 def abc_pump(base):
     """Provide a model with an ABC transport reaction."""
     atp = cobra.Metabolite("atp_c", formula='C10H12N5O13P3', compartment="c")
@@ -57,6 +62,7 @@ def abc_pump(base):
     return base
 
 
+@register_with(MODEL_REGISTRY)
 def proton_pump(base):
     """Provide a model with an ABC proton pump reaction."""
     atp = cobra.Metabolite("atp_c", formula='C10H12N5O13P3', compartment="c")
@@ -72,6 +78,7 @@ def proton_pump(base):
     return base
 
 
+@register_with(MODEL_REGISTRY)
 def phosphotransferase_system(base):
     """Provide a model with a PTS transport reaction."""
     pep = cobra.Metabolite("pep_c", formula='C3H2O6P', compartment="c")
@@ -86,6 +93,7 @@ def phosphotransferase_system(base):
     return base
 
 
+@register_with(MODEL_REGISTRY)
 def energy_transfer(base):
     """Provide a model with a membrane-spanning electron transfer reaction."""
     cytaox = cobra.Metabolite("cytaox_c", formula='X', compartment="c")
@@ -98,6 +106,7 @@ def energy_transfer(base):
     return base
 
 
+@register_with(MODEL_REGISTRY)
 def converting_reactions(base):
     """Provide a model with a couple of converting reaction."""
     a = cobra.Metabolite("a_c")
@@ -113,20 +122,6 @@ def converting_reactions(base):
     rxn3.add_metabolites({a: -1, c3: 1, c2: 1})
     base.add_reactions([rxn1, rxn2, rxn3])
     return base
-
-
-def model_builder(name):
-    """Return an empty cobra.model object."""
-    choices = {
-        "uni_anti_symport": uni_anti_symport,
-        "abc_pump": abc_pump,
-        "proton_pump": proton_pump,
-        "energy_transfer": energy_transfer,
-        "phosphotransferase_system": phosphotransferase_system,
-        "converting_reactions": converting_reactions,
-    }
-    model = cobra.Model(id_or_model=name, name=name)
-    return choices[name](model)
 
 
 @pytest.mark.parametrize("model, num", [

--- a/tests/test_for_support/test_for_syntax.py
+++ b/tests/test_for_support/test_for_syntax.py
@@ -15,19 +15,20 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+"""Ensure the expected functioning of ``memote.support.syntax``."""
+
 from __future__ import absolute_import
 
 import cobra
 import pytest
 
 import memote.support.syntax as syntax
+from memote.utils import register_with
+
+MODEL_REGISTRY = dict()
 
 
-"""
-Tests ensuring that the functions in `memote.support.syntax` work as expected.
-"""
-
-
+@register_with(MODEL_REGISTRY)
 def rxn_correct_tags(base):
     for i, pairs in enumerate(syntax.SUFFIX_MAP.items()):
         if 'c' in pairs[0]:
@@ -38,6 +39,7 @@ def rxn_correct_tags(base):
     return base
 
 
+@register_with(MODEL_REGISTRY)
 def rxn_no_tags(base):
     for i, pairs in enumerate(syntax.SUFFIX_MAP.items()):
         rxn = cobra.Reaction('R{}'.format(i))
@@ -51,6 +53,7 @@ def rxn_no_tags(base):
     return base
 
 
+@register_with(MODEL_REGISTRY)
 def rxn_tags_but_wrong_compartments(base):
     misaligned_suffix_map = dict({'p': 'c',
                                   'c': 'e',
@@ -75,6 +78,7 @@ def rxn_tags_but_wrong_compartments(base):
     return base
 
 
+@register_with(MODEL_REGISTRY)
 def trxn_correct_tags(base):
     # Simple diffusion
     rxn = cobra.Reaction('Rt')
@@ -116,6 +120,7 @@ def trxn_correct_tags(base):
     return base
 
 
+@register_with(MODEL_REGISTRY)
 def trxn_no_tags(base):
     # Simple diffusion
     rxn = cobra.Reaction('R')
@@ -157,6 +162,7 @@ def trxn_no_tags(base):
     return base
 
 
+@register_with(MODEL_REGISTRY)
 def trxn_correct_atp_driven(base):
     # ATP-driven
     rxn = cobra.Reaction('Rabc')
@@ -210,6 +216,7 @@ def trxn_correct_atp_driven(base):
     return base
 
 
+@register_with(MODEL_REGISTRY)
 def trxn_no_tag_atp_driven(base):
     # ATP-driven
     rxn = cobra.Reaction('R')
@@ -263,6 +270,7 @@ def trxn_no_tag_atp_driven(base):
     return base
 
 
+@register_with(MODEL_REGISTRY)
 def proton_pump(base):
     # Proton pump
     rxn = cobra.Reaction('Ah')
@@ -280,6 +288,7 @@ def proton_pump(base):
     return base
 
 
+@register_with(MODEL_REGISTRY)
 def atp_synthase(base):
     # ATPS
     atp = cobra.Metabolite("atp_c", formula='C10H12N5O13P3', compartment="c")
@@ -295,6 +304,7 @@ def atp_synthase(base):
     return base
 
 
+@register_with(MODEL_REGISTRY)
 def lower_case_mets(base):
     rxn = cobra.Reaction('RLOM')
     rxn.add_metabolites(
@@ -308,6 +318,7 @@ def lower_case_mets(base):
     return base
 
 
+@register_with(MODEL_REGISTRY)
 def upper_case_mets(base):
     rxn = cobra.Reaction('RHIM')
     rxn.add_metabolites(
@@ -321,6 +332,7 @@ def upper_case_mets(base):
     return base
 
 
+@register_with(MODEL_REGISTRY)
 def correct_demand_tag(base):
     rxn = cobra.Reaction('DM_abc_c')
     rxn.add_metabolites(
@@ -331,6 +343,7 @@ def correct_demand_tag(base):
     return base
 
 
+@register_with(MODEL_REGISTRY)
 def missing_demand_tag(base):
     rxn = cobra.Reaction('EX_abc_c')
     rxn.add_metabolites(
@@ -346,6 +359,7 @@ def missing_demand_tag(base):
     return base
 
 
+@register_with(MODEL_REGISTRY)
 def false_demand_tag(base):
     rxn = cobra.Reaction('DM_abc_e')
     rxn.add_metabolites(
@@ -356,6 +370,7 @@ def false_demand_tag(base):
     return base
 
 
+@register_with(MODEL_REGISTRY)
 def correct_exchange_tag(base):
     rxn = cobra.Reaction('EX_abc_e')
     rxn.add_metabolites(
@@ -366,6 +381,7 @@ def correct_exchange_tag(base):
     return base
 
 
+@register_with(MODEL_REGISTRY)
 def missing_exchange_tag(base):
     rxn = cobra.Reaction('DM_ghi_e')
     rxn.add_metabolites(
@@ -381,6 +397,7 @@ def missing_exchange_tag(base):
     return base
 
 
+@register_with(MODEL_REGISTRY)
 def correct_sink_tag(base):
     rxn = cobra.Reaction('SK_abc_c')
     rxn.add_metabolites(
@@ -392,6 +409,7 @@ def correct_sink_tag(base):
     return base
 
 
+@register_with(MODEL_REGISTRY)
 def missing_sink_tag(base):
     rxn = cobra.Reaction('EX_abc_c')
     rxn.add_metabolites(
@@ -409,6 +427,7 @@ def missing_sink_tag(base):
     return base
 
 
+@register_with(MODEL_REGISTRY)
 def false_sink_tag(base):
     rxn = cobra.Reaction('SK_abc_c')
     rxn.add_metabolites(
@@ -417,32 +436,6 @@ def false_sink_tag(base):
     )
     base.add_reactions([rxn])
     return base
-
-
-def model_builder(name):
-    choices = {
-        "rxn_correct_tags": rxn_correct_tags,
-        "rxn_no_tags": rxn_no_tags,
-        "rxn_tags_but_wrong_compartments": rxn_tags_but_wrong_compartments,
-        "trxn_correct_tags": trxn_correct_tags,
-        "trxn_no_tags": trxn_no_tags,
-        "trxn_correct_atp_driven": trxn_correct_atp_driven,
-        "trxn_no_tag_atp_driven": trxn_no_tag_atp_driven,
-        "atp_synthase": atp_synthase,
-        "proton_pump": proton_pump,
-        "lower_case_mets": lower_case_mets,
-        "upper_case_mets": upper_case_mets,
-        "correct_demand_tag": correct_demand_tag,
-        "missing_demand_tag": missing_demand_tag,
-        "false_demand_tag": false_demand_tag,
-        "correct_exchange_tag": correct_exchange_tag,
-        "missing_exchange_tag": missing_exchange_tag,
-        "correct_sink_tag": correct_sink_tag,
-        "missing_sink_tag": missing_sink_tag,
-        "false_sink_tag": false_sink_tag
-    }
-    model = cobra.Model(id_or_model=name, name=name)
-    return choices[name](model)
 
 
 @pytest.mark.parametrize("model, num", [


### PR DESCRIPTION
* [x] fix #248
* [x] add an entry to the [next release](../HISTORY.rst)

Functions that create models in the `test_for*` pytest modules should now be decorated with `@register_with(MODEL_REGISTRY)` rather than made known in the `model_builder` function.
