### PR TITLE
Allow users to provide a custom pytest directory for test discovery

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -20,13 +20,15 @@ Next Release
     - Color the header text of the parametrized test results in pure black
     - Remove the horizontal lines in the parametrized test results
     - Display all results regardless of scored/ unscored inside of buttons to
-    force a uniform line height and a more consistent look
+      force a uniform line height and a more consistent look
     - Add logic to correctly display errored tests
     - Give skipped and errored test results a distinct look
     - Explicitly handle boolean results, and add boolean as an option for the
-    'type' attribute.
+      'type' attribute.
     - Fix the raw data output in the textboxes so that they are formatted
-    python code.
+      python code.
+* Allow command line option to enable the definition of a custom test directory
+  in combination with a corresponding config file.
 
 0.4.6 (2017-10-31)
 ------------------

--- a/docs/custom_tests.rst
+++ b/docs/custom_tests.rst
@@ -1,0 +1,211 @@
+.. highlight:: shell
+
+============
+Custom Tests
+============
+
+Memote can be configured to include custom test modules from any other directory
+in addition to the tests that are included in the package.
+
+Custom Test Setup
+=================
+
+All custom test modules and the tests defined inside of them have to adhere to
+the same standard design for the results to be generated and displayed correctly.
+Optionally, a user may specify a configuration file which can be used to
+change how individual tests are displayed in the snapshot report.
+
+A Custom Test Module
+--------------------
+
+At its core, a memote test module is a collection of specific python code in a
+text file with the file ending ``.py``. Since, memote uses `pytest <https://docs.pytest.org/en/latest/>`_ for discovery
+and execution of model tests, the `conditions`_ for memote test modules and
+pytest test modules are identical.
+
+The module name has to match either ``test_*.py`` or ``*_test.py``:
+
+.. _conditions: https://docs.pytest.org/en/latest/goodpractices.html#test-package-name
+
+.. code-block:: console
+
+    your_custom_directory/
+        test_module1.py
+        module2_test.py
+        ...
+
+Minimal Test Module & Simple Test Function Template
+---------------------------------------------------
+
+The minimal content of a custom test module should look like this:
+
+.. code-block:: python
+
+    import pytest
+    from memote.utils import annotate, wrapper, truncate
+
+    import path.to.your_support_module as your_support_module
+
+
+    @annotate(
+        title="Some human-readable descriptive title for the report",
+        type="Single keyword describing how the data ought to be displayed."
+    )
+    def test_your_custom_case(read_only_model):
+    """
+    Docstring that briefly outlines the test function.
+
+    A more elaborate explanation of why this test is important, how it works,
+    and the assumptions/ theory behind it. This can be more than one line.
+    """
+    ann = test_your_custom_case.annotation
+    ann["data"] = list(your_support_module.specific_model_quality(read_only_model))
+    ann["metric"] = len(ann["data"]) / len(read_only_model.reactions)
+    ann["message"] = wrapper.fill(
+        """A concise message that displays and explains the test results.
+        For instance, if data is a list of items the amount: {} and
+        percentage ({:.2%}) values can be recorded here, as well as an
+        excerpt of the list itself: {}""".format(
+        len(ann["data"]), ann['metric'], truncate(ann['data'])
+        ))
+    )
+    assert len(ann["data"]) == 0, ann["message"]
+
+
+This is a minimal test module template containing a test function called
+``test_your_custom_case``. There can be additional lines of code, but you
+should keep in mind that any logic is best put into a separate support
+module, which is imported above as ``your_support_module``. The functions of
+this support module are called by the test function. This will simplify
+debugging, error handling and allows for dedicated unit testing on the code
+in the support module.
+
+The following components are requirements of ``test_your_custom_case``:
+
+- Each test has to be decoreated with the ``annotate()`` decorator, which
+  collects:
+
+  - The ``data`` that the test is run on. Can be of the following type: ``list``,
+    ``set``, ``tuple``, ``string``, ``float``, ``integer`` and ``boolean``. It
+    can be of type ``dictionary``, but this is only supported for parametrized
+    tests (see example below).
+
+  - The ``type`` of data. This is not the actual python type
+    of ``data``! Choose it according to how you'd like the results to be
+    displayed in the reports. For example: In the case above ``data``
+    is a list, for instance it could be list of unbalanced reactions. If you choose
+    ``type="length"``, the report will display its length. With ``type="array"``
+    it will display the individual items of the list. If ``data`` is a
+    single string then ``type="string"`` is best. In case, you'd rather display
+    the ``metric`` as opposed to the contents of ``data`` use
+    ``type="number"``. ``type="object"`` is only supported for parametrized
+    tests (see example below).
+
+  - A human-readable, descriptive ``title`` that will be displayed in the report
+    as opposed to the test function name ``test_your_custom_case`` which will
+    only serve as the test's ID internally.
+
+  - ``metric`` can be any fraction relating to the quality that is tested. In
+    memote's core tests the metrics of each scored tests are used to calculate
+    the overall score.
+
+  - The ``message`` is a brief summary of the results displayed only on the
+    command line. There are no restrictions on what it should include. We've
+    generally tried to keep this short and concise to avoid spamming the command
+    line.
+
+- The prefix 'test\_' is required by pytest for automatic test discovery.
+  Every function with this prefix will be executed when later running memote
+  with the configuration to find custom tests.
+
+- ``read_only_model`` is the required parameter to access the loaded
+  metabolic model.
+
+- In the report the docstring is taken as a tooltip for each test. It should
+  generally adhere to the `conventions`_ of the NumPy/SciPy documentation. It
+  suffices to write a brief one-sentence outline of the test function optionally
+  followed by a more elaborate explanation that helps the user to understand
+  the test's purpose and function.
+
+- The assert statement works just like the assert statement in `pytest <https://docs.pytest.org/en/latest/assert.html>`_.
+
+.. _conventions: https://github.com/numpy/numpy/blob/master/doc/HOWTO_DOCUMENT.rst.txt
+
+Parametrized Test Function Template
+-----------------------------------
+Pytest allows us to run one test function with `multiple sets of arguments`_ by
+simply using the ``pytest.mark.paremtrize`` decorator. This is quite useful
+when the same underlying assertion logic can be applied to several parameters.
+In the following example taken from ``memote.suite.tests.test_annotation`` we test
+that there are no metabolites that lack annotations from any of the databases
+listed in ``annotation.METABOLITE_ANNOTATIONS``. Without parametrization we
+would have had to copy the entire test function below to specifically check
+the metabolite annotations for each database.
+
+.. _multiple sets of arguments: https://docs.pytest.org/en/latest/parametrize.html#parametrize
+
+
+.. code-block:: python
+
+    @pytest.mark.parametrize("db", list(annotation.METABOLITE_ANNOTATIONS))
+    @annotate(title="Missing Metabolite Annotations Per Database",
+              type="object", message=dict(), data=dict(), metric=dict())
+    def test_metabolite_annotation_overview(read_only_model, db):
+        """
+        Expect all metabolites to have annotations from common databases.
+
+        The required databases are outlined in `annotation.py`.
+        """
+        ann = test_metabolite_annotation_overview.annotation
+        ann["data"][db] = get_ids(annotation.generate_component_annotation_overview(
+            read_only_model.metabolites, db))
+        ann["metric"][db] = len(ann["data"][db]) / len(read_only_model.metabolites)
+        ann["message"][db] = wrapper.fill(
+            """The following {} metabolites ({:.2%}) lack annotation for {}:
+            {}""".format(len(ann["data"][db]), ann["metric"][db], db,
+                         truncate(ann["data"][db])))
+        assert len(ann["data"][db]) == 0, ann["message"][db]
+
+
+Custom Test Configuration
+=========================
+
+Finally, there are two ways of configuring memote to find custom tests. The
+first involves the ``--custom`` option of the memote CLI and requires the user
+to provide a corresponding config file with the custom test modules, while the second
+involves passing arguments directly to pytest through the use of the
+``--pytest-args`` option, which can be abbreviated to ``-a``. This option only
+requires the user to set up the custom test module. No config file is needed
+here.
+
+The Custom Option
+-----------------
+
+When invoking the ``memote run`` or ``memote report snapshot`` commands in
+the terminal, it is possible to add the ``--custom`` option. This option takes
+two parameters in a fixed order:
+
+1. The absolute path to any directory in which pytest is to check for custom
+   tests modules. By default test discovery is recursive. More information is
+   provided `here`_.
+
+2. The absolute path to a valid configuration file.
+
+.. _here: https://docs.pytest.org/en/latest/goodpractices.html
+
+.. code-block:: console
+
+    $ memote report snapshot --custom path/to/dir/ path/to/config.yml --filename "report.html" path/to/model.xml
+
+The Pytest Option
+-----------------
+
+In case you want to avoid setting up a configuration file, it is possible to
+pass any number of absolute paths to custom test directories directly to pytest,
+as long as they are placed behind any other parameters that you might want to pass in.
+For instance here we want to get a list of the ten slowest running tests while
+including two custom test module directories:
+
+.. code-block:: console
+
+    $ memote run -a "--durations=10 path/to/dir1/ path/to/dir2/" --filename "report.html" path/to/model.xml

--- a/docs/getting_started.rst
+++ b/docs/getting_started.rst
@@ -96,8 +96,15 @@ To illustrate here it is changed to ``report.html``.
 
 While the html report is still a work in progress, we recommend relying on the
 verbose output of the command line tool above. Users can tweak the console
-output by passing additional arguments directly to pytest. This can be done by
+output by passing additional arguments directly to pytest through the
+``--pytest-args`` or simply ``-a`` option. This can be done by
 writing the pytest arguments as one continuous string.
+
+For a more detailed traceback try:
+
+.. code-block:: console
+
+    $ memote report snapshot -a "--tb long" --filename "report.html" path/to/model.xml
 
 For a full list of possible arguments please refer to the `pytest
 documentation`_.

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -23,6 +23,7 @@ Contents
 
    getting_started
    flowchart
+   custom_tests
    test_suite
    api
    contributing

--- a/memote/suite/api.py
+++ b/memote/suite/api.py
@@ -39,7 +39,7 @@ LOGGER = logging.getLogger(__name__)
 
 
 def test_model(model, filename=None, results=False, pytest_args=None,
-               exclusive=None, skip=None, solver=None):
+               exclusive=None, skip=None, solver=None, custom=None):
     """
     Test a model and optionally store results as JSON.
 
@@ -58,6 +58,10 @@ def test_model(model, filename=None, results=False, pytest_args=None,
         precedence over ``skip``.
     skip : iterable, optional
         Names of test cases or modules to skip.
+    custom : tuple, optional
+        A tuple with the absolute path to a directory that contains custom test
+        modules at index 0 and the absolute path to the corresponding config
+        file at index 1.
 
     Returns
     -------
@@ -73,7 +77,16 @@ def test_model(model, filename=None, results=False, pytest_args=None,
         pytest_args.extend(["--tb", "short"])
     if TEST_DIRECTORY not in pytest_args:
         pytest_args.append(TEST_DIRECTORY)
-    plugin = ResultCollectionPlugin(model, exclusive=exclusive, skip=skip)
+    if custom is not None:
+        custom_test_path, custom_config = custom
+        pytest_args.append(custom_test_path)
+        plugin = ResultCollectionPlugin(model, exclusive=exclusive, skip=skip,
+                                        custom_config=custom_config)
+        print('#' * 50)
+        print(plugin._custom_config)
+        print('#' * 50)
+    else:
+        plugin = ResultCollectionPlugin(model, exclusive=exclusive, skip=skip)
     code = pytest.main(pytest_args, plugins=[plugin])
     if filename is not None:
         with open(filename, "w") as file_h:
@@ -92,7 +105,9 @@ def test_model(model, filename=None, results=False, pytest_args=None,
                             for key, value in iteritems(data):
                                 if not isinstance(value, json_types):
                                     LOGGER.debug(
-                                        "  %s - %s: %s", name, key, type(value))
+                                        "  %s - %s: %s", name, key, type(
+                                            value)
+                                    )
                         except AttributeError:
                             if not isinstance(data, json_types):
                                 LOGGER.debug("  %s: %s", name, type(data))

--- a/memote/suite/api.py
+++ b/memote/suite/api.py
@@ -82,9 +82,9 @@ def test_model(model, filename=None, results=False, pytest_args=None,
         pytest_args.append(custom_test_path)
         plugin = ResultCollectionPlugin(model, exclusive=exclusive, skip=skip,
                                         custom_config=custom_config)
-        print('#' * 50)
-        print(plugin._custom_config)
-        print('#' * 50)
+        LOGGER.info("#" * 50)
+        LOGGER.info("%s", plugin.custom_config)
+        LOGGER.info("#" * 50)
     else:
         plugin = ResultCollectionPlugin(model, exclusive=exclusive, skip=skip)
     code = pytest.main(pytest_args, plugins=[plugin])

--- a/memote/suite/cli/reports.py
+++ b/memote/suite/cli/reports.py
@@ -53,7 +53,15 @@ def report():
 @click.option("--solver", type=click.Choice(["cplex", "glpk", "gurobi"]),
               default="glpk", show_default=True,
               help="Set the solver to be used.")
-def snapshot(model, filename, pytest_args, solver):
+@click.option("--custom", type=(click.Path(exists=True, file_okay=False),
+                                click.Path(exists=True, dir_okay=False)),
+              default=(None, None), show_default=True,
+              help="The absolute path to a directory containing custom test "
+                   "modules followed by the absolute path to a config file "
+                   "corresponding to the custom test modules. Please refer to "
+                   "the documentation for more information on the required "
+                   "file formats.")
+def snapshot(model, filename, pytest_args, solver, custom):
     """
     Take a snapshot of a model's state and generate a report.
 
@@ -65,7 +73,9 @@ def snapshot(model, filename, pytest_args, solver):
     if not any(a.startswith("-v") for a in pytest_args):
         pytest_args.append("-vv")
     model.solver = solver
-    _, results = api.test_model(model, results=True, pytest_args=pytest_args)
+    _, results = api.test_model(
+        model, results=True, pytest_args=pytest_args, custom=custom
+    )
     api.snapshot_report(results, filename)
 
 

--- a/memote/suite/cli/reports.py
+++ b/memote/suite/cli/reports.py
@@ -73,9 +73,8 @@ def snapshot(model, filename, pytest_args, solver, custom):
     if not any(a.startswith("-v") for a in pytest_args):
         pytest_args.append("-vv")
     model.solver = solver
-    _, results = api.test_model(
-        model, results=True, pytest_args=pytest_args, custom=custom
-    )
+    _, results = api.test_model(model, results=True, pytest_args=pytest_args,
+                                custom=custom)
     api.snapshot_report(results, filename)
 
 

--- a/memote/suite/cli/runner.py
+++ b/memote/suite/cli/runner.py
@@ -79,8 +79,8 @@ def cli():
 @click.option("--directory", type=click.Path(exists=True, file_okay=False,
                                              writable=True),
               envvar="MEMOTE_DIRECTORY",
-              help="If invoked inside a git repository, write the test results "
-              "to this directory using the commit hash as the filename.")
+              help="If invoked inside a git repository, write the test results"
+              " to this directory using the commit hash as the filename.")
 @click.option("--ignore-git", is_flag=True, show_default=True,
               help="Avoid checking the git repository status.")
 @click.option("--pytest-args", "-a", callback=callbacks.validate_pytest_args,
@@ -96,11 +96,18 @@ def cli():
 @click.option("--solver", type=click.Choice(["cplex", "glpk", "gurobi"]),
               default="glpk", show_default=True,
               help="Set the solver to be used.")
+@click.option("--custom", type=(click.Path(exists=True, file_okay=False),
+                                click.Path(exists=True, dir_okay=False)),
+              help="The absolute path to a directory containing custom test "
+                   "modules followed by the absolute path to a config file "
+                   "corresponding to the custom test modules. Please refer to"
+                   "the documentation for more information on the required "
+                   "file formats.")
 @click.argument("model", type=click.Path(exists=True, dir_okay=False),
                 envvar="MEMOTE_MODEL",
                 callback=callbacks.validate_model)
 def run(model, collect, filename, directory, ignore_git, pytest_args, exclusive,
-        skip, solver):
+        skip, solver, custom):
     """
     Run the test suite and collect results.
 
@@ -121,10 +128,10 @@ def run(model, collect, filename, directory, ignore_git, pytest_args, exclusive,
             filename = join(directory,
                             "{}.json".format(repo.active_branch.commit.hexsha))
         code = api.test_model(model, filename, pytest_args=pytest_args,
-                              skip=skip, exclusive=exclusive)
+                              skip=skip, exclusive=exclusive, custom=custom)
     else:
         code = api.test_model(model, pytest_args=pytest_args, skip=skip,
-                              exclusive=exclusive)
+                              exclusive=exclusive, custom=custom)
     sys.exit(code)
 
 

--- a/memote/suite/cli/runner.py
+++ b/memote/suite/cli/runner.py
@@ -98,9 +98,10 @@ def cli():
               help="Set the solver to be used.")
 @click.option("--custom", type=(click.Path(exists=True, file_okay=False),
                                 click.Path(exists=True, dir_okay=False)),
+              default=(None, None), show_default=True,
               help="The absolute path to a directory containing custom test "
                    "modules followed by the absolute path to a config file "
-                   "corresponding to the custom test modules. Please refer to"
+                   "corresponding to the custom test modules. Please refer to "
                    "the documentation for more information on the required "
                    "file formats.")
 @click.argument("model", type=click.Path(exists=True, dir_okay=False),

--- a/memote/suite/collect.py
+++ b/memote/suite/collect.py
@@ -47,7 +47,7 @@ class ResultCollectionPlugin(object):
     """
 
     def __init__(self, model, repository=None, branch=None, commit=None,
-                 exclusive=None, skip=None, **kwargs):
+                 exclusive=None, skip=None, custom_config=None, **kwargs):
         """
         Collect and store values during testing.
 
@@ -79,6 +79,7 @@ class ResultCollectionPlugin(object):
         self._param = re.compile(r"\[(?P<param>[a-zA-Z0-9_.\-]+)\]$")
         self._xcld = frozenset() if exclusive is None else frozenset(exclusive)
         self._skip = frozenset() if skip is None else frozenset(skip)
+        self._custom_config = custom_config
         self._collect_meta_info()
         self._read_organization()
 
@@ -122,6 +123,18 @@ class ResultCollectionPlugin(object):
         """Read the test organization."""
         with open(join(dirname(__file__), "test_config.yml")) as file_h:
             self._store.update(yaml.load(file_h))
+        if self._custom_config:
+            LOGGER.debug("Reading custom config with path: '%s'.",
+                         self._custom_config)
+            try:
+                with open(self._custom_config) as file_h:
+                    self._store.update(yaml.load(file_h))
+                LOGGER.debug("Successfully read custom config at: '%s'.",
+                             self._custom_config)
+            except Exception as e:
+                LOGGER.error(
+                    "The following error occured while trying to read the "
+                    "custom config at '%s': %s", self._custom_config, e)
 
     def pytest_namespace(self):
         """Insert model information into the pytest namespace."""

--- a/memote/suite/collect.py
+++ b/memote/suite/collect.py
@@ -79,7 +79,7 @@ class ResultCollectionPlugin(object):
         self._param = re.compile(r"\[(?P<param>[a-zA-Z0-9_.\-]+)\]$")
         self._xcld = frozenset() if exclusive is None else frozenset(exclusive)
         self._skip = frozenset() if skip is None else frozenset(skip)
-        self._custom_config = custom_config
+        self.custom_config = custom_config
         self._collect_meta_info()
         self._read_organization()
 
@@ -123,18 +123,19 @@ class ResultCollectionPlugin(object):
         """Read the test organization."""
         with open(join(dirname(__file__), "test_config.yml")) as file_h:
             self._store.update(yaml.load(file_h))
-        if self._custom_config:
+        if self.custom_config:
             LOGGER.debug("Reading custom config with path: '%s'.",
-                         self._custom_config)
+                         self.custom_config)
             try:
-                with open(self._custom_config) as file_h:
+                with open(self.custom_config) as file_h:
                     self._store.update(yaml.load(file_h))
                 LOGGER.debug("Successfully read custom config at: '%s'.",
-                             self._custom_config)
-            except Exception as e:
+                             self.custom_config)
+            except IOError as err:
                 LOGGER.error(
-                    "The following error occured while trying to read the "
-                    "custom config at '%s': %s", self._custom_config, e)
+                    "The following error occurred while trying to read the "
+                    "custom configuration at '%s': %s",
+                    self.custom_config, str(err))
 
     def pytest_namespace(self):
         """Insert model information into the pytest namespace."""

--- a/memote/utils.py
+++ b/memote/utils.py
@@ -53,7 +53,62 @@ def register_with(registry):
 
 
 def annotate(title, type, message=None, data=None, metric=1.0):
-    """Annotate a test case."""
+    """
+    Annotate a test case.
+
+    Parameters
+    ----------
+    title : str
+        A human-readable descriptive title of the test case.
+    type : str
+        A sting that determines how the result data is formatted in the report.
+        - 'array' : The tested quality is represented as a list, e.g. all
+          biomass reactions in the model. In the angular report, 'data' is
+          interpreted as a list. It is expected not to be None.
+        - 'length' : The tested quality is represented as the
+          length of a list, set or tuple, e.g. number of metabolites without
+          formula. In the angular report, 'data' is interpreted as a list. It
+          is expected not to be None.
+        - 'number' : The tested quality is represented as a percentage, e.g.
+          percentage of metabolites without charge. In the angular report,
+          'metric' is used and expected to be a floating point number.
+        - 'object' : Use only if the test case is parametrized i.e. if the
+          same basic test logic can be applied to several tested components,
+          such as testing for the presence of annotations for specific
+          databases for all metabolites. In the angular report, 'data' is
+          interpreted as a dictionary whose values can be dictionaries, lists,
+          strings, floats and integers. It is expected not to be None.
+        - 'string' : The tested quality is represented as a single string,
+          e.g. the ID of the model. In the angular report, 'data' is
+          interpreted as a string. It is expected not to be None.
+    message : str
+        A short written explanation that states and possibly explains the test
+        result.
+    data
+        Raw data which the test case generates and assesses. Can be of the
+        following types: list, set, tuple, string, float, integer, boolean and
+        dictionary.
+    metric: float
+        A value x in the range of 0 <= x <= 1 which represents the fraction of
+        'data' to the total in the model. For example, if 'data' are all
+        metabolites without formula, 'metric' should be the fraction of
+        metabolites without formula from the total of metabolites in the model.
+
+    Returns
+    -------
+    function
+        The decorated function, now extended by the attribute 'annotation'.
+
+    Notes
+    -----
+    Adds "annotation" attribute to the function object, which stores values for
+    predefined keys as a dictionary.
+
+    """
+    types = ['array', 'length', 'number', 'object', 'string']
+    if type not in types:
+        raise ValueError("Invalid type. Expected one of: %s" % types)
+
     def decorator(func):
         func.annotation = dict(
             title=title,

--- a/memote/utils.py
+++ b/memote/utils.py
@@ -52,6 +52,8 @@ def register_with(registry):
     return decorator
 
 
+# TODO: Change naming of the 'type' argument once the angular app is completed.
+# It is misleading.
 def annotate(title, type, message=None, data=None, metric=1.0):
     """
     Annotate a test case.

--- a/tests/test_for_utils.py
+++ b/tests/test_for_utils.py
@@ -67,14 +67,16 @@ def test_register_with(func, func_name):
     assert registry[func_name] is func
 
 
+# TODO: Change naming of the 'type' argument once the angular app is completed.
+# It is misleading.
 @pytest.mark.parametrize("notes, func, summary", [
-    (dict(title="One", data=4, type="integer"), one,
+    (dict(title="One", data=4, type="string"), one,
      """One line."""),
     (dict(title="Two", data="some text", type="string"), two,
      """Two lines.
     Why?
     """),
-    (dict(title="Three", data=[2, 4, 51, 63], type="number"), three,
+    (dict(title="Three", data=[2, 4, 51, 63], type="length"), three,
      """
     Three lines.
     Why?
@@ -99,3 +101,8 @@ def test_annotate(notes, func, summary):
     assert res.annotation["message"] is None
     assert res.annotation["type"] == notes["type"]
     assert res.annotation["metric"] == 1.0
+
+
+def test_annotate_value_error():
+    with pytest.raises(ValueError):
+        utils.annotate("Some Title","wrong_type")(one)

--- a/tests/test_for_utils.py
+++ b/tests/test_for_utils.py
@@ -67,8 +67,6 @@ def test_register_with(func, func_name):
     assert registry[func_name] is func
 
 
-# TODO: Change naming of the 'type' argument once the angular app is completed.
-# It is misleading.
 @pytest.mark.parametrize("notes, func, summary", [
     (dict(title="One", data=4, type="string"), one,
      """One line."""),
@@ -92,6 +90,8 @@ def test_register_with(func, func_name):
     None
 
     """),
+    pytest.mark.raises((dict(title="Some Title", type="wrong_type"), one, ""),
+                       exception=ValueError)
 ])
 def test_annotate(notes, func, summary):
     res = utils.annotate(**notes)(func)
@@ -101,8 +101,3 @@ def test_annotate(notes, func, summary):
     assert res.annotation["message"] is None
     assert res.annotation["type"] == notes["type"]
     assert res.annotation["metric"] == 1.0
-
-
-def test_annotate_value_error():
-    with pytest.raises(ValueError):
-        utils.annotate("Some Title","wrong_type")(one)


### PR DESCRIPTION
* [X] fix #285
* [X] description of feature/fix
Expanded the memote CLI with the option `--custom` which requires the user to provide a tuple containing an absolute path to a custom test directory and the absolute path to a custom config file.

I provided documentation for this approach aswell as making it clear how to provide merely one or many custom test directories (without requiring a config file) in the form of pytest arguments.

* [X] add an entry to the [next release](../HISTORY.rst)
