### PR TITLE
fix/sbo: prevent divide by zero error

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -63,6 +63,10 @@ Next Release
   to the biomass reaction.
   The function is ``essential_precursors_not_in_biomass``
 * Record the score of individual test cases and sections in the result output.
+* Correct the import of module 'annotation' with 'sbo' in `test_sbo.py`
+* Refactor sink_react_list to sink_reactions for improved readability
+* Allow `test_sink_specific_sbo_presence` to be skipped when no sink reactions
+  are present with a metric of 1.0
 
 0.5.0 (2018-01-16)
 ------------------

--- a/memote/suite/tests/test_sbo.py
+++ b/memote/suite/tests/test_sbo.py
@@ -261,11 +261,11 @@ def test_sink_specific_sbo_presence(read_only_model):
     organism's compartments.
     """
     ann = test_sink_specific_sbo_presence.annotation
-    sink_react_list = helpers.find_sink_reactions(read_only_model)
+    sink_reactions = helpers.find_sink_reactions(read_only_model)
     ann["data"] = get_ids(sbo.check_component_for_specific_sbo_term(
-        sink_react_list, "SBO:0000632"))
+        sink_reactions, "SBO:0000632"))
     try:
-        ann["metric"] = len(ann["data"]) / len(sink_react_list)
+        ann["metric"] = len(ann["data"]) / len(sink_reactions)
     except ZeroDivisionError:
         ann["metric"] = 1.0
         ann["message"] = "No sink reactions found."

--- a/memote/suite/tests/test_sbo.py
+++ b/memote/suite/tests/test_sbo.py
@@ -261,13 +261,15 @@ def test_sink_specific_sbo_presence(read_only_model):
     organism's compartments.
     """
     ann = test_sink_specific_sbo_presence.annotation
+    sink_react_list = helpers.find_sink_reactions(read_only_model)
     ann["data"] = get_ids(sbo.check_component_for_specific_sbo_term(
-        helpers.find_sink_reactions(read_only_model), "SBO:0000632"))
+        sink_react_list, "SBO:0000632"))
     try:
-        ann["metric"] = len(ann["data"]) / len(
-            helpers.find_sink_reactions(read_only_model))
+        ann["metric"] = len(ann["data"]) / len(sink_react_list)
     except ZeroDivisionError:
-        pytest.skip()
+        ann["metric"] = 1.0
+        ann["message"] = "No sink reactions found."
+        pytest.skip(ann["message"])
     ann["message"] = wrapper.fill(
         """A total of {} genes ({:.2%} of all sink reactions) lack
         annotation with the SBO term "SBO:0000632" for

--- a/memote/suite/tests/test_sbo.py
+++ b/memote/suite/tests/test_sbo.py
@@ -19,6 +19,8 @@
 
 from __future__ import absolute_import, division
 
+import pytest
+
 import memote.support.basic as basic
 import memote.support.helpers as helpers
 import memote.support.sbo as sbo
@@ -261,8 +263,11 @@ def test_sink_specific_sbo_presence(read_only_model):
     ann = test_sink_specific_sbo_presence.annotation
     ann["data"] = get_ids(sbo.check_component_for_specific_sbo_term(
         helpers.find_sink_reactions(read_only_model), "SBO:0000632"))
-    ann["metric"] = len(ann["data"]) / len(
-        helpers.find_sink_reactions(read_only_model))
+    try:
+        ann["metric"] = len(ann["data"]) / len(
+            helpers.find_sink_reactions(read_only_model))
+    except ZeroDivisionError:
+        pytest.skip()
     ann["message"] = wrapper.fill(
         """A total of {} genes ({:.2%} of all sink reactions) lack
         annotation with the SBO term "SBO:0000632" for


### PR DESCRIPTION
* [ ] fix #x (issue number)
* [ ] description of feature/fix
* [ ] tests added/passed
* [ ] add an entry to the [next release](../HISTORY.rst)

Add try/except structure to `ann["metric"]` in `test_sink_specific_sbo_presence` to prevent ZeroDivisionError when no sink reactions are present. pytest skips this test instead.