### PR TITLE
fix: replace broken link in contributing.rst

### DIFF
--- a/.github/CONTRIBUTING.rst
+++ b/.github/CONTRIBUTING.rst
@@ -85,7 +85,7 @@ Ready to contribute? Here's how to set up `memote` for local development.
    pip install them into your virtualenv.
 
 6. Commit your changes and push your branch to GitHub. Please use `semantic
-   commit messages <https://seesparkbox.com/foundry/semantic_commit_messages>`_::
+   commit messages <http://karma-runner.github.io/2.0/dev/git-commit-msg.html>`_::
 
     git add .
     git commit -m "fix: Your detailed description of your changes."

--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -67,10 +67,12 @@ Next Release
 * Refactor sink_react_list to sink_reactions for improved readability
 * Allow `test_sink_specific_sbo_presence` to be skipped when no sink reactions
   are present with a metric of 1.0
-* Fix a bug that compared the length of a float to generate a metric in 
+* Fix a bug that compared the length of a float to generate a metric in
   `test_basic.py` and generated a TypeError.
-* Fix a bug that prevented `find_biomass_precursors` 
+* Fix a bug that prevented `find_biomass_precursors`
   in `memote/support/biomass.py` from functioning due to a malformed set
+* In CONTRIBUTING.rst replace link to semantic commit guide by seesparkbox
+  with link to guide by karma, due to error with sphinx linkcheck.
 
 0.5.0 (2018-01-16)
 ------------------


### PR DESCRIPTION
* [x] fix #x (issue number)
* [x] description of feature/fix
* [ ] tests added/passed
* [x] add an entry to the [next release](../HISTORY.rst)

sphinx` linkcheck is reporting the following errors:

```
preparing documents... done
writing output... [  2%] _autogen/memote
writing output... [  5%] _autogen/memote.suite
writing output... [  8%] _autogen/memote.suite.api
writing output... [ 10%] _autogen/memote.suite.cli
writing output... [ 13%] _autogen/memote.suite.cli.callbacks
writing output... [ 16%] _autogen/memote.suite.cli.config
writing output... [ 18%] _autogen/memote.suite.cli.reports
writing output... [ 21%] _autogen/memote.suite.cli.runner
writing output... [ 24%] _autogen/memote.suite.collect
writing output... [ 27%] _autogen/memote.suite.reporting
writing output... [ 29%] _autogen/memote.suite.reporting.bag
writing output... [ 32%] _autogen/memote.suite.reporting.diff
writing output... [ 35%] _autogen/memote.suite.reporting.history
writing output... [ 37%] _autogen/memote.suite.reporting.report
writing output... [ 40%] _autogen/memote.suite.reporting.snapshot
writing output... [ 43%] _autogen/memote.support
writing output... [ 45%] _autogen/memote.support.annotation
writing output... [ 48%] _autogen/memote.support.basic
writing output... [ 51%] _autogen/memote.support.biomass
writing output... [ 54%] _autogen/memote.support.consistency
(line   46) redirect  http://doi.org/10.1371/journal.pcbi.1005494 - permanently to http://journals.plos.org/ploscompbiol/article?id=10.1371/journal.pcbi.1005494
(line   33) redirect  http://doi.org/10.1038/nprot.2009.203 - with Found to http://www.nature.com/articles/nprot.2009.203
writing output... [ 56%] _autogen/memote.support.consistency_helpers
(line   16) ok        https://scipy.github.io/old-wiki/pages/Cookbook/RankNullspace.html
writing output... [ 59%] _autogen/memote.support.helpers
(line   36) redirect  http://doi.org/10.1038/nprot.2009.203 - with Found to http://www.nature.com/articles/nprot.2009.203
(line   34) redirect  http://doi.org/10.1038/nprot.2009.203 - with Found to http://www.nature.com/articles/nprot.2009.203
(line   35) redirect  http://doi.org/10.1038/nprot.2009.203 - with Found to http://www.nature.com/articles/nprot.2009.203
writing output... [ 62%] _autogen/memote.support.sbo
writing output... [ 64%] _autogen/memote.support.syntax
writing output... [ 67%] _autogen/memote.utils
writing output... [ 70%] _autogen/memote.version_info
writing output... [ 72%] _autogen/modules
writing output... [ 75%] api
writing output... [ 78%] authors
writing output... [ 81%] contributing
(line  104) ok        https://travis-ci.org/opencobra/memote/pull_requests
(line   87) broken    https://seesparkbox.com/foundry/semantic_commit_messages - HTTPSConnectionPool(host='seesparkbox.com', port=443): Max retries exceeded with url: /foundry/semantic_commit_messages (Caused by SSLError(SSLError(1, '[SSL: CERTIFICATE_VERIFY_FAILED] certificate verify failed (_ssl.c:719)'),))
(line   46) ok        https://github.com/opencobra/memote/issues
(line   16) ok        https://github.com/opencobra/memote/issues
writing output... [ 83%] core
(line   12) redirect  http://doi.org/10.1371/journal.pcbi.1005494 - permanently to http://journals.plos.org/ploscompbiol/article?id=10.1371/journal.pcbi.1005494
(line   10) ok        https://identifiers.org/
(line   11) ok        https://identifiers.org/
(line   11) ok        https://identifiers.org/
(line    4) ok        https://identifiers.org/
(line    4) redirect  https://doi.org/10.1074%2Fmcp.M800490-MCP200 - with Found to http://www.mcponline.org/content/8/6/1361
writing output... [ 86%] custom_tests
(line  124) ok        https://github.com/numpy/numpy/blob/master/doc/HOWTO_DOCUMENT.rst.txt
(line   21) ok        https://docs.pytest.org/en/latest/
(line  136) ok        https://docs.pytest.org/en/latest/parametrize.html#parametrize
(line   21) ok        https://docs.pytest.org/en/latest/goodpractices.html#test-package-name
(line  188) ok        https://docs.pytest.org/en/latest/goodpractices.html
(line  130) ok        https://docs.pytest.org/en/latest/assert.html
writing output... [ 89%] flowchart
writing output... [ 91%] getting_started
(line   26) ok        http://docs.python-guide.org/en/latest/starting/installation/
(line   10) ok        http://docs.python-guide.org/en/latest/dev/virtualenvs/
(line   26) ok        https://pip.pypa.io/en/stable/
(line  124) ok        http://www.pathwaytools.org/
(line   43) redirect  https://github.com/opencobra/memote/archive/master.zip - with Found to https://codeload.github.com/opencobra/memote/zip/master
(line   43) redirect  https://github.com/opencobra/memote/archive/master.tar.gz - with Found to https://codeload.github.com/opencobra/memote/tar.gz/master
(line   35) ok        https://github.com/opencobra/memote
(line  124) ok        http://modelseed.org
(line  124) ok        https://github.com/SysBioChalmers/RAVEN
(line  147) ok        https://github.com
(line  147) redirect  https://gitlab.com - with Found to https://about.gitlab.com/
(line  124) ok        http://bigg.ucsd.edu
(line  184) redirect  https://gitlab.com - with Found to https://about.gitlab.com/
(line  109) ok        https://docs.pytest.org/en/latest/usage.html
(line  124) ok        http://www.secondarymetabolites.org/sysbio/
(line  161) ok        https://github.com/opencobra/cookiecutter-memote/blob/master/%7B%7Bcookiecutter.project_slug%7D%7D/README.md
(line  124) redirect  https://www.ebi.ac.uk/biomodels/ - permanently to https://wwwdev.ebi.ac.uk/biomodels/
writing output... [ 94%] history
writing output... [ 97%] index
(line   21) -local-   LICENSE
(line    8) ok        https://gitter.im/opencobra/memote
(line   11) ok        https://memote.readthedocs.io/en/latest/contributing.html
(line    9) ok        https://groups.google.com/forum/#!forum/memote
writing output... [100%] test_suite
build finished with problems, 10 warnings.
make: *** [linkcheck] Error 1
make: Leaving directory `/home/travis/build/opencobra/memote/docs'
ERROR: InvocationError: '/usr/bin/make -C /home/travis/build/opencobra/memote/docs linkcheck'
___________________________________ summary ____________________________________
ERROR:   docs: commands failed
/home/travis/.travis/job_stages: line 169:  3780 Terminated              travis_jigger $! $timeout $cmd
```

I assume that the broken link is causing Travis to fail, which is why I've replaced it with a link to a guide on semantic commit messages by karma instead.