### PR TITLE
Fix/biomass issues in helpers biomass test biomass

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -71,6 +71,10 @@ Next Release
   `test_basic.py` and generated a TypeError.
 * Fix a bug that prevented `find_biomass_precursors` 
   in `memote/support/biomass.py` from functioning due to a malformed set
+* Fix a bug that prevented `find_biomass_precursors` from correctly
+  identifying `atp` and `h2o` metabolites in cobra model reactions
+* Fix improperly labeled sbo terms for biomass production in `biomass.py`
+  and `test_for_helpers.py`
 
 0.5.0 (2018-01-16)
 ------------------

--- a/memote/support/biomass.py
+++ b/memote/support/biomass.py
@@ -72,15 +72,19 @@ def find_biomass_precursors(model, reaction):
 
     """
     id_of_main_compartment = helpers.find_compartment_id_in_model(model, 'c')
+    gam_reactants = set()
     try:
-        gam_reactants = set([
+        gam_reactants.update([
             helpers.find_met_in_model(
-                model, "MNXM3", id_of_main_compartment)[0],
-            helpers.find_met_in_model(
-                model, "MNXM2", id_of_main_compartment)[0]
-        ])
+                model, "MNXM3", id_of_main_compartment)[0]])
     except RuntimeError:
-        gam_reactants = set()
+        pass
+    try:
+        gam_reactants.update([
+            helpers.find_met_in_model(
+                model, "MNXM2", id_of_main_compartment)[0]])
+    except RuntimeError:
+        pass
 
     biomass_precursors = set(reaction.reactants) - gam_reactants
 

--- a/memote/support/helpers.py
+++ b/memote/support/helpers.py
@@ -216,7 +216,7 @@ def find_biomass_reaction(model):
     sbo_matches = set([rxn for rxn in model.reactions if
                        rxn.annotation is not None and
                        'SBO' in rxn.annotation and
-                       rxn.annotation['SBO'] == 'SBO:0000630'])
+                       rxn.annotation['SBO'] == 'SBO:0000629'])
 
     if len(sbo_matches) > 0:
         return list(sbo_matches)

--- a/tests/test_for_support/test_for_helpers.py
+++ b/tests/test_for_support/test_for_helpers.py
@@ -255,7 +255,7 @@ def biomass_sbo(base):
     c = cobra.Metabolite("RNA_c", compartment="c")
     d = cobra.Metabolite("GAM_c", compartment="c")
     rxn1 = cobra.Reaction("R0001")
-    rxn1.annotation = {'SBO': 'SBO:0000630'}
+    rxn1.annotation = {'SBO': 'SBO:0000629'}
     rxn1.add_metabolites({a: -1, b: -1, c: -1, d: -1})
     base.add_reactions([rxn1])
     return base


### PR DESCRIPTION
* [ ] fix #x (issue number)
* [x] description of feature/fix
* [ ] tests added/passed
* [x] add an entry to the [next release](../HISTORY.rst)


### readme

**Purpose**: To find & fix 3 ZeroDivisionError exceptions that result when running memote report snapshot on iJO1366.xml

**Description**: Currently, 3 functions in `memote/suite/tests/test_biomass.py` fail with ZeroDivisionError exceptions, all of which traceback to the `find_biomass_precursors` function in `memote/support/biomass.py`. The specific reaction in question which gave these errors was `ATPM`. The message displayed by all 3 ZeroDivisionError exceptions is:

```E   ZeroDivisionError: division by zero```

**Functions causing errors**:

* find_biomass_precursors: `memote/support/biomass.py` **(base traceback function)**


* test_biomass_precursors_default_production: `memote/suite/tests/test_biomass.py`
    * **(base traceback function)**


* test_direct_metabolites_in_biomass: `memote/suite/tests/test_biomass.py`
    * **(base traceback function)**


* test_essential_precursors_not_in_biomass: `memote/suite/tests/test_biomass.py`
    * **(base traceback function)**


**VIEW SUMMARY OF ISSUES AT END FOR DESCRIPTION OF BUGS AND STEPS TAKEN TO FIX THEM***

### Test 1: find_biomass_precursors unit test

**Overview**: Load in iJO1366 model, store ATPM reaction, build mini mock test model, and run find_biomass_precursors using these two models & reaction pairs


```python
import memote
import cobra

from memote.support.biomass import find_biomass_precursors
```

**Part 1**: Mini mock model & associated reactions


```python
base = cobra.Model()
met_a = cobra.Metabolite("lipid_c", compartment='c')
met_b = cobra.Metabolite("protein_c", compartment='c')
met_c = cobra.Metabolite("rna_c", compartment='c')
met_d = cobra.Metabolite("atp_c", compartment='c')
met_a1 = cobra.Metabolite("lipid_e", compartment='e')
met_b1 = cobra.Metabolite("protein_e", compartment='e')
met_c1 = cobra.Metabolite("rna_e", compartment='e')
met_d1 = cobra.Metabolite("atp_e", compartment='e')
# Reactions
rxn = cobra.Reaction("BIOMASS_TEST", lower_bound=0, upper_bound=1000)
rxn.add_metabolites({met_a: -1, met_b: -5, met_c: -2, met_d: -1})
rxn1 = cobra.Reaction("MET_Atec", lower_bound=-1000, upper_bound=1000)
rxn1.add_metabolites({met_a: 1, met_a1: -1})
rxn2 = cobra.Reaction("MET_Btec", lower_bound=-1000, upper_bound=1000)
rxn2.add_metabolites({met_b: 1, met_b1: -1})
rxn3 = cobra.Reaction("MET_Ctec", lower_bound=-1000, upper_bound=1000)
rxn3.add_metabolites({met_c: 1, met_c1: -1})
rxn4 = cobra.Reaction("MET_Dtec", lower_bound=-1000, upper_bound=1000)
rxn4.add_metabolites({met_d: 1, met_d1: -1})
base.add_reactions([rxn, rxn1, rxn2, rxn3, rxn4])
base.add_boundary(met_a1)
base.add_boundary(met_b1)
base.add_boundary(met_c1)
base.add_boundary(met_d1)
base.objective = rxn
```


```python
base
```





        <table>
            <tr>
                <td><strong>Name</strong></td>
                <td>None</td>
            </tr><tr>
                <td><strong>Memory address</strong></td>
                <td>0x0118ffb7f0</td>
            </tr><tr>
                <td><strong>Number of metabolites</strong></td>
                <td>8</td>
            </tr><tr>
                <td><strong>Number of reactions</strong></td>
                <td>9</td>
            </tr><tr>
                <td><strong>Objective expression</strong></td>
                <td>1.0*BIOMASS_TEST - 1.0*BIOMASS_TEST_reverse_5df00</td>
            </tr><tr>
                <td><strong>Compartments</strong></td>
                <td>c, e</td>
            </tr>
          </table>




```python
base.reactions.BIOMASS_TEST
```





        <table>
            <tr>
                <td><strong>Reaction identifier</strong></td><td>BIOMASS_TEST</td>
            </tr><tr>
                <td><strong>Name</strong></td><td></td>
            </tr><tr>
                <td><strong>Memory address</strong></td>
                <td>0x0118ffb320</td>
            </tr><tr>
                <td><strong>Stoichiometry</strong></td>
                <td>
                    <p style='text-align:right'>atp_c + lipid_c + 5 protein_c + 2 rna_c --> </p>
                    <p style='text-align:right'> +  + 5  + 2  --> </p>
                </td>
            </tr><tr>
                <td><strong>GPR</strong></td><td></td>
            </tr><tr>
                <td><strong>Lower bound</strong></td><td>0</td>
            </tr><tr>
                <td><strong>Upper bound</strong></td><td>1000</td>
            </tr>
        </table>
        




```python
base.reactions.MET_Atec
```





        <table>
            <tr>
                <td><strong>Reaction identifier</strong></td><td>MET_Atec</td>
            </tr><tr>
                <td><strong>Name</strong></td><td></td>
            </tr><tr>
                <td><strong>Memory address</strong></td>
                <td>0x0118ffb550</td>
            </tr><tr>
                <td><strong>Stoichiometry</strong></td>
                <td>
                    <p style='text-align:right'>lipid_e <=> lipid_c</p>
                    <p style='text-align:right'> <=> </p>
                </td>
            </tr><tr>
                <td><strong>GPR</strong></td><td></td>
            </tr><tr>
                <td><strong>Lower bound</strong></td><td>-1000</td>
            </tr><tr>
                <td><strong>Upper bound</strong></td><td>1000</td>
            </tr>
        </table>
        




```python
base.reactions.MET_Btec
```





        <table>
            <tr>
                <td><strong>Reaction identifier</strong></td><td>MET_Btec</td>
            </tr><tr>
                <td><strong>Name</strong></td><td></td>
            </tr><tr>
                <td><strong>Memory address</strong></td>
                <td>0x0118ffb780</td>
            </tr><tr>
                <td><strong>Stoichiometry</strong></td>
                <td>
                    <p style='text-align:right'>protein_e <=> protein_c</p>
                    <p style='text-align:right'> <=> </p>
                </td>
            </tr><tr>
                <td><strong>GPR</strong></td><td></td>
            </tr><tr>
                <td><strong>Lower bound</strong></td><td>-1000</td>
            </tr><tr>
                <td><strong>Upper bound</strong></td><td>1000</td>
            </tr>
        </table>
        




```python
base.reactions.MET_Ctec
```





        <table>
            <tr>
                <td><strong>Reaction identifier</strong></td><td>MET_Ctec</td>
            </tr><tr>
                <td><strong>Name</strong></td><td></td>
            </tr><tr>
                <td><strong>Memory address</strong></td>
                <td>0x0118ffb358</td>
            </tr><tr>
                <td><strong>Stoichiometry</strong></td>
                <td>
                    <p style='text-align:right'>rna_e <=> rna_c</p>
                    <p style='text-align:right'> <=> </p>
                </td>
            </tr><tr>
                <td><strong>GPR</strong></td><td></td>
            </tr><tr>
                <td><strong>Lower bound</strong></td><td>-1000</td>
            </tr><tr>
                <td><strong>Upper bound</strong></td><td>1000</td>
            </tr>
        </table>
        




```python
base.reactions.MET_Dtec
```





        <table>
            <tr>
                <td><strong>Reaction identifier</strong></td><td>MET_Dtec</td>
            </tr><tr>
                <td><strong>Name</strong></td><td></td>
            </tr><tr>
                <td><strong>Memory address</strong></td>
                <td>0x0118ffb2b0</td>
            </tr><tr>
                <td><strong>Stoichiometry</strong></td>
                <td>
                    <p style='text-align:right'>atp_e <=> atp_c</p>
                    <p style='text-align:right'> <=> </p>
                </td>
            </tr><tr>
                <td><strong>GPR</strong></td><td></td>
            </tr><tr>
                <td><strong>Lower bound</strong></td><td>-1000</td>
            </tr><tr>
                <td><strong>Upper bound</strong></td><td>1000</td>
            </tr>
        </table>
        



**Part 2**: iJO1366 model & ATPM reaction


```python
ijo1366 = cobra.io.read_sbml_model("/Users/sidcha/Documents/projects/testing_memote/iJO1366.xml")
ijo1366
```





        <table>
            <tr>
                <td><strong>Name</strong></td>
                <td>iJO1366</td>
            </tr><tr>
                <td><strong>Memory address</strong></td>
                <td>0x0119a49a90</td>
            </tr><tr>
                <td><strong>Number of metabolites</strong></td>
                <td>1805</td>
            </tr><tr>
                <td><strong>Number of reactions</strong></td>
                <td>2583</td>
            </tr><tr>
                <td><strong>Objective expression</strong></td>
                <td>-1.0*BIOMASS_Ec_iJO1366_core_53p95M_reverse_5c8b1 + 1.0*BIOMASS_Ec_iJO1366_core_53p95M</td>
            </tr><tr>
                <td><strong>Compartments</strong></td>
                <td>cytosol, extracellular space, periplasm</td>
            </tr>
          </table>




```python
ATPM = ijo1366.reactions.ATPM
ATPM
```





        <table>
            <tr>
                <td><strong>Reaction identifier</strong></td><td>ATPM</td>
            </tr><tr>
                <td><strong>Name</strong></td><td>ATP maintenance requirement</td>
            </tr><tr>
                <td><strong>Memory address</strong></td>
                <td>0x011d333630</td>
            </tr><tr>
                <td><strong>Stoichiometry</strong></td>
                <td>
                    <p style='text-align:right'>atp_c + h2o_c --> adp_c + h_c + pi_c</p>
                    <p style='text-align:right'>ATP C10H12N5O13P3 + H2O H2O --> ADP C10H12N5O10P2 + H+ + Phosphate</p>
                </td>
            </tr><tr>
                <td><strong>GPR</strong></td><td></td>
            </tr><tr>
                <td><strong>Lower bound</strong></td><td>3.15</td>
            </tr><tr>
                <td><strong>Upper bound</strong></td><td>1000.0</td>
            </tr>
        </table>
        



**Part 1, Test 1**


```python
find_biomass_precursors(ijo1366, ijo1366.reactions.ATPM)
```




    []



**Part 2, Test 1**


```python
find_biomass_precursors(base, rxn)
```




    [<Metabolite protein_c at 0x118ffb518>,
     <Metabolite atp_c at 0x118ffb4a8>,
     <Metabolite lipid_c at 0x118ffb860>,
     <Metabolite rna_c at 0x118ffb470>]




```python
find_biomass_precursors(base, rxn1)
```




    [<Metabolite lipid_e at 0x118ffb438>]




```python
find_biomass_precursors(base, rxn2)
```




    [<Metabolite protein_e at 0x118ffb400>]




```python
find_biomass_precursors(base, rxn3)
```




    [<Metabolite rna_e at 0x118ffb3c8>]




```python
find_biomass_precursors(base, rxn4)
```




    [<Metabolite atp_e at 0x118ffb4e0>]



**Summary**: function takes out ATP in part 1, but does not show other metabolites. function also fails to remove atp_c and atp_e in part 2. May warrent further investigation

### Test 2: find_compartment_in_model
**Overview**: Ensure helper function is working properly determine if it is the cause for Test 1 results


```python
from memote.support.helpers import find_compartment_id_in_model
```

**Part 1, Test 2**


```python
find_compartment_id_in_model(base, "c")
```




    'c'




```python
find_compartment_id_in_model(base, "e")
```




    'e'



**Part 2, Test 2**


```python
find_compartment_id_in_model(ijo1366, "c")
```




    'c'




```python
ijo1366.reactions.ACOAD1f
```





        <table>
            <tr>
                <td><strong>Reaction identifier</strong></td><td>ACOAD1f</td>
            </tr><tr>
                <td><strong>Name</strong></td><td>Acyl-CoA dehydrogenase (butanoyl-CoA)</td>
            </tr><tr>
                <td><strong>Memory address</strong></td>
                <td>0x011b551198</td>
            </tr><tr>
                <td><strong>Stoichiometry</strong></td>
                <td>
                    <p style='text-align:right'>btcoa_c + fad_c <=> b2coa_c + fadh2_c</p>
                    <p style='text-align:right'>Butanoyl-CoA + Flavin adenine dinucleotide oxidized <=> Crotonoyl-CoA + Flavin adenine dinucleotide reduced</p>
                </td>
            </tr><tr>
                <td><strong>GPR</strong></td><td>b0221</td>
            </tr><tr>
                <td><strong>Lower bound</strong></td><td>-1000.0</td>
            </tr><tr>
                <td><strong>Upper bound</strong></td><td>1000.0</td>
            </tr>
        </table>
        




```python
find_biomass_precursors(ijo1366, ijo1366.reactions.ACOAD1f)
```




    [<Metabolite btcoa_c at 0x11caeb630>, <Metabolite fad_c at 0x11cb525c0>]




```python
ijo1366.reactions.LIPACabcpp
```





        <table>
            <tr>
                <td><strong>Reaction identifier</strong></td><td>LIPACabcpp</td>
            </tr><tr>
                <td><strong>Name</strong></td><td>Lipid (cold) A transport via ABC system (periplasm)</td>
            </tr><tr>
                <td><strong>Memory address</strong></td>
                <td>0x011d680080</td>
            </tr><tr>
                <td><strong>Stoichiometry</strong></td>
                <td>
                    <p style='text-align:right'>atp_c + h2o_c + lipa_cold_c --> adp_c + h_c + lipa_cold_p + pi_c</p>
                    <p style='text-align:right'>ATP C10H12N5O13P3 + H2O H2O + Cold adapted KDO(2)-lipid (A) --> ADP C10H12N5O10P2 + H+ + Cold adapted KDO(2)-lipid (A) + Phosphate</p>
                </td>
            </tr><tr>
                <td><strong>GPR</strong></td><td>b0914</td>
            </tr><tr>
                <td><strong>Lower bound</strong></td><td>0.0</td>
            </tr><tr>
                <td><strong>Upper bound</strong></td><td>1000.0</td>
            </tr>
        </table>
        




```python
find_biomass_precursors(ijo1366, ijo1366.reactions.LIPACabcpp)
```




    [<Metabolite lipa_cold_c at 0x11cc1d390>]



**Summary**: helper function performs properly, and find_biomass_precursors has expected behavior for these specific reactions. This function is likely not the culprit

### Test 3: find_met_in_model unit test
**Overview**: Ensure helper function is working properly determine if it is the cause for Test 1 results


```python
from memote.support.helpers import find_met_in_model
```

**Part 1, Test 3**


```python
find_met_in_model(base, "MNXM3", "c"), find_met_in_model(base, "MNXM2", "c")
```


    ---------------------------------------------------------------------------

    RuntimeError                              Traceback (most recent call last)

    <ipython-input-43-5126fd5e59c2> in <module>()
    ----> 1 find_met_in_model(base, "MNXM3", "c"), find_met_in_model(base, "MNXM2", "c")
    

    ~/Documents/projects/testing_memote/memote/memote/support/helpers.py in find_met_in_model(model, mnx_id, compartment_id)
        618                            "the MetaNetX Database exists for your "
        619                            "identifier "
    --> 620                            "namespace.".format(compartment_id, mnx_id))
        621     elif len(candidates_in_compartment) > 1:
        622         raise RuntimeError("It was not possible to uniquely identify "


    RuntimeError: It was not possible to identify any metabolite in compartment c corresponding to the following MetaNetX identifier: MNXM2.Make sure that a cross-reference to this ID in the MetaNetX Database exists for your identifier namespace.



```python
find_met_in_model(base, "MNXM3", "e"), find_met_in_model(base, "MNXM2", "e")
```


    ---------------------------------------------------------------------------

    RuntimeError                              Traceback (most recent call last)

    <ipython-input-42-48e17811b36c> in <module>()
    ----> 1 find_met_in_model(base, "MNXM3", "e"), find_met_in_model(base, "MNXM2", "e")
    

    ~/Documents/projects/testing_memote/memote/memote/support/helpers.py in find_met_in_model(model, mnx_id, compartment_id)
        618                            "the MetaNetX Database exists for your "
        619                            "identifier "
    --> 620                            "namespace.".format(compartment_id, mnx_id))
        621     elif len(candidates_in_compartment) > 1:
        622         raise RuntimeError("It was not possible to uniquely identify "


    RuntimeError: It was not possible to identify any metabolite in compartment e corresponding to the following MetaNetX identifier: MNXM2.Make sure that a cross-reference to this ID in the MetaNetX Database exists for your identifier namespace.


**Part 2, Test 3**


```python
find_met_in_model(ijo1366, "MNXM3", "c"), find_met_in_model(ijo1366, "MNXM2", "c")
```




    ([<Metabolite atp_c at 0x11ad63160>], [<Metabolite h2o_c at 0x11aef3e48>])




```python
find_met_in_model(ijo1366, "MNXM3", "c"), find_met_in_model(ijo1366, "MNXM2", "c")
```




    ([<Metabolite atp_c at 0x11ad63160>], [<Metabolite h2o_c at 0x11aef3e48>])



**Summary**: helper function runs as expected, but curious behavior found. Further testing may be warrented

### Test 3, continued: find_met_in_model, a closer look

**Part 1**


```python
find_met_in_model(base, "MNXM3", "c")
```




    [<Metabolite atp_c at 0x118ffb4a8>]




```python
find_met_in_model(base, "MNXM3", "e")
```




    [<Metabolite atp_e at 0x118ffb4e0>]




```python
find_met_in_model(base, "MNXM2", "c")
```


    ---------------------------------------------------------------------------

    RuntimeError                              Traceback (most recent call last)

    <ipython-input-52-4d3d46b12307> in <module>()
    ----> 1 find_met_in_model(base, "MNXM2", "c")
    

    ~/Documents/projects/testing_memote/memote/memote/support/helpers.py in find_met_in_model(model, mnx_id, compartment_id)
        618                            "the MetaNetX Database exists for your "
        619                            "identifier "
    --> 620                            "namespace.".format(compartment_id, mnx_id))
        621     elif len(candidates_in_compartment) > 1:
        622         raise RuntimeError("It was not possible to uniquely identify "


    RuntimeError: It was not possible to identify any metabolite in compartment c corresponding to the following MetaNetX identifier: MNXM2.Make sure that a cross-reference to this ID in the MetaNetX Database exists for your identifier namespace.



```python
find_met_in_model(base, "MNXM3", "e")
```




    [<Metabolite atp_e at 0x118ffb4e0>]



**Part 2**


```python
find_met_in_model(ijo1366, "MNXM3", "c")
```




    [<Metabolite atp_c at 0x11ad63160>]




```python
find_met_in_model(ijo1366, "MNXM3", "e")
```


    ---------------------------------------------------------------------------

    RuntimeError                              Traceback (most recent call last)

    <ipython-input-51-5c38b1022cea> in <module>()
    ----> 1 find_met_in_model(ijo1366, "MNXM3", "e")
    

    ~/Documents/projects/testing_memote/memote/memote/support/helpers.py in find_met_in_model(model, mnx_id, compartment_id)
        618                            "the MetaNetX Database exists for your "
        619                            "identifier "
    --> 620                            "namespace.".format(compartment_id, mnx_id))
        621     elif len(candidates_in_compartment) > 1:
        622         raise RuntimeError("It was not possible to uniquely identify "


    RuntimeError: It was not possible to identify any metabolite in compartment e corresponding to the following MetaNetX identifier: MNXM3.Make sure that a cross-reference to this ID in the MetaNetX Database exists for your identifier namespace.



```python
find_met_in_model(ijo1366, "MNXM2", "c")
```




    [<Metabolite h2o_c at 0x11aef3e48>]




```python
find_met_in_model(ijo1366, "MNXM2", "e")
```




    [<Metabolite h2o_e at 0x11afef588>]



**Summary**: When only one of {ATP, H2O} metabolites is located in reaction, the whole tuple/list/set data structure throws a `RuntimeError` exception. Looking at `find_biomass_precurors` source code below:

~~~
try:
    gam_reactants = set([
        helpers.find_met_in_model(
            model, "MNXM3", id_of_main_compartment)[0],
        helpers.find_met_in_model(
            model, "MNXM2", id_of_main_compartment)[0]
    ])
except RuntimeError:
    gam_reactants = set()
~~~

it becomes apparent that this behavior is behind `find_biomass_precursors`'s failure to seperate `atp_c` and `atp_e` from the other metabolites in Test 1. The try-except structure needs to be modified to look at both `helpers.find_met_in_model` function calls seperately and then add them into a set later instead of generating an empty `gam_reactants` set when a `RuntimeError` exception is thrown for (potentially) only one of the two function calls.

### Test 4: find_biomass_reaction unit test
**Overview**: Previous test results led Christian to believe this test may also have a hand in causing the bugs seen, as ATPM was the reaction that generated the `TypeError` exceptions being thrown. This should not have occured in the first place, as ATPM is not a biomass objective growth function. This unit test is to ensure this function is behaving properly.


```python
from memote.support.helpers import find_biomass_reaction
```

**Part 1, Test 4**


```python
find_biomass_reaction(base)
```




    [<Reaction BIOMASS_TEST at 0x118ffb320>]



**Part 2, Test 4**


```python
find_biomass_reaction(ijo1366)
```




    [<Reaction ATPM at 0x11b667080>]




```python
ATPM.annotation
```




    {'SBO': 'SBO:0000630',
     'bigg.reaction': 'ATPM',
     'biocyc': 'META:ATPASE-RXN',
     'ec-code': ['3.6.1.15',
      '3.6.1.3',
      '3.6.1.5',
      '3.6.1.8',
      '3.6.3.1',
      '3.6.3.10',
      '3.6.3.11',
      '3.6.3.12',
      '3.6.3.14',
      '3.6.3.15',
      '3.6.3.16',
      '3.6.3.17',
      '3.6.3.18',
      '3.6.3.19',
      '3.6.3.2',
      '3.6.3.20',
      '3.6.3.21',
      '3.6.3.22',
      '3.6.3.23',
      '3.6.3.24',
      '3.6.3.25',
      '3.6.3.26',
      '3.6.3.27',
      '3.6.3.28',
      '3.6.3.29',
      '3.6.3.3',
      '3.6.3.30',
      '3.6.3.31',
      '3.6.3.32',
      '3.6.3.33',
      '3.6.3.34',
      '3.6.3.35',
      '3.6.3.36',
      '3.6.3.37',
      '3.6.3.38',
      '3.6.3.39',
      '3.6.3.4',
      '3.6.3.40',
      '3.6.3.41',
      '3.6.3.42',
      '3.6.3.43',
      '3.6.3.44',
      '3.6.3.46',
      '3.6.3.47',
      '3.6.3.48',
      '3.6.3.49',
      '3.6.3.5',
      '3.6.3.50',
      '3.6.3.51',
      '3.6.3.52',
      '3.6.3.53',
      '3.6.3.54',
      '3.6.3.6',
      '3.6.3.7',
      '3.6.3.8',
      '3.6.3.9',
      '3.6.4.1',
      '3.6.4.10',
      '3.6.4.11',
      '3.6.4.12',
      '3.6.4.13',
      '3.6.4.2',
      '3.6.4.3',
      '3.6.4.4',
      '3.6.4.5',
      '3.6.4.6',
      '3.6.4.7',
      '3.6.4.8',
      '3.6.4.9'],
     'kegg.reaction': 'R00086',
     'metanetx.reaction': 'MNXR96131',
     'rhea': ['13065', '13066', '13067', '13068']}



**Summary**: This function has an SBO value of 0000630, which is what `find_biomass_reaction` searches for as a biomass objective function. However, SBO: 0000630 corresponds to ATP maintenance, with the proper SBO value for biomass growth being SBO: 0000629. This explains why ATPM is considered a biomass reaction while actual two biomass reactions in iJO1366 are not found. This issue has also been verified to exist in `test_for_helpers.py` as well, and may exist across memote. Should be marked as an open issue.

### Summary of Issues:

Two bugs were found to the culprits for the strange behavior seen when running `memote report snapshot -a "-vv" iJO1366.xml`. The first issue dealt with the try-except structure used when generating 2 function calls to `helpers.find_met_in_model` which prevented find_biomass_precursors from functioning properly. Splitting the try-except statement into two separate try-except statements (one for each function call) will solve this. The second issue dealt with an improper numbering of the biomass growth objective function. Original label was SBO: 0000630, which actually corresponds to [ATP maintenance](http://www.ebi.ac.uk/sbo/main/SBO:0000630). Correct label should be 0000629, which corresponds to [biomass production](http://www.ebi.ac.uk/sbo/main/SBO:0000629). This is also a known bug in `test_for_helpers.py` and possibly elsewhere. Should be marked as an open issue.
