### PR TITLE
fix/basic: fix string-float type error in assert statement

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -67,6 +67,8 @@ Next Release
 * Refactor sink_react_list to sink_reactions for improved readability
 * Allow `test_sink_specific_sbo_presence` to be skipped when no sink reactions
   are present with a metric of 1.0
+* Fix a bug that compared the length of a float to generate a metric in 
+  `test_basic.py` and generated a TypeError
 
 0.5.0 (2018-01-16)
 ------------------

--- a/memote/suite/tests/test_basic.py
+++ b/memote/suite/tests/test_basic.py
@@ -325,7 +325,7 @@ def test_transport_reaction_gpr_presence(read_only_model):
         """There are a total of {} transport reactions ({:.2%} of all
         transport reactions) without GPR:
         {}""".format(len(ann["data"]), ann["metric"], truncate(ann["data"])))
-    assert len(ann["metric"]) < 0.2, ann["message"]
+    assert ann["metric"] < 0.2, ann["message"]
 
 
 @annotate(title="Number of Unique Metabolites", type="count")


### PR DESCRIPTION
* [ ] fix #x (issue number)
* [ ] description of feature/fix
* [ ] tests added/passed
* [ ] add an entry to the [next release](../HISTORY.rst)

Changed assert statement from comparing the length of `ann["metric"]` to just comparing ann["metric"] itself, preventing a type error (as floats don't have a length)
