### PR TITLE
fix: unicode decode errors

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -119,6 +119,8 @@ Next Release
   exchange reactions, transporters and the biomass reaction itself.
 * Implement a test that checks for a low ratio of transport reactions without
   GPR relative to the total amount of transport reactions.
+* Fix UnicodeDecodeError when memote tries to open the html template for the
+  snapshot report.
 
 0.4.6 (2017-10-31)
 ------------------

--- a/memote/suite/api.py
+++ b/memote/suite/api.py
@@ -117,7 +117,7 @@ def snapshot_report(results, filename):
     """
     report = SnapshotReport(results)
     LOGGER.info("Writing basic report '%s'.", filename)
-    with io.open(filename, "w") as file_h:
+    with io.open(filename, "w", encoding="utf-8") as file_h:
         file_h.write(report.render_html())
 
 

--- a/memote/suite/reporting/snapshot.py
+++ b/memote/suite/reporting/snapshot.py
@@ -40,7 +40,9 @@ class SnapshotReport(Report):
     def __init__(self, data, **kwargs):
         """Initialize the data."""
         super(SnapshotReport, self).__init__(**kwargs)
-        with io.open(join(TEMPLATES_PATH, "snapshot.html")) as file_path:
+        with io.open(
+            join(TEMPLATES_PATH, "snapshot.html"), encoding="utf-8"
+        ) as file_path:
             self._template = Template(file_path.read())
         self.data = data
 


### PR DESCRIPTION
* [x] fix #348 (issue number)
* [x] description of feature/fix
* [x] tests added/passed
* [x] add an entry to the [next release](../HISTORY.rst)

This PR implements @jonovik 's proposal to fix UnicodeDecodeErrors that we see locally on win 10 and macOS Sierra.