### PR TITLE
fix: include memote in the version info

### DIFF
--- a/memote/version_info.py
+++ b/memote/version_info.py
@@ -24,6 +24,7 @@ SYS_ORDER = [
 PKG_ORDER = [
     "pip",
     "setuptools",
+    "memote",
     "cobra",
     "future",
     "swiglpk",


### PR DESCRIPTION
Seems a silly oversight.
