### PR TITLE
Fix/biomass find biomass precursors

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -67,6 +67,8 @@ Next Release
 * Refactor sink_react_list to sink_reactions for improved readability
 * Allow `test_sink_specific_sbo_presence` to be skipped when no sink reactions
   are present with a metric of 1.0
+* Fix a bug that compared the length of a float to generate a metric in 
+  `test_basic.py` and generated a TypeError
 
 0.5.0 (2018-01-16)
 ------------------

--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -68,7 +68,9 @@ Next Release
 * Allow `test_sink_specific_sbo_presence` to be skipped when no sink reactions
   are present with a metric of 1.0
 * Fix a bug that compared the length of a float to generate a metric in 
-  `test_basic.py` and generated a TypeError
+  `test_basic.py` and generated a TypeError.
+* Fix a bug that prevented `find_biomass_precursors` 
+  in `memote/support/biomass.py` from functioning due to a malformed set
 
 0.5.0 (2018-01-16)
 ------------------

--- a/memote/suite/tests/test_basic.py
+++ b/memote/suite/tests/test_basic.py
@@ -325,7 +325,7 @@ def test_transport_reaction_gpr_presence(read_only_model):
         """There are a total of {} transport reactions ({:.2%} of all
         transport reactions) without GPR:
         {}""".format(len(ann["data"]), ann["metric"], truncate(ann["data"])))
-    assert len(ann["metric"]) < 0.2, ann["message"]
+    assert ann["metric"] < 0.2, ann["message"]
 
 
 @annotate(title="Number of Unique Metabolites", type="count")

--- a/memote/support/biomass.py
+++ b/memote/support/biomass.py
@@ -73,12 +73,12 @@ def find_biomass_precursors(model, reaction):
     """
     id_of_main_compartment = helpers.find_compartment_id_in_model(model, 'c')
     try:
-        gam_reactants = set(
+        gam_reactants = set([
             helpers.find_met_in_model(
                 model, "MNXM3", id_of_main_compartment)[0],
             helpers.find_met_in_model(
                 model, "MNXM2", id_of_main_compartment)[0]
-        )
+        ])
     except RuntimeError:
         gam_reactants = set()
 


### PR DESCRIPTION
* [ ] fix #x (issue number)
* [x] description of feature/fix
* [ ] tests added/passed
* [ ] add an entry to the [next release](../HISTORY.rst)

**Purpose**: To find & fix 4 TypeError exceptions that result when running memote report snapshot on iJO1366.xml

**Description**: Currently, 4 functions in `memote/suite/tests/test_biomass.py` fail with TypeError exceptions, all of which traceback to the `find_biomass_precursors` function in `memote/support/biomass.py`. The specific reaction in question which gave these errors was `ATPM`. The message displayed by all 4 TypeError exceptions is:

```E   TypeError: set expected at most 1 arguments, got 2```

**Testing Summary**: TypeError exception is replicated, with identical message output. Looking into the source code, the line in question is:


~~~
gam_reactants = set(
    helpers.find_met_in_model(
        model, "MNXM3", id_of_main_compartment)[0],
    helpers.find_met_in_model(
        model, "MNXM2", id_of_main_compartment)[0]
)
~~~

**Reason behind bug**: the `set()` datatype only accepts one argument, not two. This is where the `TypeError` occurs. This can be fixed by inputting the elements into a list and then inputting that into `set()`