### PR TITLE
Fix/optimize sbc

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -3,6 +3,7 @@ History
 
 Next Release
 ------------
+
 * Test summary only displays extended narrative summary describing test,
   and not one-line summary describing expected function behavior/output
 * Fix the following bugs:
@@ -17,12 +18,12 @@ Next Release
 * Add filter in ``report_data_service`` that changed the test result status to
   "error" when the data attribute is ``null``, thus avoiding that the report
   interface breaks when trying to access data.
+* Add test for identifying stoichiometrically balanced cycles in models
 
 0.6.1 (2018-03-01)
 ------------------
+
 * Emergency fix for distributing required JSON file.
-
-
 
 0.6.0 (2018-02-27)
 ------------------

--- a/memote/suite/tests/test_consistency.py
+++ b/memote/suite/tests/test_consistency.py
@@ -182,11 +182,9 @@ def test_find_stoichiometrically_balanced_cycles(read_only_model):
     constrained networks resulting in reactions that can carry flux when
     all the boundaries have been closed.
     """
-    # Skip inside function so it happens during call and not during setup.
-    # TODO: Consider using a timeout on the solver in future instead.
     ann = test_find_stoichiometrically_balanced_cycles.annotation
-    ann["data"] = get_ids(
-        consistency.find_stoichiometrically_balanced_cycles(read_only_model))
+    ann["data"] = consistency.find_stoichiometrically_balanced_cycles(
+        read_only_model)
     ann["metric"] = len(ann["data"]) / len(read_only_model.reactions)
     ann["message"] = wrapper.fill(
         """There are {} ({:.2%}) reactions

--- a/memote/suite/tests/test_consistency.py
+++ b/memote/suite/tests/test_consistency.py
@@ -184,7 +184,6 @@ def test_find_stoichiometrically_balanced_cycles(read_only_model):
     """
     # Skip inside function so it happens during call and not during setup.
     # TODO: Consider using a timeout on the solver in future instead.
-    pytest.skip("Loopless FVA currently runs too slowly for large models.")
     ann = test_find_stoichiometrically_balanced_cycles.annotation
     ann["data"] = get_ids(
         consistency.find_stoichiometrically_balanced_cycles(read_only_model))

--- a/memote/support/consistency.py
+++ b/memote/support/consistency.py
@@ -449,17 +449,10 @@ def find_stoichiometrically_balanced_cycles(model):
            http://doi.org/10.1038/nprot.2009.203
 
     """
-    try:
-        fva_result = flux_variability_analysis(model, loopless=False)
-        fva_result_loopless = flux_variability_analysis(model, loopless=True)
-    except Infeasible as err:
-        LOGGER.error("Failed to find stoichiometrically balanced cycles "
-                     "because '{}'. This may be a bug.".format(err))
-        return []
-    row_ids_max = fva_result[
-        fva_result.maximum != fva_result_loopless.maximum].index
-    row_ids_min = fva_result[
-        fva_result.minimum != fva_result_loopless.minimum].index
+    helpers.close_boundaries_sensibly(model)
+    fva_result = flux_variability_analysis(model, loopless=False)
+    row_ids_max = fva_result[fva_result["maximum"] == 1].index
+    row_ids_min = fva_result[fva_result["minimum"] == -1].index
     differential_fluxes = set(row_ids_min).union(set(row_ids_max))
     return [model.reactions.get_by_id(id) for id in differential_fluxes]
 

--- a/memote/support/consistency.py
+++ b/memote/support/consistency.py
@@ -421,13 +421,9 @@ def find_universally_blocked_reactions(model):
 
 def find_stoichiometrically_balanced_cycles(model):
     u"""
-    Find metabolic rxns in stoichiometrically balanced cycles (SBCs).
+    Find metabolic reactions in stoichiometrically balanced cycles (SBCs).
 
-    The flux distribution of nominal FVA is compared with loopless FVA
-    (loopless=True) to determine reactions that participate in loops, as
-    participation in loops would increase the flux through a given reactions
-    to the maximal bounds. This function then returns reactions where the
-    flux differs between the two FVA calculations.
+    Identify forward and reverse cycles by closing all exchanges and using FVA.
 
     Parameters
     ----------
@@ -451,10 +447,8 @@ def find_stoichiometrically_balanced_cycles(model):
     """
     helpers.close_boundaries_sensibly(model)
     fva_result = flux_variability_analysis(model, loopless=False)
-    row_ids_max = fva_result[fva_result["maximum"] == 1].index
-    row_ids_min = fva_result[fva_result["minimum"] == -1].index
-    differential_fluxes = set(row_ids_min).union(set(row_ids_max))
-    return [model.reactions.get_by_id(id) for id in differential_fluxes]
+    return fva_result.index[
+        (fva_result["minimum"] == -1) | (fva_result["maximum"] == 1)].tolist()
 
 
 def find_orphans(model):

--- a/tests/test_for_support/test_for_consistency.py
+++ b/tests/test_for_support/test_for_consistency.py
@@ -409,6 +409,22 @@ def loopy_toy_model(base):
     base.reactions.VB.bounds = 0, 1
     return base
 
+@register_with(MODEL_REGISTRY)
+def loopless_toy_model(base):
+    base.add_metabolites([cobra.Metabolite(i) for i in "ABC"])
+    base.add_reactions([cobra.Reaction(i)
+                        for i in ["VA", "VB", "v1", "v2"]]
+                       )
+    base.reactions.VA.add_metabolites({"A": 1})
+    base.reactions.VB.add_metabolites({"C": -1})
+    base.reactions.v1.add_metabolites({"A": -1, "B": 1})
+    base.reactions.v2.add_metabolites({"B": -1, "C": 1})
+    base.reactions.v1.bounds = -1000, 1000
+    base.reactions.v2.bounds = -1000, 1000
+    base.objective = 'VB'
+    base.reactions.VB.bounds = 0, 1
+    return base
+
 
 @register_with(MODEL_REGISTRY)
 def constrained_toy_model(base):
@@ -644,7 +660,7 @@ def test_blocked_reactions(model, num):
 
 @pytest.mark.parametrize("model, num", [
     ("loopy_toy_model", 3),
-    ("constrained_toy_model", 0),
+    ("loopless_toy_model", 0),
     ("infeasible_toy_model", 0),
 ], indirect=["model"])
 def test_find_stoichiometrically_balanced_cycles(model, num):


### PR DESCRIPTION
* [x] fix #104 
* [x] description of feature/fix
* [x] tests added/passed
* [x] add an entry to the [next release](../HISTORY.rst)

Performing `test_find_stoichiometrically_balanced_cycles` currently is intractable for large models. These commits change the `find_stoichiometrically_balanced_cycles` function to work faster, by replacing 2 FVA calculations with only 1.
