### PR TITLE
feat: add exclusive testing, skipping, and config

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -3,7 +3,14 @@ History
 
 Next Release
 ------------
+
 * Enable test result and meta-data collection.
+* Allow command line option and configuration of exclusive test cases and
+  modules skipping all others (``--exclusive test_biomass``).
+* Allow command line option and configuration to skip test cases and
+  modules (``--skip test_model_id_presence``).
+* Introduce a dummy configuration file for the report organization and test
+  scoring weights.
 
 0.4.6 (2017-10-31)
 ------------------

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -4,7 +4,7 @@ include HISTORY.rst
 include LICENSE
 include README.rst
 
-recursive-include memote *.py *.html
+recursive-include memote *.py *.html *.yml
 recursive-include tests *.py
 recursive-exclude * __pycache__
 recursive-exclude * *.py[co]

--- a/memote/suite/api.py
+++ b/memote/suite/api.py
@@ -38,7 +38,8 @@ __all__ = ("test_model", "snapshot_report", "diff_report", "history_report")
 LOGGER = logging.getLogger(__name__)
 
 
-def test_model(model, filename=None, results=False, pytest_args=None):
+def test_model(model, filename=None, results=False, pytest_args=None,
+               exclusive=None, skip=None):
     """
     Test a model and optionally store results as JSON.
 
@@ -52,6 +53,11 @@ def test_model(model, filename=None, results=False, pytest_args=None):
         Whether to return the results in addition to the return code.
     pytest_args : list, optional
         Additional arguments for the pytest suite.
+    exclusive : iterable, optional
+        Names of test cases or modules to run and exclude all others. Takes
+        precedence over ``skip``.
+    skip : iterable, optional
+        Names of test cases or modules to skip.
 
     Returns
     -------
@@ -67,7 +73,7 @@ def test_model(model, filename=None, results=False, pytest_args=None):
         pytest_args.extend(["--tb", "short"])
     if TEST_DIRECTORY not in pytest_args:
         pytest_args.append(TEST_DIRECTORY)
-    plugin = ResultCollectionPlugin(model)
+    plugin = ResultCollectionPlugin(model, exclusive=exclusive, skip=skip)
     code = pytest.main(pytest_args, plugins=[plugin])
     if filename is not None:
         with open(filename, "w") as file_h:

--- a/memote/suite/cli/config.py
+++ b/memote/suite/cli/config.py
@@ -39,6 +39,8 @@ class ConfigSectionSchema(object):
                                           writable=True))
         github_repository = Param(type=str)
         github_username = Param(type=str)
+        exclusive = Param(type=str, multiple=True)
+        skip = Param(type=str, multiple=True)
 
 
 class ConfigFileProcessor(ConfigFileReader):

--- a/memote/suite/test_config.yml
+++ b/memote/suite/test_config.yml
@@ -1,0 +1,39 @@
+cards:
+  scored:
+    title: "Core Tests"
+    sections:
+      consistency:
+        title: "Consistency"
+        weight: 1.0
+        cases:
+        - test_1
+        - test_2
+      annotation:
+        title: "Annotation"
+        weight: 1.0
+        cases:
+        - test_1
+        - test_2
+  basic:
+    title: "Basic Information"
+    cases:
+      - test_1
+      - test_2
+  biomass:
+    title: "Biomass"
+    cases:
+      - test_1
+      - test_2
+  consistency:
+    title: "Stoichiometry Matrix"
+    cases:
+      - test_1
+      - test_2
+  syntax:
+    title: "BiGG Syntax"
+    cases:
+      - test_1
+      - test_2
+weights:
+  test_1: 1.0
+  test_2: 1.0


### PR DESCRIPTION
* Test cases and modules can be run exclusively with `--exclusive <name>`. This option can be passed multiple times or configured.
* Test cases and modules can be skipped with `--skip <name>`. This option can be passed multiple times or configured.
* Introduces a dummy configuration for test grouping and weighing. This is directly inserted into the result JSON.
* Re-organizes the resulting JSON a bit.
