### PR TITLE
fix: functions return objects not str ids

### DIFF
--- a/memote/support/consistency.py
+++ b/memote/support/consistency.py
@@ -527,7 +527,7 @@ def find_metabolites_produced_with_closed_bounds(model):
                 met, type='irrex', reaction_id='IRREX', lb=0, ub=1
             )
             if helpers.run_fba(model, exch.id) > 0:
-                mets_produced.append(met.id)
+                mets_produced.append(met)
     return mets_produced
 
 
@@ -553,7 +553,7 @@ def find_metabolites_consumed_with_closed_bounds(model):
                 met, type='irrex', reaction_id='IRREX', lb=-1, ub=0
             )
             if helpers.run_fba(model, exch.id, direction='min') < 0:
-                mets_consumed.append(met.id)
+                mets_consumed.append(met)
     return mets_consumed
 
 


### PR DESCRIPTION
* [ ] fix #x (issue number)
* [x] description of feature/fix
* [ ] tests added/passed
* [ ] add an entry to the [next release](../HISTORY.rst)

### Summary
* `find_metabolites_produced_with_closed_bounds`
* `find_metabolites_consumed_with_closed_bounds`

These two functions were returning a list of metabolite ids, not metabolite objects. To keep memote functions consistent, these functions now return a list of metabolite objects, not string ids, as previously discussed with Moritz and Christian. An entry to `History.rst` will be added after #350 is pulled so as to not create unnecessary merge conflicts within `History.rst`
