### PR TITLE
fix: drop support for Python 3.4 just like pandas

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -23,9 +23,9 @@ matrix:
     env: TOXENV=py27
   - python: '3.5'
     env: TOXENV=py35
-  - python: '3.5-dev'
-    env: TOXENV=py35
   - python: '3.6'
+    env: TOXENV=py36
+  - python: '3.6-dev'
     env: TOXENV=py36
 install:
 - travis_retry pip install -U pip setuptools wheel tox

--- a/.travis.yml
+++ b/.travis.yml
@@ -21,8 +21,6 @@ matrix:
     env: TOXENV=docs
   - python: '2.7'
     env: TOXENV=py27
-  - python: '3.4'
-    env: TOXENV=py34
   - python: '3.5'
     env: TOXENV=py35
   - python: '3.5-dev'

--- a/setup.py
+++ b/setup.py
@@ -24,6 +24,12 @@ import sys
 
 from setuptools import find_packages, setup
 
+if sys.version_info[:2] == (3, 4):
+    warn("Support for Python 3.4 was dropped by pandas. Since cobrapy is a "
+         "pure Python package you can still install it but will have to "
+         "carefully manage your own pandas and numpy versions. We no longer "
+         "include it in our automatic testing.")
+
 with open("README.rst") as readme_file:
     readme = readme_file.read()
 


### PR DESCRIPTION
Unfortunate dependency mess. Just like pandas we remove 3.4 from our automatic test pipeline.
