### PR TITLE
fix: comment `run_apidoc`

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -46,13 +46,13 @@ clean-test: ## remove test and coverage artifacts
 	rm -fr htmlcov/
 
 lint: ## check style with flake8
-	flake8 memote tests
+	flake8 memote
 
 test: ## run tests quickly with the default Python
-	pytest tests/
+	pytest -v
 
 test-all: ## run tests on every Python version with tox
-	tox
+	detox
 
 coverage: ## check code coverage quickly with the default Python
 		coverage run --source memote `which py.test`

--- a/docs/Makefile
+++ b/docs/Makefile
@@ -15,7 +15,7 @@ endif
 # Internal variables.
 PAPEROPT_a4     = -D latex_paper_size=a4
 PAPEROPT_letter = -D latex_paper_size=letter
-ALLSPHINXOPTS   = -d $(BUILDDIR)/doctrees $(PAPEROPT_$(PAPER)) $(SPHINXOPTS) .
+ALLSPHINXOPTS   = $(PAPEROPT_$(PAPER)) $(SPHINXOPTS) .
 # the i18n builder cannot share the environment and doctrees with the others
 I18NSPHINXOPTS  = $(PAPEROPT_$(PAPER)) $(SPHINXOPTS) .
 

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -285,13 +285,13 @@ texinfo_documents = [
 # -- sphinx-apidoc calling ---------------------------------------------
 
 
-def run_apidoc(_):
-    from sphinx.apidoc import main
+# def run_apidoc(_):
+#     from sphinx.apidoc import main
 
-    mod_path = join(PROJECT_ROOT, 'memote')
-    auto_path = join(dirname(__file__), '_autogen')
-    main([None, '-f', '-d', '2', '-e', '-o', auto_path, mod_path])
+    # mod_path = join(PROJECT_ROOT, 'memote')
+    # auto_path = join(dirname(__file__), '_autogen')
+    # main([None, '-f', '-d', '2', '-e', '-o', auto_path, mod_path])
 
 
-def setup(app):
-    app.connect('builder-inited', run_apidoc)
+# def setup(app):
+#     app.connect('builder-inited', run_apidoc)


### PR DESCRIPTION
* The widely spread recipe for building apidoc automatically seems to
  mess up Sphinx 1.7, however, it seems to just work without it? Leaving
  it in commented for now.
* Make slight adjustments to the Makefiles.

* [ ] fix #x (issue number)
* [ ] description of feature/fix
* [ ] tests added/passed
* [ ] add an entry to the [next release](../HISTORY.rst)
