### PR TITLE
Feat/better error handling

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -3,7 +3,7 @@ History
 
 Next Release
 ------------
-* Test summary only displays extended narrative summmary describing test,
+* Test summary only displays extended narrative summary describing test,
   and not one-line summary describing expected function behavior/output
 * Fix the following bugs:
     - Fix type annotation on the test for Biomass Production in Complete Medium
@@ -14,6 +14,9 @@ Next Release
     - Move Matrix statistics category to unscored side into their own card
     - Add a tuple of (number of reactions, number of genes) to the data
       annotation of the metabolic coverage test.
+* Add filter in ``report_data_service`` that changed the test result status to
+  "error" when the data attribute is ``null``, thus avoiding that the report
+  interface breaks when trying to access data.
 
 0.6.1 (2018-03-01)
 ------------------

--- a/memote-report-app/src/app/report-data.service.ts
+++ b/memote-report-app/src/app/report-data.service.ts
@@ -17,8 +17,8 @@ export class ReportDataService {
   public loadResults(): void {
     // TODO: Might want to parse and decompress a string in future.
     // const data = JSON.parse((<any>window).data);
-    this.convertResults((<any>window).data);
-    // this.http.get('/data/testData.json').subscribe(data => {this.convertResults(data); });
+    // this.convertResults((<any>window).data);
+    this.http.get('/data/testData.json').subscribe(data => {this.convertResults(data); });
   }
 
   public byID(string) {

--- a/memote-report-app/src/app/report-data.service.ts
+++ b/memote-report-app/src/app/report-data.service.ts
@@ -48,6 +48,15 @@ export class ReportDataService {
     return JSON.stringify(object);
   }
 
+  private errorFailsafe(data: TestResult) {
+    if (data.result !== 'skipped' && !data.data ){
+      data['result'] = 'error';
+      return data;
+    } else {
+      return data;
+    }
+  }
+
   private convertResults(data: Object): void {
     // Store each test result as a TestResult object in a central list.
     for (const test of Object.keys(data['tests'])){
@@ -55,24 +64,28 @@ export class ReportDataService {
         for (const param of Object.keys(data['tests'][test]['data'])) {
           const newID = test + ':' + param;
           this.allTests.push(
-            new TestResult(
-              newID,
-              {data: data['tests'][test]['data'][param],
-              duration: data['tests'][test]['duration'][param],
-              message: data['tests'][test]['message'][param],
-              metric: data['tests'][test]['metric'][param],
-              result: data['tests'][test]['result'][param],
-              summary: data['tests'][test]['summary'],
-              title: data['tests'][test]['title'],
-              type: data['tests'][test]['type']}
+            this.errorFailsafe(
+              new TestResult(
+                newID,
+                {data: data['tests'][test]['data'][param],
+                duration: data['tests'][test]['duration'][param],
+                message: data['tests'][test]['message'][param],
+                metric: data['tests'][test]['metric'][param],
+                result: data['tests'][test]['result'][param],
+                summary: data['tests'][test]['summary'],
+                title: data['tests'][test]['title'],
+                type: data['tests'][test]['type']}
+              )
             )
           );
         }
       } else {
       this.allTests.push(
-        new TestResult(
-          test,
-          data['tests'][test]));
+        this.errorFailsafe(
+          new TestResult(
+            test,
+            data['tests'][test]))
+        );
       }
     }
     // Extract metaddata information to be used in the metadata card

--- a/memote-report-app/src/app/report-data.service.ts
+++ b/memote-report-app/src/app/report-data.service.ts
@@ -48,15 +48,6 @@ export class ReportDataService {
     return JSON.stringify(object);
   }
 
-  private errorFailsafe(data: TestResult) {
-    if (data.result !== 'skipped' && !data.data ){
-      data['result'] = 'error';
-      return data;
-    } else {
-      return data;
-    }
-  }
-
   private convertResults(data: Object): void {
     // Store each test result as a TestResult object in a central list.
     for (const test of Object.keys(data['tests'])){
@@ -64,7 +55,6 @@ export class ReportDataService {
         for (const param of Object.keys(data['tests'][test]['data'])) {
           const newID = test + ':' + param;
           this.allTests.push(
-            this.errorFailsafe(
               new TestResult(
                 newID,
                 {data: data['tests'][test]['data'][param],
@@ -76,16 +66,14 @@ export class ReportDataService {
                 title: data['tests'][test]['title'],
                 type: data['tests'][test]['type']}
               )
-            )
-          );
+            );
         }
       } else {
       this.allTests.push(
-        this.errorFailsafe(
           new TestResult(
             test,
-            data['tests'][test]))
-        );
+            data['tests'][test])
+      );
       }
     }
     // Extract metaddata information to be used in the metadata card

--- a/memote-report-app/src/app/report-data.service.ts
+++ b/memote-report-app/src/app/report-data.service.ts
@@ -17,8 +17,8 @@ export class ReportDataService {
   public loadResults(): void {
     // TODO: Might want to parse and decompress a string in future.
     // const data = JSON.parse((<any>window).data);
-    // this.convertResults((<any>window).data);
-    this.http.get('/data/testData.json').subscribe(data => {this.convertResults(data); });
+    this.convertResults((<any>window).data);
+    //this.http.get('/data/testData.json').subscribe(data => {this.convertResults(data); });
   }
 
   public byID(string) {

--- a/memote-report-app/src/app/test-result.model.ts
+++ b/memote-report-app/src/app/test-result.model.ts
@@ -9,6 +9,14 @@ export class TestResult {
   public title: string;
   public type: string;
 
+  private errorFailsafe(result: string) {
+    if (this.result !== 'skipped' && !this.data ){
+      this.result = 'error';
+    } else {
+      this.result = result;
+    }
+  }
+  
   constructor(id: string, {data, duration, message, metric, result, summary, title, type}: {
       data: any, duration: number, message: string, metric: number,
       result: string, summary: string, title: string, type: string
@@ -18,7 +26,7 @@ export class TestResult {
         this.duration = duration;
         this.message = message;
         this.metric = metric;
-        this.result = result;
+        this.errorFailsafe(result);
         this.summary = summary;
         this.title = title;
         this.type = type;

--- a/memote-report-app/src/index.html
+++ b/memote-report-app/src/index.html
@@ -10,6 +10,6 @@
 </head>
 <body style="background-color: rgba(177, 212, 237, 0.1)">
   <app-root></app-root>
-  <script>window.data = $results;</script>
+  <!-- <script>window.data = $results;</script> -->
 </body>
 </html>

--- a/memote-report-app/src/index.html
+++ b/memote-report-app/src/index.html
@@ -10,6 +10,6 @@
 </head>
 <body style="background-color: rgba(177, 212, 237, 0.1)">
   <app-root></app-root>
-  <!-- <script>window.data = $results;</script> -->
+  <script>window.data = $results;</script>
 </body>
 </html>


### PR DESCRIPTION
* [x] description of feature/fix
* [x] add an entry to the [next release](../HISTORY.rst)

#### Description:
Tests that are skipped will always have an empty (`none`) data attribute. For tests which pass or fail this may be the case:
- when the user writing the tests does not to set the data attribute,
- or the helper function providing the data throws an exception.

When the display type `count` is chosen, the report attempts to determine the length of whatever is stored as data. When data is `null` (Angular equivalent of the python `none`) this results in an error which breaks the interface.

Since either of those cases above can be seen as errors (by a user or by one of the helper functions), the fix implemented in this PR consists of setting the `result` attribute of each test from passed or failed to error.