### PR TITLE
Matrix tests

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -77,6 +77,8 @@ Next Release
   identifying `atp` and `h2o` metabolites in cobra model reactions
 * Fix improperly labeled sbo terms for biomass production in `biomass.py`
   and `test_for_helpers.py`
+* Add matrix conditioning functions in ``matrix.py`` which are used for 
+  model stoichiometric matrix testing in ``test_matrix.py``
 
 
 0.5.0 (2018-01-16)

--- a/memote/suite/test_config.yml
+++ b/memote/suite/test_config.yml
@@ -34,6 +34,11 @@ cards:
         title: "Matrix Conditioning"
         weight: 1.0
         cases:
+        - test_absolute_extreme_coefficient_ratio
+        - test_number_independent_conservation_relations
+        - test_number_steady_state_flux_solutions
+        - test_matrix_rank
+        - test_degrees_of_freedom
   test_basic:
     title: "Basic Information"
     cases:

--- a/memote/suite/tests/test_matrix.py
+++ b/memote/suite/tests/test_matrix.py
@@ -20,6 +20,7 @@
 from __future__ import absolute_import, division
 
 import memote.support.matrix as matrix
+from memote.utils import annotate, wrapper
 
 
 @annotate(title="Ratio between largest and smallest non-zero coefficients",

--- a/memote/suite/tests/test_matrix.py
+++ b/memote/suite/tests/test_matrix.py
@@ -24,8 +24,7 @@ from memote.utils import annotate, wrapper
 
 
 @annotate(title="Ratio between largest and smallest non-zero coefficients",
-          type="percent"
-          )
+          type="percent")
 def test_absolute_extreme_coefficient_ratio(model):
     """
     Show ratio of the absolute largest and smallest non-zero coefficients.
@@ -50,8 +49,7 @@ def test_absolute_extreme_coefficient_ratio(model):
 
 
 @annotate(title="Number of independent conservation relations in model",
-          type="number"
-          )
+          type="number")
 def test_number_independent_conservation_relations(model):
     """
     Show number of independent conservation relations in the model.

--- a/memote/suite/tests/test_matrix.py
+++ b/memote/suite/tests/test_matrix.py
@@ -1,0 +1,48 @@
+# -*- coding: utf-8 -*-
+
+# Copyright 2017 Novo Nordisk Foundation Center for Biosustainability,
+# Technical University of Denmark.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Tests for matrix properties performed on an instance of ``cobra.Model``."""
+
+from __future__ import absolute_import, division
+
+import memote.support.matrix as matrix
+
+
+@annotate(title="Ratio between largest and smallest non-zero coefficients",
+          type="percent"
+)
+def test_absolute_extreme_coefficient_ratio(model):
+    """Show ratio of the absolute largest and smallest non-zero coefficients.
+
+    This test will return the absolute largest and smallest, non-zero
+    coefficients from the S-Matrix. A large ratio of these values may point to
+    potential numerical issues when trying to solve the underlying system of
+    equations.
+
+    To pass this test the ratio should not exceed 10^9. This threshold has
+    been selected based on experience, and is likely to be adapted when more
+    data on solver performance becomes available.
+    """
+    ann = test_absolute_extreme_coefficient_ratio.annotation
+    ann["data"] = matrix.absolute_extreme_coefficient_ratio(model)
+    ann["metric"] = ann["data"][0] / ann["data"][1]
+    ann["message"] = wrapper.fill(
+        """The ratio of the absolute highest coefficient {} and the lowest,
+        non-zero coefficient {} is: {}""".format(
+            ann["data"][0], ann["data"][1], ann['metric']
+        ))
+    assert ann["metric"] < 1e9, ann["message"]

--- a/memote/suite/tests/test_matrix.py
+++ b/memote/suite/tests/test_matrix.py
@@ -43,7 +43,7 @@ def test_absolute_extreme_coefficient_ratio(model):
     ann["metric"] = ann["data"][0] / ann["data"][1]
     ann["message"] = wrapper.fill(
         """The ratio of the absolute highest coefficient {} and the lowest,
-        non-zero coefficient {} is: {}""".format(
+        non-zero coefficient {} is: {}.""".format(
             ann["data"][0], ann["data"][1], ann['metric']))
     assert ann["metric"] < 1e9, ann["message"]
 
@@ -63,7 +63,7 @@ def test_number_independent_conservation_relations(model):
     ann = test_number_independent_conservation_relations.annotation
     ann["data"] = matrix.number_independent_conservation_relations(model)
     ann["message"] = wrapper.fill(
-        """The number of independent conservation relations is {}""".format(
+        """The number of independent conservation relations is {}.""".format(
             ann["data"]))
 
 
@@ -81,7 +81,7 @@ def test_number_steady_state_flux_solutions(model):
     ann = test_number_steady_state_flux_solutions.annotation
     ann["data"] = matrix.number_steady_state_flux_solutions(model)
     ann["message"] = wrapper.fill(
-        """The number of independent steady-state flux solution vectors is {}
+        """The number of independent steady-state flux solution vectors is {}.
         """.format(ann["data"]))
 
 
@@ -98,7 +98,7 @@ def test_matrix_rank(model):
     ann = test_matrix_rank.annotation
     ann["data"] = matrix.matrix_rank(model)
     ann["message"] = wrapper.fill(
-        """The rank of the S-Matrix is {}""".format(ann["data"]))
+        """The rank of the S-Matrix is {}.""".format(ann["data"]))
 
 
 @annotate(title="Degrees of freedom of S-Matrix", type="number")
@@ -115,4 +115,4 @@ def test_degrees_of_freedom(model):
     ann = test_degrees_of_freedom.annotation
     ann["data"] = matrix.degrees_of_freedom(model)
     ann["message"] = wrapper.fill(
-        """The degrees of freedom of the S-Matrix is {}""".format(ann["data"]))
+        """The degrees of freedom of the S-Matrix is {}.""".format(ann["data"]))

--- a/memote/suite/tests/test_matrix.py
+++ b/memote/suite/tests/test_matrix.py
@@ -45,8 +45,7 @@ def test_absolute_extreme_coefficient_ratio(model):
     ann["message"] = wrapper.fill(
         """The ratio of the absolute highest coefficient {} and the lowest,
         non-zero coefficient {} is: {}""".format(
-            ann["data"][0], ann["data"][1], ann['metric']
-        ))
+            ann["data"][0], ann["data"][1], ann['metric']))
     assert ann["metric"] < 1e9, ann["message"]
 
 
@@ -67,8 +66,7 @@ def test_number_independent_conservation_relations(model):
     ann["data"] = matrix.number_independent_conservation_relations(model)
     ann["message"] = wrapper.fill(
         """The number of independent conservation relations is {}""".format(
-            ann["data"]
-        ))
+            ann["data"]))
 
 
 @annotate(title="Number of steady-state flux solution vectors", type="number")
@@ -86,8 +84,7 @@ def test_number_steady_state_flux_solutions(model):
     ann["data"] = matrix.number_steady_state_flux_solutions(model)
     ann["message"] = wrapper.fill(
         """The number of independent steady-state flux solution vectors is {}
-        """.format(ann["data"]
-                   ))
+        """.format(ann["data"]))
 
 
 @annotate(title="Rank of S-Matrix", type="number")
@@ -103,8 +100,7 @@ def test_matrix_rank(model):
     ann = test_matrix_rank.annotation
     ann["data"] = matrix.matrix_rank(model)
     ann["message"] = wrapper.fill(
-        """The rank of the S-Matrix is {}""".format(ann["data"]
-                                                    ))
+        """The rank of the S-Matrix is {}""".format(ann["data"]))
 
 
 @annotate(title="Degrees of freedom of S-Matrix", type="number")
@@ -121,5 +117,4 @@ def test_degrees_of_freedom(model):
     ann = test_degrees_of_freedom.annotation
     ann["data"] = matrix.degrees_of_freedom(model)
     ann["message"] = wrapper.fill(
-        """The degrees of freedom of the S-Matrix is {}""".format(ann["data"]
-                                                                  ))
+        """The degrees of freedom of the S-Matrix is {}""".format(ann["data"]))

--- a/memote/suite/tests/test_matrix.py
+++ b/memote/suite/tests/test_matrix.py
@@ -25,9 +25,10 @@ from memote.utils import annotate, wrapper
 
 @annotate(title="Ratio between largest and smallest non-zero coefficients",
           type="percent"
-)
+          )
 def test_absolute_extreme_coefficient_ratio(model):
-    """Show ratio of the absolute largest and smallest non-zero coefficients.
+    """
+    Show ratio of the absolute largest and smallest non-zero coefficients.
 
     This test will return the absolute largest and smallest, non-zero
     coefficients from the S-Matrix. A large ratio of these values may point to

--- a/memote/suite/tests/test_matrix.py
+++ b/memote/suite/tests/test_matrix.py
@@ -48,3 +48,78 @@ def test_absolute_extreme_coefficient_ratio(model):
             ann["data"][0], ann["data"][1], ann['metric']
         ))
     assert ann["metric"] < 1e9, ann["message"]
+
+
+@annotate(title="Number of independent conservation relations in model",
+          type="number"
+          )
+def test_number_independent_conservation_relations(model):
+    """
+    Show number of independent conservation relations in the model.
+
+    This test will return the number of conservation relations, i.e.
+    conservation pools through the left null space of the S-Matrix.
+
+    This test is not scored, as the dimension of the left null space
+    depends on the S-Matrix constructed, which is system-specific.
+    """
+    ann = test_number_independent_conservation_relations.annotation
+    ann["data"] = matrix.number_independent_conservation_relations(model)
+    ann["message"] = wrapper.fill(
+        """The number of independent conservation relations is {}""".format(
+            ann["data"]
+        ))
+
+
+@annotate(title="Number of steady-state flux solution vectors", type="number")
+def test_number_steady_state_flux_solutions(model):
+    """
+    Show number of independent steady-state flux solution vectors for model.
+
+    This test will return the number of steady-state flux solution vectors
+    through the null space of the S-Matrix.
+
+    This test is not scored, as the dimension of the null space depends on the
+    S-Matrix constructed, which is system-specific.
+    """
+    ann = test_number_steady_state_flux_solutions.annotation
+    ann["data"] = matrix.number_steady_state_flux_solutions(model)
+    ann["message"] = wrapper.fill(
+        """The number of independent steady-state flux solution vectors is {}
+        """.format(ann["data"]
+                   ))
+
+
+@annotate(title="Rank of S-Matrix", type="number")
+def test_matrix_rank(model):
+    """
+    Show rank of the S-Matrix.
+
+    This test will return the rank of the S-Matrix of the model.
+
+    This test is not scored, as the rank depends on the S-Matrix constructed,
+    which is system-specific.
+    """
+    ann = test_matrix_rank.annotation
+    ann["data"] = matrix.matrix_rank(model)
+    ann["message"] = wrapper.fill(
+        """The rank of the S-Matrix is {}""".format(ann["data"]
+                                                    ))
+
+
+@annotate(title="Degrees of freedom of S-Matrix", type="number")
+def test_degrees_of_freedom(model):
+    """
+    Show degrees of freedom of the S-Matrix.
+
+    This test will return the degrees of freedom, i.e. "free variables" of the
+    S-Matrix.
+
+    This test is not scored, as the degrees of freedom depends on S-Matrix
+    constructed, which is system-specific.
+    """
+    ann = test_degrees_of_freedom.annotation
+    ann["data"] = matrix.degrees_of_freedom(model)
+    ann["message"] = wrapper.fill(
+        """The degrees of freedom of the S-Matrix is {}""".format(ann["data"]
+                                                                  ))

--- a/memote/support/matrix.py
+++ b/memote/support/matrix.py
@@ -74,15 +74,15 @@ def degrees_of_freedom(model):
     ------
     This specifically refers to the dimensionality of the right nullspace
     of the S matrix, as dim(Null(S)) corresponds directly to the number of
-    free variables in the system [1]. The forumla used calculates this using 
+    free variables in the system [1]. The forumla used calculates this using
     the rank-nullity theorem [2].
 
     References:
     -----------
-    .. [1] Fukuda, K. & Terlaky, T. Criss-cross methods: A fresh view on 
+    .. [1] Fukuda, K. & Terlaky, T. Criss-cross methods: A fresh view on
            pivot algorithms. Mathematical Programming 79, 369-395 (1997).
 
-    .. [2] Alama, J. The Rank+Nullity Theorem. Formalized Mathematics 15, 
+    .. [2] Alama, J. The Rank+Nullity Theorem. Formalized Mathematics 15,
            (2007).
 
     """

--- a/memote/support/matrix.py
+++ b/memote/support/matrix.py
@@ -80,10 +80,10 @@ def degrees_of_freedom(model):
     References:
     -----------
     .. [1] Fukuda, K. & Terlaky, T. Criss-cross methods: A fresh view on 
-       pivot algorithms. Mathematical Programming 79, 369-395 (1997).
+           pivot algorithms. Mathematical Programming 79, 369-395 (1997).
 
     .. [2] Alama, J. The Rank+Nullity Theorem. Formalized Mathematics 15, 
-       (2007).
+           (2007).
 
     """
     s_matrix, _, _ = con_helpers.stoichiometry_matrix(

--- a/memote/support/matrix.py
+++ b/memote/support/matrix.py
@@ -45,5 +45,49 @@ def number_independent_conservation_relations(model):
     s_matrix, _, _ = con_helpers.stoichiometry_matrix(
         model.metabolites, model.reactions
     )
-    n_matrix = con_helpers.nullspace(s_matrix)
+    ln_matrix = con_helpers.nullspace_basis(s_matrix.T)
+    return ln_matrix.shape[1]
+
+
+def number_steady_state_flux_solutions(model):
+    """Return the amount of steady-state flux solutions of this model."""
+    s_matrix, _, _ = con_helpers.stoichiometry_matrix(
+        model.metabolites, model.reactions
+    )
+    n_matrix = con_helpers.nullspace_basis(s_matrix)
     return n_matrix.shape[1]
+
+
+def matrix_rank(model):
+    """Return the rank of the model's stoichiometric matrix."""
+    s_matrix, _, _ = con_helpers.stoichiometry_matrix(
+        model.metabolites, model.reactions
+    )
+    return con_helpers.rank(s_matrix)
+
+
+def degrees_of_freedom(model):
+    """
+    Return the degrees of freedom, i.e. number of "free variables".
+
+    This specifically refers to the dimensionality of the right nullspace
+    of the S matrix, as dim(Null(S)) corresponds directly to the number of
+    free variables in the system. The forumla used calculates this using the
+    rank-nullity theorem. For more information, see the links below.
+
+    See Also:
+    ---------
+    doi:
+    10.1007/BF02614325
+
+    linear algebra review slides:
+    https://see.stanford.edu/materials/lsoeldsee263/03-lin-alg.pdf
+
+    wikipedia link for quick reference:
+    https://en.wikipedia.org/wiki/Rank%E2%80%93nullity_theorem
+
+    """
+    s_matrix, _, _ = con_helpers.stoichiometry_matrix(
+        model.metabolites, model.reactions
+    )
+    return s_matrix.shape[1] - matrix_rank(model)

--- a/memote/support/matrix.py
+++ b/memote/support/matrix.py
@@ -27,9 +27,7 @@ LOGGER = logging.getLogger(__name__)
 
 
 def absolute_extreme_coefficient_ratio(model):
-    """
-    Return the absolute maximum and absolute non-zero minimum coefficients.
-    """
+    """Return the absolute max and absolute non-zero min coefficients."""
     # S-Matrix with absolute values:
     s_matrix, _, _ = con_helpers.stoichiometry_matrix(
         model.metabolites, model.reactions
@@ -43,9 +41,7 @@ def absolute_extreme_coefficient_ratio(model):
 
 
 def number_independent_conservation_relations(model):
-    """
-    Return the amount of conserved metabolic pools.
-    """
+    """ Return the amount of conserved metabolic pools."""
     s_matrix, _, _ = con_helpers.stoichiometry_matrix(
         model.metabolites, model.reactions
     )

--- a/memote/support/matrix.py
+++ b/memote/support/matrix.py
@@ -32,10 +32,10 @@ def absolute_extreme_coefficient_ratio(model):
     s_matrix, _, _ = con_helpers.stoichiometry_matrix(
         model.metabolites, model.reactions
     )
-    abs_matrix, _, _ = abs(s_matrix)
+    abs_matrix = np.absolute(s_matrix)
 
-    absolute_max_coef = abs_matrix.max()
-    absolute_non_zero_min_coef = np.min(abs_matrix[np.nonzero(abs_matrix)])
+    absolute_max_coef = np.amax(abs_matrix)
+    absolute_non_zero_min_coef = abs_matrix[abs_matrix > 0].min()
 
     return (absolute_max_coef, absolute_non_zero_min_coef)
 

--- a/memote/support/matrix.py
+++ b/memote/support/matrix.py
@@ -1,0 +1,53 @@
+# -*- coding: utf-8 -*-
+
+# Copyright 2017 Novo Nordisk Foundation Center for Biosustainability,
+# Technical University of Denmark.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Supporting functions checking the matrix condition of the model object."""
+
+from __future__ import absolute_import
+
+import logging
+import numpy as np
+import memote.support.consistency_helpers as con_helpers
+
+LOGGER = logging.getLogger(__name__)
+
+
+def absolute_extreme_coefficient_ratio(model):
+    """
+    Return the absolute maximum and absolute non-zero minimum coefficients.
+    """
+    # S-Matrix with absolute values:
+    s_matrix, _, _ = con_helpers.stoichiometry_matrix(
+        model.metabolites, model.reactions
+    )
+    abs_matrix, _, _ = abs(s_matrix)
+
+    absolute_max_coef = abs_matrix.max()
+    absolute_non_zero_min_coef = np.min(abs_matrix[np.nonzero(abs_matrix)])
+
+    return (absolute_max_coef, absolute_non_zero_min_coef)
+
+
+def number_independent_conservation_relations(model):
+    """
+    Return the amount of conserved metabolic pools.
+    """
+    s_matrix, _, _ = con_helpers.stoichiometry_matrix(
+        model.metabolites, model.reactions
+    )
+    n_matrix = con_helpers.nullspace(s_matrix)
+    return n_matrix.shape[1]

--- a/memote/support/matrix.py
+++ b/memote/support/matrix.py
@@ -41,7 +41,7 @@ def absolute_extreme_coefficient_ratio(model):
 
 
 def number_independent_conservation_relations(model):
-    """ Return the amount of conserved metabolic pools."""
+    """Return the amount of conserved metabolic pools."""
     s_matrix, _, _ = con_helpers.stoichiometry_matrix(
         model.metabolites, model.reactions
     )

--- a/memote/support/matrix.py
+++ b/memote/support/matrix.py
@@ -70,21 +70,20 @@ def degrees_of_freedom(model):
     """
     Return the degrees of freedom, i.e. number of "free variables".
 
+    Notes:
+    ------
     This specifically refers to the dimensionality of the right nullspace
     of the S matrix, as dim(Null(S)) corresponds directly to the number of
-    free variables in the system. The forumla used calculates this using the
-    rank-nullity theorem. For more information, see the links below.
+    free variables in the system [1]. The forumla used calculates this using 
+    the rank-nullity theorem [2].
 
-    See Also:
-    ---------
-    doi:
-    10.1007/BF02614325
+    References:
+    -----------
+    .. [1] Fukuda, K. & Terlaky, T. Criss-cross methods: A fresh view on 
+       pivot algorithms. Mathematical Programming 79, 369-395 (1997).
 
-    linear algebra review slides:
-    https://see.stanford.edu/materials/lsoeldsee263/03-lin-alg.pdf
-
-    wikipedia link for quick reference:
-    https://en.wikipedia.org/wiki/Rank%E2%80%93nullity_theorem
+    .. [2] Alama, J. The Rank+Nullity Theorem. Formalized Mathematics 15, 
+       (2007).
 
     """
     s_matrix, _, _ = con_helpers.stoichiometry_matrix(


### PR DESCRIPTION
* [x] fix #233 
* [x] description of feature/fix
* [x] tests added/passed
* [x] add an entry to the [next release](../HISTORY.rst)

### Summary

These changes should address the concerns in issue #233 except for adding in/testing for a list of parallel routes. Additionally, the number of independent conserved metabolite relations, i.e. conservation pools, is added but the actual pools themselves are not shown as the left-nullspace of large network reconstructions is extremely difficult to interpret.
