### PR TITLE
Fix/typeerrors memote report snapshot

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -79,6 +79,8 @@ Next Release
   and `test_for_helpers.py`
 * Add matrix conditioning functions in ``matrix.py`` which are used for 
   model stoichiometric matrix testing in ``test_matrix.py``
+* Add missing rank and nullspace_basis functions in ``consistency_helpers.py``
+* Fix issue with improper string/dict formatting in ``test_biomass.py`` tests
 
 
 0.5.0 (2018-01-16)

--- a/memote/suite/tests/test_biomass.py
+++ b/memote/suite/tests/test_biomass.py
@@ -277,14 +277,15 @@ def test_direct_metabolites_in_biomass(model, reaction_id):
         m.id for m in biomass.find_direct_metabolites(model, reaction)]
     ann["metric"][reaction_id] = len(ann["data"][reaction_id]) / \
         len(biomass.find_biomass_precursors(model, reaction))
-    ann["message"][reaction_id] = wrapper.fill(
+    msg = wrapper.fill(
         """{} contains a total of {} direct metabolites ({:.2%}). Specifically
         these are: {}.""".format(reaction_id,
                                  len(ann["data"][reaction_id]),
-                                 ann["metric"],
+                                 ann["metric"][reaction_id],
                                  ann["data"][reaction_id]
                                  )
     )
+    ann["message"][reaction_id] = msg
     assert ann["metric"][reaction_id] < 0.5, ann["message"][reaction_id]
 
 
@@ -322,13 +323,14 @@ def test_essential_precursors_not_in_biomass(model, reaction_id):
         )]
     ann["metric"][reaction_id] = len(ann["data"][reaction_id]) / \
         len(biomass.find_biomass_precursors(model, reaction))
-    ann["message"][reaction_id] = wrapper.fill(
+    msg = wrapper.fill(
         """{} lacks a total of {} essential metabolites
         ({:.2%} of all biomass precursors). Specifically
         these are: {}.""".format(reaction_id,
                                  len(ann["data"][reaction_id]),
-                                 ann["metric"],
+                                 ann["metric"][reaction_id],
                                  ann["data"][reaction_id]
                                  )
     )
+    ann["message"][reaction_id] = msg
     assert len(ann["data"][reaction_id]) == 0, ann["message"][reaction_id]

--- a/memote/suite/tests/test_biomass.py
+++ b/memote/suite/tests/test_biomass.py
@@ -277,7 +277,7 @@ def test_direct_metabolites_in_biomass(model, reaction_id):
         m.id for m in biomass.find_direct_metabolites(model, reaction)]
     ann["metric"][reaction_id] = len(ann["data"][reaction_id]) / \
         len(biomass.find_biomass_precursors(model, reaction))
-    msg = wrapper.fill(
+    ann["message"][reaction_id] = wrapper.fill(
         """{} contains a total of {} direct metabolites ({:.2%}). Specifically
         these are: {}.""".format(reaction_id,
                                  len(ann["data"][reaction_id]),
@@ -285,7 +285,6 @@ def test_direct_metabolites_in_biomass(model, reaction_id):
                                  ann["data"][reaction_id]
                                  )
     )
-    ann["message"][reaction_id] = msg
     assert ann["metric"][reaction_id] < 0.5, ann["message"][reaction_id]
 
 
@@ -323,7 +322,7 @@ def test_essential_precursors_not_in_biomass(model, reaction_id):
         )]
     ann["metric"][reaction_id] = len(ann["data"][reaction_id]) / \
         len(biomass.find_biomass_precursors(model, reaction))
-    msg = wrapper.fill(
+    ann["message"][reaction_id] = wrapper.fill(
         """{} lacks a total of {} essential metabolites
         ({:.2%} of all biomass precursors). Specifically
         these are: {}.""".format(reaction_id,
@@ -332,5 +331,4 @@ def test_essential_precursors_not_in_biomass(model, reaction_id):
                                  ann["data"][reaction_id]
                                  )
     )
-    ann["message"][reaction_id] = msg
     assert len(ann["data"][reaction_id]) == 0, ann["message"][reaction_id]

--- a/memote/suite/tests/test_biomass.py
+++ b/memote/suite/tests/test_biomass.py
@@ -134,7 +134,7 @@ def test_biomass_open_production(model, reaction_id):
 
 @pytest.mark.parametrize("reaction_id", BIOMASS_IDS)
 @annotate(title="Blocked Biomass Precursors At Default State", type="count",
-          data=dict(), message=dict())
+          data=dict(), metric=dict(), message=dict())
 def test_biomass_precursors_default_production(read_only_model, reaction_id):
     """
     Expect production of all biomass precursors in default medium.
@@ -168,7 +168,7 @@ def test_biomass_precursors_default_production(read_only_model, reaction_id):
 
 @pytest.mark.parametrize("reaction_id", BIOMASS_IDS)
 @annotate(title="Blocked Biomass Precursors In Complete Medium", type="count",
-          data=dict(), message=dict())
+          data=dict(), metric=dict(), message=dict())
 def test_biomass_precursors_open_production(model, reaction_id):
     """
     Expect precursor production in complete medium.

--- a/memote/support/consistency_helpers.py
+++ b/memote/support/consistency_helpers.py
@@ -96,7 +96,8 @@ def stoichiometry_matrix(metabolites, reactions):
 
 
 def rank(A, atol=1e-13, rtol=0):
-    """Estimate the rank (i.e. the dimension of the column space) of a matrix.
+    """
+    Estimate the rank, i.e. the dimension of the column space, of a matrix.
 
     The algorithm used by this function is based on the singular value
     decomposition of `A`.
@@ -130,7 +131,6 @@ def rank(A, atol=1e-13, rtol=0):
         provide the option of the absolute tolerance.
 
     """
-
     A = np.atleast_2d(A)
     s = svd(A, compute_uv=False)
     tol = max(atol, rtol * s[0])
@@ -155,7 +155,8 @@ def nullspace(matrix, atol=1e-13, rtol=0.0):
 
 
 def nullspace_basis(A, atol=1e-13, rtol=0):
-    """Compute an approximate basis for the nullspace of A.
+    """
+    Compute an approximate basis for the nullspace of A.
 
     The algorithm used by this function is based on the singular value
     decomposition of `A`.
@@ -190,8 +191,8 @@ def nullspace_basis(A, atol=1e-13, rtol=0):
     -----
     Adapted from:
     https://scipy.github.io/old-wiki/pages/Cookbook/RankNullspace.html
-    """
 
+    """
     A = np.atleast_2d(A)
     u, s, vh = svd(A)
     tol = max(atol, rtol * s[0])

--- a/memote/support/consistency_helpers.py
+++ b/memote/support/consistency_helpers.py
@@ -138,22 +138,6 @@ def rank(A, atol=1e-13, rtol=0):
     return rank
 
 
-def nullspace(matrix, atol=1e-13, rtol=0.0):
-    """
-    Compute the nullspace of a 2D `numpy.array`.
-
-    Notes
-    -----
-    Adapted from:
-    https://scipy.github.io/old-wiki/pages/Cookbook/RankNullspace.html
-
-    """
-    matrix = np.atleast_2d(matrix)
-    _, s, vh = svd(matrix)
-    tol = max(atol, rtol * s[0])
-    return np.compress(s < tol, vh, axis=0).T
-
-
 def nullspace_basis(A, atol=1e-13, rtol=0):
     """
     Compute an approximate basis for the nullspace of A.

--- a/memote/support/consistency_helpers.py
+++ b/memote/support/consistency_helpers.py
@@ -95,7 +95,7 @@ def stoichiometry_matrix(metabolites, reactions):
     return matrix, met_index, rxn_index
 
 
-def rank(A, atol=1e-13, rtol=0):
+def rank(stoichiometry_matrix, atol=1e-13, rtol=0):
     """
     Estimate the rank, i.e. the dimension of the column space, of a matrix.
 
@@ -104,9 +104,9 @@ def rank(A, atol=1e-13, rtol=0):
 
     Parameters
     ----------
-    A : ndarray
-        A should be at most 2-D.  A 1-D array with length n will be treated
-        as a 2-D with shape (1, n)
+    stoichiometry_matrix : ndarray
+        stoichiometry_matrix should be at most 2-D.  A 1-D array with length n
+        will be treated as a 2-D with shape (1, n)
     atol : float
         The absolute tolerance for a zero singular value.  Singular values
         smaller than `atol` are considered to be zero.

--- a/memote/support/consistency_helpers.py
+++ b/memote/support/consistency_helpers.py
@@ -95,6 +95,49 @@ def stoichiometry_matrix(metabolites, reactions):
     return matrix, met_index, rxn_index
 
 
+def rank(A, atol=1e-13, rtol=0):
+    """Estimate the rank (i.e. the dimension of the column space) of a matrix.
+
+    The algorithm used by this function is based on the singular value
+    decomposition of `A`.
+
+    Parameters
+    ----------
+    A : ndarray
+        A should be at most 2-D.  A 1-D array with length n will be treated
+        as a 2-D with shape (1, n)
+    atol : float
+        The absolute tolerance for a zero singular value.  Singular values
+        smaller than `atol` are considered to be zero.
+    rtol : float
+        The relative tolerance.  Singular values less than rtol*smax are
+        considered to be zero, where smax is the largest singular value.
+
+    If both `atol` and `rtol` are positive, the combined tolerance is the
+    maximum of the two; that is::
+        tol = max(atol, rtol * smax)
+    Singular values smaller than `tol` are considered to be zero.
+
+    Returns
+    -------
+    rank : int
+        The estimated rank of the matrix.
+
+    See Also
+    --------
+    numpy.linalg.matrix_rank
+        matrix_rank is basically the same as this function, but it does not
+        provide the option of the absolute tolerance.
+
+    """
+
+    A = np.atleast_2d(A)
+    s = svd(A, compute_uv=False)
+    tol = max(atol, rtol * s[0])
+    rank = int((s >= tol).sum())
+    return rank
+
+
 def nullspace(matrix, atol=1e-13, rtol=0.0):
     """
     Compute the nullspace of a 2D `numpy.array`.
@@ -109,6 +152,52 @@ def nullspace(matrix, atol=1e-13, rtol=0.0):
     _, s, vh = svd(matrix)
     tol = max(atol, rtol * s[0])
     return np.compress(s < tol, vh, axis=0).T
+
+
+def nullspace_basis(A, atol=1e-13, rtol=0):
+    """Compute an approximate basis for the nullspace of A.
+
+    The algorithm used by this function is based on the singular value
+    decomposition of `A`.
+
+    Parameters
+    ----------
+    A : ndarray
+        A should be at most 2-D.  A 1-D array with length k will be treated
+        as a 2-D with shape (1, k)
+    atol : float
+        The absolute tolerance for a zero singular value.  Singular values
+        smaller than `atol` are considered to be zero.
+    rtol : float
+        The relative tolerance.  Singular values less than rtol*smax are
+        considered to be zero, where smax is the largest singular value.
+
+    If both `atol` and `rtol` are positive, the combined tolerance is the
+    maximum of the two; that is::
+        tol = max(atol, rtol * smax)
+    Singular values smaller than `tol` are considered to be zero.
+
+    Returns
+    -------
+    ns : ndarray
+        If `A` is an array with shape (m, k), then `ns` will be an array
+        with shape (k, n), where n is the estimated dimension of the
+        nullspace of `A`.  The columns of `ns` are a basis for the
+        nullspace; each element in numpy.dot(A, ns) will be approximately
+        zero.
+
+    Notes
+    -----
+    Adapted from:
+    https://scipy.github.io/old-wiki/pages/Cookbook/RankNullspace.html
+    """
+
+    A = np.atleast_2d(A)
+    u, s, vh = svd(A)
+    tol = max(atol, rtol * s[0])
+    nnz = (s >= tol).sum()
+    ns = vh[nnz:].conj().T
+    return ns
 
 
 def get_interface(model):

--- a/memote/support/consistency_helpers.py
+++ b/memote/support/consistency_helpers.py
@@ -166,7 +166,7 @@ def nullspace(stoichiometry_matrix, atol=1e-13, rtol=0):
     -------
     ns : ndarray
         If `stoichiometry_matrix` is an array with shape (m, k), then `ns` will
-        be an array with shape (k, n), where n is the estimated dimension of 
+        be an array with shape (k, n), where n is the estimated dimension of
         the nullspace of `A`.  The columns of `ns` are a basis for the
         nullspace; each element in numpy.dot(A, ns) will be approximately
         zero.

--- a/memote/support/consistency_helpers.py
+++ b/memote/support/consistency_helpers.py
@@ -100,7 +100,7 @@ def rank(stoichiometry_matrix, atol=1e-13, rtol=0):
     Estimate the rank, i.e. the dimension of the column space, of a matrix.
 
     The algorithm used by this function is based on the singular value
-    decomposition of `A`.
+    decomposition of `stoichiometry_matrix`.
 
     Parameters
     ----------
@@ -140,10 +140,10 @@ def rank(stoichiometry_matrix, atol=1e-13, rtol=0):
 
 def nullspace(stoichiometry_matrix, atol=1e-13, rtol=0):
     """
-    Compute an approximate basis for the nullspace of A.
+    Compute an approximate basis for the nullspace of a matrix.
 
     The algorithm used by this function is based on the singular value
-    decomposition of `A`.
+    decomposition of `stoichiometry_matrix`.
 
     Parameters
     ----------

--- a/memote/support/consistency_helpers.py
+++ b/memote/support/consistency_helpers.py
@@ -17,7 +17,7 @@
 
 """Helper functions for stoichiometric consistency checks."""
 
-from __future__ import absolute_import
+from __future__ import absolute_import, division
 
 import logging
 from collections import defaultdict

--- a/memote/support/consistency_helpers.py
+++ b/memote/support/consistency_helpers.py
@@ -131,14 +131,14 @@ def rank(stoichiometry_matrix, atol=1e-13, rtol=0):
         provide the option of the absolute tolerance.
 
     """
-    A = np.atleast_2d(A)
-    s = svd(A, compute_uv=False)
+    stoichiometry_matrix = np.atleast_2d(stoichiometry_matrix)
+    s = svd(stoichiometry_matrix, compute_uv=False)
     tol = max(atol, rtol * s[0])
     rank = int((s >= tol).sum())
     return rank
 
 
-def nullspace(A, atol=1e-13, rtol=0):
+def nullspace(stoichiometry_matrix, atol=1e-13, rtol=0):
     """
     Compute an approximate basis for the nullspace of A.
 
@@ -147,9 +147,9 @@ def nullspace(A, atol=1e-13, rtol=0):
 
     Parameters
     ----------
-    A : ndarray
-        A should be at most 2-D.  A 1-D array with length k will be treated
-        as a 2-D with shape (1, k)
+    stoichiometry_matrix : ndarray
+        stoichiometry_matrix should be at most 2-D.  A 1-D array with length k
+        will be treated as a 2-D with shape (1, k)
     atol : float
         The absolute tolerance for a zero singular value.  Singular values
         smaller than `atol` are considered to be zero.
@@ -165,9 +165,9 @@ def nullspace(A, atol=1e-13, rtol=0):
     Returns
     -------
     ns : ndarray
-        If `A` is an array with shape (m, k), then `ns` will be an array
-        with shape (k, n), where n is the estimated dimension of the
-        nullspace of `A`.  The columns of `ns` are a basis for the
+        If `stoichiometry_matrix` is an array with shape (m, k), then `ns` will
+        be an array with shape (k, n), where n is the estimated dimension of 
+        the nullspace of `A`.  The columns of `ns` are a basis for the
         nullspace; each element in numpy.dot(A, ns) will be approximately
         zero.
 
@@ -177,8 +177,8 @@ def nullspace(A, atol=1e-13, rtol=0):
     https://scipy.github.io/old-wiki/pages/Cookbook/RankNullspace.html
 
     """
-    A = np.atleast_2d(A)
-    u, s, vh = svd(A)
+    stoichiometry_matrix = np.atleast_2d(stoichiometry_matrix)
+    u, s, vh = svd(stoichiometry_matrix)
     tol = max(atol, rtol * s[0])
     nnz = (s >= tol).sum()
     ns = vh[nnz:].conj().T

--- a/memote/support/consistency_helpers.py
+++ b/memote/support/consistency_helpers.py
@@ -138,7 +138,21 @@ def rank(stoichiometry_matrix, atol=1e-13, rtol=0):
     return rank
 
 
-def nullspace(stoichiometry_matrix, atol=1e-13, rtol=0):
+def nullspace(matrix, atol=1e-13, rtol=0.0):
+    """
+    Compute the nullspace of a 2D `numpy.array`.
+    Notes
+    -----
+    Adapted from:
+    https://scipy.github.io/old-wiki/pages/Cookbook/RankNullspace.html
+    """
+    matrix = np.atleast_2d(matrix)
+    _, sigma, vh = svd(matrix)
+    tol = max(atol, rtol * sigma[0])
+    return np.compress(sigma < tol, vh, axis=0).T
+
+
+def nullspace_basis(stoichiometry_matrix, atol=1e-13, rtol=0):
     """
     Compute an approximate basis for the nullspace of a matrix.
 

--- a/memote/support/consistency_helpers.py
+++ b/memote/support/consistency_helpers.py
@@ -138,7 +138,7 @@ def rank(A, atol=1e-13, rtol=0):
     return rank
 
 
-def nullspace_basis(A, atol=1e-13, rtol=0):
+def nullspace(A, atol=1e-13, rtol=0):
     """
     Compute an approximate basis for the nullspace of A.
 

--- a/memote/support/consistency_helpers.py
+++ b/memote/support/consistency_helpers.py
@@ -141,10 +141,12 @@ def rank(stoichiometry_matrix, atol=1e-13, rtol=0):
 def nullspace(matrix, atol=1e-13, rtol=0.0):
     """
     Compute the nullspace of a 2D `numpy.array`.
+
     Notes
     -----
     Adapted from:
     https://scipy.github.io/old-wiki/pages/Cookbook/RankNullspace.html
+
     """
     matrix = np.atleast_2d(matrix)
     _, sigma, vh = svd(matrix)

--- a/memote/support/matrix.py
+++ b/memote/support/matrix.py
@@ -45,7 +45,7 @@ def number_independent_conservation_relations(model):
     s_matrix, _, _ = con_helpers.stoichiometry_matrix(
         model.metabolites, model.reactions
     )
-    ln_matrix = con_helpers.nullspace_basis(s_matrix.T)
+    ln_matrix = con_helpers.nullspace(s_matrix.T)
     return ln_matrix.shape[1]
 
 
@@ -54,7 +54,7 @@ def number_steady_state_flux_solutions(model):
     s_matrix, _, _ = con_helpers.stoichiometry_matrix(
         model.metabolites, model.reactions
     )
-    n_matrix = con_helpers.nullspace_basis(s_matrix)
+    n_matrix = con_helpers.nullspace(s_matrix)
     return n_matrix.shape[1]
 
 

--- a/memote/support/matrix.py
+++ b/memote/support/matrix.py
@@ -45,7 +45,7 @@ def number_independent_conservation_relations(model):
     s_matrix, _, _ = con_helpers.stoichiometry_matrix(
         model.metabolites, model.reactions
     )
-    ln_matrix = con_helpers.nullspace(s_matrix.T)
+    ln_matrix = con_helpers.nullspace_basis(s_matrix.T)
     return ln_matrix.shape[1]
 
 
@@ -54,7 +54,7 @@ def number_steady_state_flux_solutions(model):
     s_matrix, _, _ = con_helpers.stoichiometry_matrix(
         model.metabolites, model.reactions
     )
-    n_matrix = con_helpers.nullspace(s_matrix)
+    n_matrix = con_helpers.nullspace_basis(s_matrix)
     return n_matrix.shape[1]
 
 


### PR DESCRIPTION
* [x] fix #349 
* [x] description of feature/fix
* [x] tests added/passed
* [x] add an entry to the [next release](../HISTORY.rst)


### readme

**Purpose**: To find & fix 4 `TypeError` exceptions that result when running memote report snapshot on iJO1366.xml

**Description**: Currently, 2 functions in `memote/suite/tests/test_biomass.py` fail with `TypeError` exceptions. The specific reactions in question which gave these errors were `BIOMASS_Ec_iJO1366_core_53p95M` and `BIOMASS_Ec_iJO1366_WT_53p95M`. The message displayed by all 4 `TypeError` exceptions is:

```E   TypeError: unsupported format string passed to dict.__format__```

**Functions causing errors**:


* test_direct_metabolites_in_biomass: `memote/suite/tests/test_biomass.py`
    * **(base traceback function)**


* test_essential_precursors_not_in_biomass: `memote/suite/tests/test_biomass.py`
    * **(base traceback function)**


**VIEW SUMMARY OF ISSUES AT END FOR DESCRIPTION OF BUGS AND STEPS TAKEN TO FIX THEM***

### Test 1: Mockup to recreate errors


```python
data_list = ["atp", "h2o", "co2"]

s = "hello {}".format(data_list)
s
```




    "hello ['atp', 'h2o', 'co2']"




```python
data_list = []

s = "hello {}".format(data_list)
s
```




    'hello []'



**Summary**: Simply formatting a list into a string does not pose any issues with unsupported string formats. This suggests the issue comes from the dictionaries being used instead.

### Test 2: Mockup with iJO1366 to recreate errors


```python
import memote
import cobra
from __future__ import absolute_import

import logging

import pytest
import numpy as np

import memote.support.biomass as biomass
import memote.support.helpers as helpers
from memote.utils import annotate, truncate, get_ids, wrapper

```


```python
ijo1366 = cobra.io.read_sbml_model("/Users/sidcha/Documents/projects/testing_memote/iJO1366.xml")
ijo1366
```





        <table>
            <tr>
                <td><strong>Name</strong></td>
                <td>iJO1366</td>
            </tr><tr>
                <td><strong>Memory address</strong></td>
                <td>0x011270f630</td>
            </tr><tr>
                <td><strong>Number of metabolites</strong></td>
                <td>1805</td>
            </tr><tr>
                <td><strong>Number of reactions</strong></td>
                <td>2583</td>
            </tr><tr>
                <td><strong>Objective expression</strong></td>
                <td>-1.0*BIOMASS_Ec_iJO1366_core_53p95M_reverse_5c8b1 + 1.0*BIOMASS_Ec_iJO1366_core_53p95M</td>
            </tr><tr>
                <td><strong>Compartments</strong></td>
                <td>cytosol, extracellular space, periplasm</td>
            </tr>
          </table>




```python
### Actual function below
```


```python
@annotate(title="Ratio of Direct Metabolites in Biomass Reaction",
          type="percent", data=dict(), message=dict(), metric=dict())
def test_direct_metabolites_in_biomass(model, reaction_id):
    """
    Expect the biomass reactions to contain atp and adp.

    Some biomass precursors are taken from the media and directly consumed by
    the biomass reaction. It might not be a problem for ions or
    metabolites for which the organism in question is auxotrophic. However,
    too many of these metabolites may be artifacts of automated gap-filling
    procedures. Many gap-filling algorithms attempt to minimise the number of
    added reactions. This can lead to many biomass precursors being
    "direct metabolites".

    This test reports the ratio of direct metabolites to the total amount of
    precursors to a given biomass reaction. It specifically looks for
    metabolites that are only in either exchange, transport or biomass
    reactions. Bear in mind that this may lead to false positives in heavily
    compartimentalized models.

    To pass this test, the ratio of direct metabolites should be less than 50%
    of all biomass precursors. This is an arbitrary threshold but it takes
    into account that while certain ions do not serve a relevant metabolic
    function, it may still be important to include them in the biomass
    reaction to account for the impact of their uptake energy costs.

    This threshold is subject to change in the future.
    """
    # TODO: Update the threshold as soon as we have an overview of the average!
    ann = test_direct_metabolites_in_biomass.annotation
    reaction = model.reactions.get_by_id(reaction_id)
    ann["data"][reaction_id] = [
        m.id for m in biomass.find_direct_metabolites(model, reaction)]
    ann["metric"][reaction_id] = len(ann["data"][reaction_id]) / \
        len(biomass.find_biomass_precursors(model, reaction))
    ann["message"][reaction_id] = wrapper.fill(
        """{} contains a total of {} direct metabolites ({:.2%}). Specifically
        these are: {}.""".format(reaction_id,
                                 len(ann["data"][reaction_id]),
                                 ann["metric"],
                                 ann["data"][reaction_id]
                                 )
    )
    assert ann["metric"][reaction_id] < 0.5, ann["message"][reaction_id]

```


```python
test_direct_metabolites_in_biomass(ijo1366, ijo1366.reactions.BIOMASS_Ec_iJO1366_core_53p95M.id)
```


    ---------------------------------------------------------------------------

    TypeError                                 Traceback (most recent call last)

    <ipython-input-7-6984526fedbc> in <module>()
    ----> 1 test_direct_metabolites_in_biomass(ijo1366, ijo1366.reactions.BIOMASS_Ec_iJO1366_core_53p95M.id)
    

    <ipython-input-6-b79ca9825d90> in test_direct_metabolites_in_biomass(model, reaction_id)
         38                                  len(ann["data"][reaction_id]),
         39                                  ann["metric"],
    ---> 40                                  ann["data"][reaction_id]
         41                                  )
         42     )


    TypeError: unsupported format string passed to dict.__format__


**Summary**: Error successfully recreated. Alongside test 1, it seems quite likely the dictionaries the root cause

### Test 3: Mockup with dictionaries


```python
data_list = ['ni2_c', 'k_c', 'kdo2lipid4_e', 'mn2_c', 'cobalt2_c', 'ca2_c', 'mg2_c', 'zn2_c', 'cl_c']

s = "hello {}".format(data_list)
s
```




    "hello ['ni2_c', 'k_c', 'kdo2lipid4_e', 'mn2_c', 'cobalt2_c', 'ca2_c', 'mg2_c', 'zn2_c', 'cl_c']"




```python
a = dict()
a[1] = "hello"
```


```python
a.__format__(['zn2_c', 'cl_c', 'ni2_c', 'k_c', 'kdo2lipid4_e', 'mn2_c', 'cobalt2_c', 'ca2_c', 'mg2_c'])
```


    ---------------------------------------------------------------------------

    TypeError                                 Traceback (most recent call last)

    <ipython-input-10-e46240452be9> in <module>()
    ----> 1 a.__format__(['zn2_c', 'cl_c', 'ni2_c', 'k_c', 'kdo2lipid4_e', 'mn2_c', 'cobalt2_c', 'ca2_c', 'mg2_c'])
    

    TypeError: __format__() argument 1 must be str, not list



```python
", ".join(['zn2_c', 'cl_c', 'ni2_c', 'k_c', 'kdo2lipid4_e', 'mn2_c', 'cobalt2_c', 'ca2_c', 'mg2_c'])
```




    'zn2_c, cl_c, ni2_c, k_c, kdo2lipid4_e, mn2_c, cobalt2_c, ca2_c, mg2_c'




```python
a.__format__('zn2_c, cl_c, ni2_c, k_c, kdo2lipid4_e, mn2_c, cobalt2_c, ca2_c, mg2_c')
```


    ---------------------------------------------------------------------------

    TypeError                                 Traceback (most recent call last)

    <ipython-input-12-35347de5ec3e> in <module>()
    ----> 1 a.__format__('zn2_c, cl_c, ni2_c, k_c, kdo2lipid4_e, mn2_c, cobalt2_c, ca2_c, mg2_c')
    

    TypeError: unsupported format string passed to dict.__format__



```python
a.__format__("")
```




    "{1: 'hello'}"



**Summary**: From this mockup and the results of previous tests, it seems like `.format` function seems to be calling on the dictionary value `ann["message"][reaction_id]` intstead of the string value it should be set to.

### Test 4: Testing solution


```python
@annotate(title="Ratio of Direct Metabolites in Biomass Reaction",
          type="percent", data=dict(), message=dict(), metric=dict())
def test_direct_metabolites_in_biomass(model, reaction_id):
    """
    Expect the biomass reactions to contain atp and adp.

    Some biomass precursors are taken from the media and directly consumed by
    the biomass reaction. It might not be a problem for ions or
    metabolites for which the organism in question is auxotrophic. However,
    too many of these metabolites may be artifacts of automated gap-filling
    procedures. Many gap-filling algorithms attempt to minimise the number of
    added reactions. This can lead to many biomass precursors being
    "direct metabolites".

    This test reports the ratio of direct metabolites to the total amount of
    precursors to a given biomass reaction. It specifically looks for
    metabolites that are only in either exchange, transport or biomass
    reactions. Bear in mind that this may lead to false positives in heavily
    compartimentalized models.

    To pass this test, the ratio of direct metabolites should be less than 50%
    of all biomass precursors. This is an arbitrary threshold but it takes
    into account that while certain ions do not serve a relevant metabolic
    function, it may still be important to include them in the biomass
    reaction to account for the impact of their uptake energy costs.

    This threshold is subject to change in the future.
    """
    # TODO: Update the threshold as soon as we have an overview of the average!
    ann = test_direct_metabolites_in_biomass.annotation
    reaction = model.reactions.get_by_id(reaction_id)
    ann["data"][reaction_id] = [
        m.id for m in biomass.find_direct_metabolites(model, reaction)]
    ### TEST EDITS:
    print("raw: ", ann["data"][reaction_id])
    print("type: ", type(ann["data"][reaction_id]))
    ann["metric"][reaction_id] = len(ann["data"][reaction_id]) / \
        len(biomass.find_biomass_precursors(model, reaction))
    print("metric: ", ann["metric"])
    ### TEST FIXES:
    msg ="""{} contains a total of {} direct metabolites ({:.2%}). Specifically
        these are {}.""".format(reaction_id,
                                len(ann["data"][reaction_id]),
                                ann["metric"][reaction_id],
                                ann["data"][reaction_id]
                               )
    print(msg)
    ann["message"][reaction_id] = wrapper.fill(msg)
    assert ann["metric"][reaction_id] < 0.5, ann["message"][reaction_id]

```


```python
test_direct_metabolites_in_biomass(ijo1366, ijo1366.reactions.BIOMASS_Ec_iJO1366_core_53p95M.id)
```

    raw:  ['zn2_c', 'cl_c', 'ni2_c', 'k_c', 'kdo2lipid4_e', 'mn2_c', 'cobalt2_c', 'ca2_c', 'mg2_c']
    type:  <class 'list'>
    metric:  {'BIOMASS_Ec_iJO1366_core_53p95M': 0.13636363636363635}
    BIOMASS_Ec_iJO1366_core_53p95M contains a total of 9 direct metabolites (13.64%). Specifically
            these are ['zn2_c', 'cl_c', 'ni2_c', 'k_c', 'kdo2lipid4_e', 'mn2_c', 'cobalt2_c', 'ca2_c', 'mg2_c'].


### Summary of Issues:

Improper referencing from the `.format` function seems to have been the cause for the issues. Instead of using the string formatting function, the dictionary formatting function seems to have been called instead. Explicitly generating a string variable and formatting it first seems to have solved the issue.
