### PR TITLE
feat: add solver configuration

### DIFF
--- a/memote/suite/api.py
+++ b/memote/suite/api.py
@@ -39,7 +39,7 @@ LOGGER = logging.getLogger(__name__)
 
 
 def test_model(model, filename=None, results=False, pytest_args=None,
-               exclusive=None, skip=None):
+               exclusive=None, skip=None, solver=None):
     """
     Test a model and optionally store results as JSON.
 

--- a/memote/suite/cli/config.py
+++ b/memote/suite/cli/config.py
@@ -41,6 +41,8 @@ class ConfigSectionSchema(object):
         github_username = Param(type=str)
         exclusive = Param(type=str, multiple=True)
         skip = Param(type=str, multiple=True)
+        solver = Param(type=click.Choice(["cplex", "glpk", "gurobi"]),
+                       default="glpk")
 
 
 class ConfigFileProcessor(ConfigFileReader):

--- a/memote/suite/cli/reports.py
+++ b/memote/suite/cli/reports.py
@@ -50,7 +50,10 @@ def report():
 @click.option("--pytest-args", "-a", callback=callbacks.validate_pytest_args,
               help="Any additional arguments you want to pass to pytest. "
                    "Should be given as one continuous string.")
-def snapshot(model, filename, pytest_args):
+@click.option("--solver", type=click.Choice(["cplex", "glpk", "gurobi"]),
+              default="glpk", show_default=True,
+              help="Set the solver to be used.")
+def snapshot(model, filename, pytest_args, solver):
     """
     Take a snapshot of a model's state and generate a report.
 
@@ -61,6 +64,7 @@ def snapshot(model, filename, pytest_args):
         pytest_args = ["--tb", "short"] + pytest_args
     if not any(a.startswith("-v") for a in pytest_args):
         pytest_args.append("-vv")
+    model.solver = solver
     _, results = api.test_model(model, results=True, pytest_args=pytest_args)
     api.snapshot_report(results, filename)
 

--- a/memote/suite/cli/runner.py
+++ b/memote/suite/cli/runner.py
@@ -81,7 +81,7 @@ def cli():
               envvar="MEMOTE_DIRECTORY",
               help="If invoked inside a git repository, write the test results "
               "to this directory using the commit hash as the filename.")
-@click.option("--ignore-git", is_flag=True,
+@click.option("--ignore-git", is_flag=True, show_default=True,
               help="Avoid checking the git repository status.")
 @click.option("--pytest-args", "-a", callback=callbacks.validate_pytest_args,
               help="Any additional arguments you want to pass to pytest. "
@@ -93,11 +93,14 @@ def cli():
 @click.option("--skip", type=str, multiple=True,
               help="The name of a test or test module to be skipped. This "
                    "option can be used multiple times.")
+@click.option("--solver", type=click.Choice(["cplex", "glpk", "gurobi"]),
+              default="glpk", show_default=True,
+              help="Set the solver to be used.")
 @click.argument("model", type=click.Path(exists=True, dir_okay=False),
                 envvar="MEMOTE_MODEL",
                 callback=callbacks.validate_model)
 def run(model, collect, filename, directory, ignore_git, pytest_args, exclusive,
-        skip):
+        skip, solver):
     """
     Run the test suite and collect results.
 
@@ -112,6 +115,7 @@ def run(model, collect, filename, directory, ignore_git, pytest_args, exclusive,
         pytest_args = ["--tb", "short"] + pytest_args
     if not any(a.startswith("-v") for a in pytest_args):
         pytest_args.append("-vv")
+    model.solver = solver
     if collect:
         if repo is not None and directory is not None:
             filename = join(directory,

--- a/setup.py
+++ b/setup.py
@@ -43,6 +43,7 @@ requirements = [
     "click",
     "click-configfile",
     "click-log",
+    "six",
     "future",
     "pytest>=3.1",
     "gitpython",


### PR DESCRIPTION
A different solver can now be specified with `memote run --solver <solver name> <model>`
