### PR TITLE
Fix/report bugs

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -5,6 +5,15 @@ Next Release
 ------------
 * Test summary only displays extended narrative summmary describing test,
   and not one-line summary describing expected function behavior/output
+* Fix the following bugs:
+    - Fix type annotation on the test for Biomass Production in Complete Medium
+    - Fix TypeError when running memote new which was associated with unicode
+      and string formatting in py2.7
+    - Sort existing test results from misc into the respective categories
+      (by editing test_config.yml)
+    - Move Matrix statistics category to unscored side into their own card
+    - Add a tuple of (number of reactions, number of genes) to the data
+      annotation of the metabolic coverage test.
 
 0.6.1 (2018-03-01)
 ------------------

--- a/memote/suite/results/result_manager.py
+++ b/memote/suite/results/result_manager.py
@@ -77,15 +77,14 @@ class ResultManager(object):
             self.add_environment(result.meta)
         if pretty:
             kwargs = dict(sort_keys=True, indent=2,
-                          separators=(",", ": "), ensure_ascii=True)
+                          separators=(",", ": "), ensure_ascii=False)
         else:
             kwargs = dict(sort_keys=False, indent=None,
-                          separators=(",", ":"), ensure_ascii=True)
+                          separators=(",", ":"), ensure_ascii=False)
         LOGGER.info("Storing result in '%s'.", filename)
         with open(filename, "w", encoding="utf-8") as file_handle:
             try:
-                return file_handle.write(
-                    str(json.dumps(result, **kwargs)))
+                return file_handle.write(json.dumps(result, **kwargs))
             except TypeError as error:
                 log_json_incompatible_types(result)
                 raise_with_traceback(error)

--- a/memote/suite/results/result_manager.py
+++ b/memote/suite/results/result_manager.py
@@ -22,7 +22,7 @@ from __future__ import absolute_import
 import json
 import logging
 import platform
-from builtins import open, str
+from builtins import open
 from datetime import datetime
 
 import pip

--- a/memote/suite/results/result_manager.py
+++ b/memote/suite/results/result_manager.py
@@ -76,13 +76,14 @@ class ResultManager(object):
         if env_info:
             self.add_environment(result.meta)
         if pretty:
-            kwargs = dict(sort_keys=True, indent=2, separators=(",", ": "))
+            kwargs = dict(sort_keys=True, indent=2, separators=(",", ": "), ensure_ascii=True)
         else:
-            kwargs = dict(sort_keys=False, indent=None, separators=(",", ":"))
+            kwargs = dict(sort_keys=False, indent=None, separators=(",", ":"), ensure_ascii=True)
         LOGGER.info("Storing result in '%s'.", filename)
         with open(filename, "w", encoding="utf-8") as file_handle:
             try:
-                return json.dump(result, file_handle, **kwargs)
+                return file_handle.write(
+                    unicode(json.dumps(result, **kwargs)))
             except TypeError as error:
                 log_json_incompatible_types(result)
                 raise_with_traceback(error)

--- a/memote/suite/results/result_manager.py
+++ b/memote/suite/results/result_manager.py
@@ -27,6 +27,7 @@ from datetime import datetime
 
 import pip
 from future.utils import raise_with_traceback
+import io
 
 from memote.utils import log_json_incompatible_types
 from memote.version_info import PKG_ORDER
@@ -76,11 +77,13 @@ class ResultManager(object):
         if env_info:
             self.add_environment(result.meta)
         if pretty:
-            kwargs = dict(sort_keys=True, indent=2, separators=(",", ": "), ensure_ascii=True)
+            kwargs = dict(sort_keys=True, indent=2,
+                          separators=(",", ": "), ensure_ascii=True)
         else:
-            kwargs = dict(sort_keys=False, indent=None, separators=(",", ":"), ensure_ascii=True)
+            kwargs = dict(sort_keys=False, indent=None,
+                          separators=(",", ":"), ensure_ascii=True)
         LOGGER.info("Storing result in '%s'.", filename)
-        with open(filename, "w", encoding="utf-8") as file_handle:
+        with io.open(filename, "w", encoding="utf-8") as file_handle:
             try:
                 return file_handle.write(
                     unicode(json.dumps(result, **kwargs)))

--- a/memote/suite/results/result_manager.py
+++ b/memote/suite/results/result_manager.py
@@ -22,12 +22,11 @@ from __future__ import absolute_import
 import json
 import logging
 import platform
-from builtins import open
+from builtins import open, str
 from datetime import datetime
 
 import pip
 from future.utils import raise_with_traceback
-import io
 
 from memote.utils import log_json_incompatible_types
 from memote.version_info import PKG_ORDER
@@ -83,10 +82,10 @@ class ResultManager(object):
             kwargs = dict(sort_keys=False, indent=None,
                           separators=(",", ":"), ensure_ascii=True)
         LOGGER.info("Storing result in '%s'.", filename)
-        with io.open(filename, "w", encoding="utf-8") as file_handle:
+        with open(filename, "w", encoding="utf-8") as file_handle:
             try:
                 return file_handle.write(
-                    unicode(json.dumps(result, **kwargs)))
+                    str(json.dumps(result, **kwargs)))
             except TypeError as error:
                 log_json_incompatible_types(result)
                 raise_with_traceback(error)

--- a/memote/suite/templates/test_config.yml
+++ b/memote/suite/templates/test_config.yml
@@ -10,6 +10,9 @@ cards:
         - test_find_disconnected
         - test_stoichiometric_consistency
         - test_reaction_charge_balance
+        - test_find_reactions_unbounded_flux_default_condition
+        - test_find_metabolites_produced_with_closed_bounds
+        - test_find_metabolites_consumed_with_closed_bounds
       annotation:
         title: "Annotation"
         weight: 1.0
@@ -25,18 +28,21 @@ cards:
       sbo:
         title: "SBO Terms"
         weight: 2.0
+        cases:
+        - test_metabolite_sbo_presence
+        - test_metabolite_specific_sbo_presence
+        - test_reaction_sbo_presence
+        - test_metabolic_reaction_specific_sbo_presence
+        - test_transport_reaction_specific_sbo_presence
+        - test_exchange_specific_sbo_presence
+        - test_demand_specific_sbo_presence
+        - test_sink_specific_sbo_presence
+        - test_gene_sbo_presence
+        - test_gene_specific_sbo_presence
+        - test_biomass_specific_sbo_presence
       sequence:
         title: "Sequence Cross References"
         weight: 2.0
-      matrix:
-        title: "Matrix Conditioning"
-        weight: 1.0
-        cases:
-        - test_absolute_extreme_coefficient_ratio
-        - test_number_independent_conservation_relations
-        - test_number_steady_state_flux_solutions
-        - test_matrix_rank
-        - test_degrees_of_freedom
   test_basic:
     title: "Basic Information"
     cases:
@@ -48,6 +54,7 @@ cards:
     - test_metabolic_coverage
     - test_ngam_presence
     - test_gene_protein_reaction_rule_presence
+    - test_transport_reaction_gpr_presence
     - test_metabolites_charge_presence
     - test_metabolites_formula_presence
     - test_transport_reaction_presence
@@ -65,13 +72,25 @@ cards:
     - test_biomass_precursors_open_production
     - test_gam_in_biomass
     - test_fast_growth_default
+    - test_direct_metabolites_in_biomass
+    - test_biomass_open_production
+    - test_essential_precursors_not_in_biomass
   test_consistency:
     title: "Stoichiometry Matrix"
     cases:
     - test_detect_energy_generating_cycles
+    - test_find_stoichiometrically_balanced_cycles
     - test_blocked_reactions
     - test_find_orphans
     - test_find_deadends
+  matrix:
+    title: "Matrix Conditioning"
+    cases:
+    - test_absolute_extreme_coefficient_ratio
+    - test_number_independent_conservation_relations
+    - test_number_steady_state_flux_solutions
+    - test_matrix_rank
+    - test_degrees_of_freedom
 weights:
   test_reaction_mass_balance: 1.0
   test_find_disconnected: 1.0

--- a/memote/suite/tests/test_basic.py
+++ b/memote/suite/tests/test_basic.py
@@ -211,6 +211,7 @@ def test_metabolic_coverage(read_only_model):
     gene products and their enzymatic transformations are ‘lumped’.
     """
     ann = test_metabolic_coverage.annotation
+    ann["data"] = (len(read_only_model.reactions), len(read_only_model.genes))
     ann["metric"] = basic.calculate_metabolic_coverage(read_only_model)
     ann["message"] = wrapper.fill(
         """The degree of metabolic coverage is {:.2}.""".format(ann["metric"]))

--- a/memote/suite/tests/test_biomass.py
+++ b/memote/suite/tests/test_biomass.py
@@ -113,7 +113,7 @@ def test_biomass_default_production(model, reaction_id):
 
 
 @pytest.mark.parametrize("reaction_id", BIOMASS_IDS)
-@annotate(title="Biomass Production In Complete Medium", type="count",
+@annotate(title="Biomass Production In Complete Medium", type="number",
           data=dict(), message=dict(), metric=dict())
 def test_biomass_open_production(model, reaction_id):
     """


### PR DESCRIPTION
* [x] fix #366 
* [x] description of feature/fix
* [x] add an entry to the [next release](../HISTORY.rst)

In this PR I'm going to fix a bunch of smaller bugs associated with the report. 
Fixed so far are:
- Wrong type annotation on the test for Biomass Production in Complete Medium
- TypeError when running `memote new`
- Sort existing test results from misc into the respective categories (by editing test_config.yml)
- Move Matrix statistics category to unscored side into their own card
- Added a tuple of (number of reactions, number of genes) to the data annotation of the metabolic coverage test.

I'll be adding to this PR as I go and let you know when it's OK to be merged!