### PR TITLE
Feat/report fixed pure metabolic reactions

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -4,6 +4,10 @@ History
 Next Release
 ------------
 
+* Add test for identifying purely metabolic reactions with fixed constraints in
+  models
+* Add test for identifying transport reactions with fixed constraints in models
+
 0.6.2 (2018-03-12)
 ------------------
 
@@ -24,9 +28,6 @@ Next Release
 * Add test for identifying stoichiometrically balanced cycles in models
 * Correct the arguments used for repositories such that ``memote run`` and
   ``memote history`` work as expected inside of a repository.
-* Add test for identifying purely metabolic reactions with fixed constraints in
-  models
-* Add test for identifying transport reactions with fixed constraints in models
 
 0.6.1 (2018-03-01)
 ------------------

--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -24,6 +24,8 @@ Next Release
 * Add test for identifying stoichiometrically balanced cycles in models
 * Correct the arguments used for repositories such that ``memote run`` and
   ``memote history`` work as expected inside of a repository.
+* Add test for identifying purely metabolic reaction with fixed constraints in
+  models
 
 0.6.1 (2018-03-01)
 ------------------

--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -24,7 +24,6 @@ Next Release
 * Add test for identifying stoichiometrically balanced cycles in models
 * Correct the arguments used for repositories such that ``memote run`` and
   ``memote history`` work as expected inside of a repository.
-* Add test for identifying purely metabolic reaction with fixed constraints in
 * Add test for identifying purely metabolic reactions with fixed constraints in
   models
 * Add test for identifying transport reactions with fixed constraints in models

--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -25,7 +25,9 @@ Next Release
 * Correct the arguments used for repositories such that ``memote run`` and
   ``memote history`` work as expected inside of a repository.
 * Add test for identifying purely metabolic reaction with fixed constraints in
+* Add test for identifying purely metabolic reactions with fixed constraints in
   models
+* Add test for identifying transport reactions with fixed constraints in models
 
 0.6.1 (2018-03-01)
 ------------------

--- a/memote/suite/templates/test_config.yml
+++ b/memote/suite/templates/test_config.yml
@@ -48,6 +48,7 @@ cards:
     cases:
     - test_find_unique_metabolites
     - test_find_transport_reactions
+    - test_find_constrained_transport_reactions
     - test_find_pure_metabolic_reactions
     - test_find_constrained_pure_metabolic_reactions
     - test_protein_complex_presence

--- a/memote/suite/templates/test_config.yml
+++ b/memote/suite/templates/test_config.yml
@@ -49,6 +49,7 @@ cards:
     - test_find_unique_metabolites
     - test_find_transport_reactions
     - test_find_pure_metabolic_reactions
+    - test_find_constrained_pure_metabolic_reactions
     - test_protein_complex_presence
     - test_compartments_presence
     - test_metabolic_coverage

--- a/memote/suite/tests/test_basic.py
+++ b/memote/suite/tests/test_basic.py
@@ -303,7 +303,8 @@ def test_find_constrained_pure_metabolic_reactions(read_only_model):
     ann = test_find_constrained_pure_metabolic_reactions.annotation
     ann["data"] = get_ids(
         basic.test_find_constrained_pure_metabolic_reactions(read_only_model))
-    ann["metric"] = len(ann["data"]) / len(read_only_model.reactions)
+    ann["metric"] = len(ann["data"]) / \
+    len(basic.find_pure_metabolic_reactions(read_only_model))
     ann["message"] = wrapper.fill(
         """A total of {:d} ({:.2%}) purely metabolic reactions have fixed
         constraints in the model, this excludes transporters, exchanges, or
@@ -331,7 +332,8 @@ def test_find_constrained_transport_reactions(read_only_model):
     ann = test_find_constrained_transport_reactions.annotation
     ann["data"] = get_ids(
         basic.test_find_constrained_transport_reactions(read_only_model))
-    ann["metric"] = len(ann["data"]) / len(read_only_model.reactions)
+    ann["metric"] = len(ann["data"]) / \
+    len(set(helpers.find_transport_reactions(model)))
     ann["message"] = wrapper.fill(
         """A total of {:d} ({:.2%}) purely metabolic reactions have fixed
         constraints in the model, this excludes transporters, exchanges, or

--- a/memote/suite/tests/test_basic.py
+++ b/memote/suite/tests/test_basic.py
@@ -21,7 +21,8 @@ from __future__ import absolute_import, division
 
 import memote.support.basic as basic
 import memote.support.helpers as helpers
-from memote.utils import annotate, get_ids, truncate, wrapper
+from memote.utils import annotate, get_ids, get_ids_and_bounds, truncate
+from memote.utils import wrapper
 
 
 @annotate(title="Model Identifier", type="raw")

--- a/memote/suite/tests/test_basic.py
+++ b/memote/suite/tests/test_basic.py
@@ -287,7 +287,8 @@ def test_find_pure_metabolic_reactions(read_only_model):
     assert len(ann["data"]) >= 1, ann["message"]
 
 
-@annotate(title="Number of Purely Metabolic Reactions", type="count")
+@annotate(title="Number of Purely Metabolic Reactions with Constraints", 
+          type="count")
 def test_find_constrained_pure_metabolic_reactions(read_only_model):
     """
     Expect zero or more purely metabolic reactions to have fixed constraints.
@@ -302,6 +303,34 @@ def test_find_constrained_pure_metabolic_reactions(read_only_model):
     ann = test_find_constrained_pure_metabolic_reactions.annotation
     ann["data"] = get_ids(
         basic.test_find_constrained_pure_metabolic_reactions(read_only_model))
+    ann["metric"] = len(ann["data"]) / len(read_only_model.reactions)
+    ann["message"] = wrapper.fill(
+        """A total of {:d} ({:.2%}) purely metabolic reactions have fixed
+        constraints in the model, this excludes transporters, exchanges, or
+        pseudo-reactions: {}""".format(len(ann["data"]), ann["metric"],
+                                       truncate(ann["data"])))
+
+
+@annotate(title="Number of Tranport Reactions with Constraints", type="count")
+def test_find_constrained_transport_reactions(read_only_model):
+    """
+    Expect zero or more transport reactions to have fixed constraints.
+
+    Cellular metabolism in any organism usually involves the transport of
+    metabolites across a lipid bi-layer. Hence, this test checks that there is
+    at least one reaction, which transports metabolites from one compartment
+    to another.
+
+    A transport reaction is defined as follows:
+    1. It contains metabolites from at least two compartments and
+    2. at least one metabolite undergoes no chemical conversion, i.e.,
+    the formula stays the same on both sides of the equation.
+
+    This test will not be able to identify transport via the PTS System.
+    """
+    ann = test_find_constrained_transport_reactions.annotation
+    ann["data"] = get_ids(
+        basic.test_find_constrained_transport_reactions(read_only_model))
     ann["metric"] = len(ann["data"]) / len(read_only_model.reactions)
     ann["message"] = wrapper.fill(
         """A total of {:d} ({:.2%}) purely metabolic reactions have fixed

--- a/memote/suite/tests/test_basic.py
+++ b/memote/suite/tests/test_basic.py
@@ -302,14 +302,28 @@ def test_find_constrained_pure_metabolic_reactions(read_only_model):
     """
     ann = test_find_constrained_pure_metabolic_reactions.annotation
     pmr = basic.find_pure_metabolic_reactions(read_only_model)
-    ann["data"] = get_ids(
-        basic.test_find_constrained_pure_metabolic_reactions(pmr))
+    ann["data"] = get_ids(set(
+        [rxn for rxn in pmr if basic.is_constrained_reaction(rxn)]))
     ann["metric"] = len(ann["data"]) / len(pmr)
     ann["message"] = wrapper.fill(
         """A total of {:d} ({:.2%}) purely metabolic reactions have fixed
         constraints in the model, this excludes transporters, exchanges, or
         pseudo-reactions: {}""".format(len(ann["data"]), ann["metric"],
                                        truncate(ann["data"])))
+
+
+@annotate(title="Number of Transport Reactions", type="count")
+def test_find_transport_reactions(read_only_model):
+    """Expect >= 1 transport reactions are present in the read_only_model."""
+    ann = test_find_transport_reactions.annotation
+    ann["data"] = get_ids(helpers.find_transport_reactions(read_only_model))
+    ann["metric"] = len(ann["data"]) / len(read_only_model.reactions)
+    ann["message"] = wrapper.fill(
+        """A total of {:d} ({:.2%}) transport reactions are defined in the
+        model, this excludes purely metabolic reactions, exchanges, or
+        pseudo-reactions: {}""".format(
+            len(ann["data"]), ann["metric"], truncate(ann["data"])))
+    assert len(ann["data"]) >= 1, ann["message"]
 
 
 @annotate(title="Number of Tranport Reactions with Constraints", type="count")
@@ -331,28 +345,14 @@ def test_find_constrained_transport_reactions(read_only_model):
     This test will not be able to identify transport via the PTS System.
     """
     ann = test_find_constrained_transport_reactions.annotation
-    transporters = set(helpers.find_transport_reactions(model))
-    ann["data"] = get_ids(
-        basic.test_find_constrained_transport_reactions(transporters))
+    transporters = set(helpers.find_transport_reactions(read_only_model))
+    ann["data"] = get_ids(set(
+        [rxn for rxn in transporters if basic.is_constrained_reaction(rxn)]))
     ann["metric"] = len(ann["data"]) / len(transporters)
     ann["message"] = wrapper.fill(
         """A total of {:d} ({:.2%}) transport reactions have fixed
         constraints in the model: {}""".format(len(ann["data"]), ann["metric"],
                                                truncate(ann["data"])))
-
-
-@annotate(title="Number of Transport Reactions", type="count")
-def test_find_transport_reactions(read_only_model):
-    """Expect >= 1 transport reactions are present in the read_only_model."""
-    ann = test_find_transport_reactions.annotation
-    ann["data"] = get_ids(helpers.find_transport_reactions(read_only_model))
-    ann["metric"] = len(ann["data"]) / len(read_only_model.reactions)
-    ann["message"] = wrapper.fill(
-        """A total of {:d} ({:.2%}) transport reactions are defined in the
-        model, this excludes purely metabolic reactions, exchanges, or
-        pseudo-reactions: {}""".format(
-            len(ann["data"]), ann["metric"], truncate(ann["data"])))
-    assert len(ann["data"]) >= 1, ann["message"]
 
 
 @annotate(title="Fraction of Transport Reactions without GPR", type="percent")

--- a/memote/suite/tests/test_basic.py
+++ b/memote/suite/tests/test_basic.py
@@ -287,7 +287,7 @@ def test_find_pure_metabolic_reactions(read_only_model):
     assert len(ann["data"]) >= 1, ann["message"]
 
 
-@annotate(title="Number of Purely Metabolic Reactions with Constraints", 
+@annotate(title="Number of Purely Metabolic Reactions with Constraints",
           type="count")
 def test_find_constrained_pure_metabolic_reactions(read_only_model):
     """
@@ -304,7 +304,7 @@ def test_find_constrained_pure_metabolic_reactions(read_only_model):
     ann["data"] = get_ids(
         basic.test_find_constrained_pure_metabolic_reactions(read_only_model))
     ann["metric"] = len(ann["data"]) / \
-    len(basic.find_pure_metabolic_reactions(read_only_model))
+        len(basic.find_pure_metabolic_reactions(read_only_model))
     ann["message"] = wrapper.fill(
         """A total of {:d} ({:.2%}) purely metabolic reactions have fixed
         constraints in the model, this excludes transporters, exchanges, or
@@ -318,9 +318,10 @@ def test_find_constrained_transport_reactions(read_only_model):
     Expect zero or more transport reactions to have fixed constraints.
 
     Cellular metabolism in any organism usually involves the transport of
-    metabolites across a lipid bi-layer. Hence, this test checks that there is
-    at least one reaction, which transports metabolites from one compartment
-    to another.
+    metabolites across a lipid bi-layer. Hence, this test reports how many 
+    of these reactions, which transports metabolites from one compartment
+    to another, have fixed constraints. This test does not have any mandatory
+    'pass' criteria.
 
     A transport reaction is defined as follows:
     1. It contains metabolites from at least two compartments and
@@ -333,11 +334,10 @@ def test_find_constrained_transport_reactions(read_only_model):
     ann["data"] = get_ids(
         basic.test_find_constrained_transport_reactions(read_only_model))
     ann["metric"] = len(ann["data"]) / \
-    len(set(helpers.find_transport_reactions(model)))
+        len(set(helpers.find_transport_reactions(read_only_model)))
     ann["message"] = wrapper.fill(
-        """A total of {:d} ({:.2%}) purely metabolic reactions have fixed
-        constraints in the model, this excludes transporters, exchanges, or
-        pseudo-reactions: {}""".format(len(ann["data"]), ann["metric"],
+        """A total of {:d} ({:.2%}) transport reactions have fixed
+        constraints in the model: {}""".format(len(ann["data"]), ann["metric"],
                                        truncate(ann["data"])))
 
 

--- a/memote/suite/tests/test_basic.py
+++ b/memote/suite/tests/test_basic.py
@@ -287,6 +287,29 @@ def test_find_pure_metabolic_reactions(read_only_model):
     assert len(ann["data"]) >= 1, ann["message"]
 
 
+@annotate(title="Number of Purely Metabolic Reactions", type="count")
+def test_find_constrained_pure_metabolic_reactions(read_only_model):
+    """
+    Expect zero or more purely metabolic reactions to have fixed constraints.
+
+    If a reaction is neither a transport reaction, a biomass reaction nor a
+    boundary reaction, it is counted as a purely metabolic reaction. This test
+    requires the presence of metabolite formula to be able to identify
+    transport reactions. This test simply reports the number of purely 
+    metabolic reactions that have fixed constraints and does not have any
+    mandatory 'pass' criteria.
+    """
+    ann = test_find_constrained_pure_metabolic_reactions.annotation
+    ann["data"] = get_ids(
+        basic.test_find_constrained_pure_metabolic_reactions(read_only_model))
+    ann["metric"] = len(ann["data"]) / len(read_only_model.reactions)
+    ann["message"] = wrapper.fill(
+        """A total of {:d} ({:.2%}) purely metabolic reactions have fixed 
+        constraints in the model, this excludes transporters, exchanges, or 
+        pseudo-reactions: {}""".format(len(ann["data"]), ann["metric"], 
+                                       truncate(ann["data"])))
+
+
 @annotate(title="Number of Transport Reactions", type="count")
 def test_find_transport_reactions(read_only_model):
     """Expect >= 1 transport reactions are present in the read_only_model."""

--- a/memote/suite/tests/test_basic.py
+++ b/memote/suite/tests/test_basic.py
@@ -346,7 +346,7 @@ def test_find_constrained_transport_reactions(read_only_model):
     """
     ann = test_find_constrained_transport_reactions.annotation
     transporters = set(helpers.find_transport_reactions(read_only_model))
-    ann["data"] = get_ids(set(
+    ann["data"] = get_ids_and_bounds(set(
         [rxn for rxn in transporters if basic.is_constrained_reaction(rxn)]))
     ann["metric"] = len(ann["data"]) / len(transporters)
     ann["message"] = wrapper.fill(

--- a/memote/suite/tests/test_basic.py
+++ b/memote/suite/tests/test_basic.py
@@ -302,7 +302,7 @@ def test_find_constrained_pure_metabolic_reactions(read_only_model):
     """
     ann = test_find_constrained_pure_metabolic_reactions.annotation
     pmr = basic.find_pure_metabolic_reactions(read_only_model)
-    ann["data"] = get_ids(set(
+    ann["data"] = get_ids_and_bounds(set(
         [rxn for rxn in pmr if basic.is_constrained_reaction(rxn)]))
     ann["metric"] = len(ann["data"]) / len(pmr)
     ann["message"] = wrapper.fill(

--- a/memote/suite/tests/test_basic.py
+++ b/memote/suite/tests/test_basic.py
@@ -318,7 +318,7 @@ def test_find_constrained_transport_reactions(read_only_model):
     Expect zero or more transport reactions to have fixed constraints.
 
     Cellular metabolism in any organism usually involves the transport of
-    metabolites across a lipid bi-layer. Hence, this test reports how many 
+    metabolites across a lipid bi-layer. Hence, this test reports how many
     of these reactions, which transports metabolites from one compartment
     to another, have fixed constraints. This test does not have any mandatory
     'pass' criteria.
@@ -338,7 +338,7 @@ def test_find_constrained_transport_reactions(read_only_model):
     ann["message"] = wrapper.fill(
         """A total of {:d} ({:.2%}) transport reactions have fixed
         constraints in the model: {}""".format(len(ann["data"]), ann["metric"],
-                                       truncate(ann["data"])))
+                                               truncate(ann["data"])))
 
 
 @annotate(title="Number of Transport Reactions", type="count")

--- a/memote/suite/tests/test_basic.py
+++ b/memote/suite/tests/test_basic.py
@@ -301,10 +301,10 @@ def test_find_constrained_pure_metabolic_reactions(read_only_model):
     mandatory 'pass' criteria.
     """
     ann = test_find_constrained_pure_metabolic_reactions.annotation
+    pmr = basic.find_pure_metabolic_reactions(read_only_model)
     ann["data"] = get_ids(
-        basic.test_find_constrained_pure_metabolic_reactions(read_only_model))
-    ann["metric"] = len(ann["data"]) / \
-        len(basic.find_pure_metabolic_reactions(read_only_model))
+        basic.test_find_constrained_pure_metabolic_reactions(pmr))
+    ann["metric"] = len(ann["data"]) / len(pmr)
     ann["message"] = wrapper.fill(
         """A total of {:d} ({:.2%}) purely metabolic reactions have fixed
         constraints in the model, this excludes transporters, exchanges, or
@@ -331,10 +331,10 @@ def test_find_constrained_transport_reactions(read_only_model):
     This test will not be able to identify transport via the PTS System.
     """
     ann = test_find_constrained_transport_reactions.annotation
+    transporters = set(helpers.find_transport_reactions(model))
     ann["data"] = get_ids(
-        basic.test_find_constrained_transport_reactions(read_only_model))
-    ann["metric"] = len(ann["data"]) / \
-        len(set(helpers.find_transport_reactions(read_only_model)))
+        basic.test_find_constrained_transport_reactions(transporters))
+    ann["metric"] = len(ann["data"]) / len(transporters)
     ann["message"] = wrapper.fill(
         """A total of {:d} ({:.2%}) transport reactions have fixed
         constraints in the model: {}""".format(len(ann["data"]), ann["metric"],

--- a/memote/suite/tests/test_basic.py
+++ b/memote/suite/tests/test_basic.py
@@ -21,8 +21,8 @@ from __future__ import absolute_import, division
 
 import memote.support.basic as basic
 import memote.support.helpers as helpers
-from memote.utils import annotate, get_ids, get_ids_and_bounds, truncate
-from memote.utils import wrapper
+from memote.utils import (
+    annotate, get_ids, get_ids_and_bounds, truncate, wrapper)
 
 
 @annotate(title="Model Identifier", type="raw")
@@ -303,8 +303,8 @@ def test_find_constrained_pure_metabolic_reactions(read_only_model):
     """
     ann = test_find_constrained_pure_metabolic_reactions.annotation
     pmr = basic.find_pure_metabolic_reactions(read_only_model)
-    ann["data"] = get_ids_and_bounds(set(
-        [rxn for rxn in pmr if basic.is_constrained_reaction(rxn)]))
+    ann["data"] = get_ids_and_bounds(
+        [rxn for rxn in pmr if basic.is_constrained_reaction(rxn)])
     ann["metric"] = len(ann["data"]) / len(pmr)
     ann["message"] = wrapper.fill(
         """A total of {:d} ({:.2%}) purely metabolic reactions have fixed
@@ -346,9 +346,9 @@ def test_find_constrained_transport_reactions(read_only_model):
     This test will not be able to identify transport via the PTS System.
     """
     ann = test_find_constrained_transport_reactions.annotation
-    transporters = set(helpers.find_transport_reactions(read_only_model))
-    ann["data"] = get_ids_and_bounds(set(
-        [rxn for rxn in transporters if basic.is_constrained_reaction(rxn)]))
+    transporters = helpers.find_transport_reactions(read_only_model)
+    ann["data"] = get_ids_and_bounds(
+        [rxn for rxn in transporters if basic.is_constrained_reaction(rxn)])
     ann["metric"] = len(ann["data"]) / len(transporters)
     ann["message"] = wrapper.fill(
         """A total of {:d} ({:.2%}) transport reactions have fixed

--- a/memote/suite/tests/test_basic.py
+++ b/memote/suite/tests/test_basic.py
@@ -295,7 +295,7 @@ def test_find_constrained_pure_metabolic_reactions(read_only_model):
     If a reaction is neither a transport reaction, a biomass reaction nor a
     boundary reaction, it is counted as a purely metabolic reaction. This test
     requires the presence of metabolite formula to be able to identify
-    transport reactions. This test simply reports the number of purely 
+    transport reactions. This test simply reports the number of purely
     metabolic reactions that have fixed constraints and does not have any
     mandatory 'pass' criteria.
     """
@@ -304,9 +304,9 @@ def test_find_constrained_pure_metabolic_reactions(read_only_model):
         basic.test_find_constrained_pure_metabolic_reactions(read_only_model))
     ann["metric"] = len(ann["data"]) / len(read_only_model.reactions)
     ann["message"] = wrapper.fill(
-        """A total of {:d} ({:.2%}) purely metabolic reactions have fixed 
-        constraints in the model, this excludes transporters, exchanges, or 
-        pseudo-reactions: {}""".format(len(ann["data"]), ann["metric"], 
+        """A total of {:d} ({:.2%}) purely metabolic reactions have fixed
+        constraints in the model, this excludes transporters, exchanges, or
+        pseudo-reactions: {}""".format(len(ann["data"]), ann["metric"],
                                        truncate(ann["data"])))
 
 

--- a/memote/support/basic.py
+++ b/memote/support/basic.py
@@ -221,47 +221,14 @@ def find_pure_metabolic_reactions(model):
     return set(model.reactions) - (exchanges | transporters | biomass)
 
 
-def find_constrained_pure_metabolic_reactions(model_or_rxns):
-    """
-    Return purely metabolic reactions with fixed constraints.
-
-    Purely metabolic reactions in this case are defined as reactions that are
-    neither transporters, exchanges, nor pseudo.
-
-    Parameters
-    ----------
-    model_or_rxns : cobra.Model or set of cobra.Reaction
-        The metabolic model under investigation or a set of reactions from
-        the metabolic model under investigation.
-
-    """
-    pmr = None
-    if isinstance(model_or_rxns, cobra.core.Model):
-        pmr = find_pure_metabolic_reactions(model_or_rxns)
-    elif isinstance(model_or_rxns, set) and isinstance(list(model_or_rxns)[0],
-                                                       cobra.core.Reaction):
-        pmr = model_or_rxns
-    return set([rxn for rxn in pmr if rxn.lower_bound > 0])
-
-
-def find_constrained_transport_reactions(model_or_rxns):
-    """
-    Return transport reactions with fixed constraints.
-
-    Parameters
-    ----------
-    model_or_rxns : cobra.Model or set of cobra.Reaction
-        The metabolic model under investigation or a set of reactions from
-        the metabolic model under investigation.
-
-    """
-    transporters = None
-    if isinstance(model_or_rxns, cobra.core.Model):
-        transporters = set(helpers.find_transport_reactions(model))
-    elif isinstance(model_or_rxns, set) and isinstance(list(model_or_rxns)[0],
-                                                       cobra.core.Reaction):
-        transporters = model_or_rxns
-    return set([rxn for rxn in transporters if rxn.lower_bound > 0])
+def is_constrained_reaction(rxn):
+    """Return whether a reaction has fixed constraints."""
+    if rxn.reversibility:
+        return True if (
+            rxn.lower_bound != -1000 or rxn.upper_bound != 1000) else False
+    else:
+        return True if (
+            rxn.lower_bound != 0 or rxn.upper_bound != 1000) else False
 
 
 def find_unique_metabolites(model):

--- a/memote/support/basic.py
+++ b/memote/support/basic.py
@@ -186,7 +186,7 @@ def calculate_metabolic_coverage(model):
 
 def find_protein_complexes(model):
     """
-    Find tuples of gene identifiers that constitute functional enzyme complexes.
+    Find tuples of gene identifiers that comprise functional enzyme complexes.
 
     Parameters
     ----------
@@ -222,8 +222,10 @@ def find_pure_metabolic_reactions(model):
 
 def find_constrained_pure_metabolic_reactions(model):
     """
-    Return reactions with fixed constraints that are neither transporters, 
-    exchanges, nor pseudo.
+    Return purely metabolic reactions with fixed constraints.
+
+    Purely metabolic reactions in this case are defined as reactions that are 
+    neither transporters, exchanges, nor pseudo.
 
     Parameters
     ----------

--- a/memote/support/basic.py
+++ b/memote/support/basic.py
@@ -223,9 +223,9 @@ def find_pure_metabolic_reactions(model):
 def is_constrained_reaction(rxn):
     """Return whether a reaction has fixed constraints."""
     if rxn.reversibility:
-        return (rxn.lower_bound != -1000 or rxn.upper_bound != 1000)
+        return rxn.lower_bound > -1000 or rxn.upper_bound < 1000
     else:
-        return (rxn.lower_bound != 0 or rxn.upper_bound != 1000)
+        return rxn.lower_bound > 0 or rxn.upper_bound < 1000
 
 
 def find_unique_metabolites(model):

--- a/memote/support/basic.py
+++ b/memote/support/basic.py
@@ -220,6 +220,21 @@ def find_pure_metabolic_reactions(model):
     return set(model.reactions) - (exchanges | transporters | biomass)
 
 
+def find_constrained_pure_metabolic_reactions(model):
+    """
+    Return reactions with fixed constraints that are neither transporters, 
+    exchanges, nor pseudo.
+
+    Parameters
+    ----------
+    model : cobra.Model
+        The metabolic model under investigation.
+
+    """
+    pmr = find_pure_metabolic_reactions(model)
+    return set([rxn for rxn in pmr if rxn.lower_bound > 0])
+
+
 def find_unique_metabolites(model):
     """Return set of metabolite IDs without duplicates from compartments."""
     # TODO: BiGG specific (met_c).

--- a/memote/support/basic.py
+++ b/memote/support/basic.py
@@ -224,7 +224,7 @@ def find_constrained_pure_metabolic_reactions(model):
     """
     Return purely metabolic reactions with fixed constraints.
 
-    Purely metabolic reactions in this case are defined as reactions that are 
+    Purely metabolic reactions in this case are defined as reactions that are
     neither transporters, exchanges, nor pseudo.
 
     Parameters

--- a/memote/support/basic.py
+++ b/memote/support/basic.py
@@ -20,6 +20,7 @@
 from __future__ import absolute_import
 
 import logging
+import cobra
 
 import memote.support.helpers as helpers
 
@@ -220,7 +221,7 @@ def find_pure_metabolic_reactions(model):
     return set(model.reactions) - (exchanges | transporters | biomass)
 
 
-def find_constrained_pure_metabolic_reactions(model):
+def find_constrained_pure_metabolic_reactions(model_or_rxns):
     """
     Return purely metabolic reactions with fixed constraints.
 
@@ -229,25 +230,37 @@ def find_constrained_pure_metabolic_reactions(model):
 
     Parameters
     ----------
-    model : cobra.Model
-        The metabolic model under investigation.
+    model_or_rxns : cobra.Model or set of cobra.Reaction
+        The metabolic model under investigation or a set of reactions from
+        the metabolic model under investigation.
 
     """
-    pmr = find_pure_metabolic_reactions(model)
+    pmr = None
+    if isinstance(model_or_rxns, cobra.core.Model):
+        pmr = find_pure_metabolic_reactions(model_or_rxns)
+    elif isinstance(model_or_rxns, set) and isinstance(list(model_or_rxns)[0],
+                                                       cobra.core.Reaction):
+        pmr = model_or_rxns
     return set([rxn for rxn in pmr if rxn.lower_bound > 0])
 
 
-def find_constrained_transport_reactions(model):
+def find_constrained_transport_reactions(model_or_rxns):
     """
     Return transport reactions with fixed constraints.
 
     Parameters
     ----------
-    model: cobra.Model
-        The metabolic model under investigation.
+    model_or_rxns : cobra.Model or set of cobra.Reaction
+        The metabolic model under investigation or a set of reactions from
+        the metabolic model under investigation.
 
     """
-    transporters = set(helpers.find_transport_reactions(model))
+    transporters = None
+    if isinstance(model_or_rxns, cobra.core.Model):
+        transporters = set(helpers.find_transport_reactions(model))
+    elif isinstance(model_or_rxns, set) and isinstance(list(model_or_rxns)[0],
+                                                       cobra.core.Reaction):
+        transporters = model_or_rxns
     return set([rxn for rxn in transporters if rxn.lower_bound > 0])
 
 

--- a/memote/support/basic.py
+++ b/memote/support/basic.py
@@ -223,11 +223,9 @@ def find_pure_metabolic_reactions(model):
 def is_constrained_reaction(rxn):
     """Return whether a reaction has fixed constraints."""
     if rxn.reversibility:
-        return True if (
-            rxn.lower_bound != -1000 or rxn.upper_bound != 1000) else False
+        return (rxn.lower_bound != -1000 or rxn.upper_bound != 1000)
     else:
-        return True if (
-            rxn.lower_bound != 0 or rxn.upper_bound != 1000) else False
+        return (rxn.lower_bound != 0 or rxn.upper_bound != 1000)
 
 
 def find_unique_metabolites(model):

--- a/memote/support/basic.py
+++ b/memote/support/basic.py
@@ -237,6 +237,20 @@ def find_constrained_pure_metabolic_reactions(model):
     return set([rxn for rxn in pmr if rxn.lower_bound > 0])
 
 
+def find_constrained_transport_reactions(model):
+    """
+    Return transport reactions with fixed constraints.
+
+    Parameters
+    ----------
+    model: cobra.Model
+        The metabolic model under investigation.
+
+    """
+    transporters = set(helpers.find_transport_reactions(model))
+    return set([rxn for rxn in transporters if rxn.lower_bound > 0])
+
+
 def find_unique_metabolites(model):
     """Return set of metabolite IDs without duplicates from compartments."""
     # TODO: BiGG specific (met_c).

--- a/memote/support/basic.py
+++ b/memote/support/basic.py
@@ -20,7 +20,6 @@
 from __future__ import absolute_import
 
 import logging
-import cobra
 
 import memote.support.helpers as helpers
 

--- a/memote/support/consistency.py
+++ b/memote/support/consistency.py
@@ -71,7 +71,8 @@ def check_stoichiometric_consistency(model):
     See [1]_ section 3.1 for a complete description of the algorithm.
 
     .. [1] Gevorgyan, A., M. G Poolman, and D. A Fell.
-           "Detection of Stoichiometric Inconsistencies in Biomolecular Models."
+           "Detection of Stoichiometric Inconsistencies in Biomolecular 
+           Models."
            Bioinformatics 24, no. 19 (2008): 2245.
 
     """
@@ -121,7 +122,8 @@ def find_unconserved_metabolites(model):
 
 
     .. [1] Gevorgyan, A., M. G Poolman, and D. A Fell.
-           "Detection of Stoichiometric Inconsistencies in Biomolecular Models."
+           "Detection of Stoichiometric Inconsistencies in Biomolecular 
+           Models."
            Bioinformatics 24, no. 19 (2008): 2245.
 
     """
@@ -179,7 +181,8 @@ def find_inconsistent_min_stoichiometry(model, atol=1e-13):
 
 
     .. [1] Gevorgyan, A., M. G Poolman, and D. A Fell.
-           "Detection of Stoichiometric Inconsistencies in Biomolecular Models."
+           "Detection of Stoichiometric Inconsistencies in Biomolecular 
+           Models."
            Bioinformatics 24, no. 19 (2008): 2245.
 
     """
@@ -189,7 +192,8 @@ def find_inconsistent_min_stoichiometry(model, atol=1e-13):
     unconserved_mets = find_unconserved_metabolites(model)
     LOGGER.info("model has %d unconserved metabolites", len(unconserved_mets))
     internal_rxns = con_helpers.get_internals(model)
-    internal_mets = set(met for rxn in internal_rxns for met in rxn.metabolites)
+    internal_mets = set(
+        met for rxn in internal_rxns for met in rxn.metabolites)
     get_id = attrgetter("id")
     reactions = sorted(internal_rxns, key=get_id)
     metabolites = sorted(internal_mets, key=get_id)

--- a/memote/support/consistency.py
+++ b/memote/support/consistency.py
@@ -71,7 +71,7 @@ def check_stoichiometric_consistency(model):
     See [1]_ section 3.1 for a complete description of the algorithm.
 
     .. [1] Gevorgyan, A., M. G Poolman, and D. A Fell.
-           "Detection of Stoichiometric Inconsistencies in Biomolecular 
+           "Detection of Stoichiometric Inconsistencies in Biomolecular
            Models."
            Bioinformatics 24, no. 19 (2008): 2245.
 
@@ -122,7 +122,7 @@ def find_unconserved_metabolites(model):
 
 
     .. [1] Gevorgyan, A., M. G Poolman, and D. A Fell.
-           "Detection of Stoichiometric Inconsistencies in Biomolecular 
+           "Detection of Stoichiometric Inconsistencies in Biomolecular
            Models."
            Bioinformatics 24, no. 19 (2008): 2245.
 
@@ -181,7 +181,7 @@ def find_inconsistent_min_stoichiometry(model, atol=1e-13):
 
 
     .. [1] Gevorgyan, A., M. G Poolman, and D. A Fell.
-           "Detection of Stoichiometric Inconsistencies in Biomolecular 
+           "Detection of Stoichiometric Inconsistencies in Biomolecular
            Models."
            Bioinformatics 24, no. 19 (2008): 2245.
 

--- a/memote/utils.py
+++ b/memote/utils.py
@@ -69,7 +69,7 @@ def annotate(title, type, message=None, data=None, metric=1.0):
     title : str
         A human-readable descriptive title of the test case.
     type : str
-        A string that determines how the result data is formatted in the 
+        A string that determines how the result data is formatted in the
         report. It is expected not to be None.
         - 'number' : 'data' is a single number which can be an integer or
           float and should be represented as such.

--- a/memote/utils.py
+++ b/memote/utils.py
@@ -24,8 +24,8 @@ from builtins import dict, str
 from numpydoc.docscrape import NumpyDocString
 from textwrap import TextWrapper
 
-__all__ = ("register_with", "annotate", "get_ids", "truncate",
-           "log_json_incompatible_types")
+__all__ = ("register_with", "annotate", "get_ids", "get_ids_and_bounds",
+           "truncate", "wrapper", "log_json_incompatible_types")
 
 LOGGER = logging.getLogger(__name__)
 

--- a/memote/utils.py
+++ b/memote/utils.py
@@ -125,6 +125,11 @@ def get_ids(iterable):
     return [element.id for element in iterable]
 
 
+def get_ids_and_bounds(iterable):
+    """Retrieve the identifier and bounds of a  number of objects."""
+    return [(elem.id, elem.lower_bound, elem.upper_bound) for elem in iterable]
+
+
 def truncate(sequence):
     """
     Create a potentially shortened text display of a list.

--- a/memote/utils.py
+++ b/memote/utils.py
@@ -69,8 +69,8 @@ def annotate(title, type, message=None, data=None, metric=1.0):
     title : str
         A human-readable descriptive title of the test case.
     type : str
-        A sting that determines how the result data is formatted in the report.
-        It is expected not to be None.
+        A string that determines how the result data is formatted in the 
+        report. It is expected not to be None.
         - 'number' : 'data' is a single number which can be an integer or
           float and should be represented as such.
         - 'count' : 'data' is a list, set or tuple. Choosing 'count' will

--- a/tests/test_for_support/test_for_basic.py
+++ b/tests/test_for_support/test_for_basic.py
@@ -250,6 +250,26 @@ def transport_gpr(base):
     return base
 
 
+@register_with(MODEL_REGISTRY)
+def transport_gpr_constrained(base):
+    """Provide a model with a constrained transport reaction without GPR."""
+    met_a = cobra.Metabolite("co2_c", formula='CO2', compartment="c")
+    met_b = cobra.Metabolite("co2_e", formula='CO2', compartment="e")
+    met_c = cobra.Metabolite("na_c", formula='Na', compartment="c")
+    met_d = cobra.Metabolite("na_e", formula='Na', compartment="e")
+    uni = cobra.Reaction("UNI")
+    uni.gene_reaction_rule="X and Y"
+    uni.add_metabolites({met_a: 1, met_b: -1})
+    anti = cobra.Reaction("ANTI")
+    anti.gene_reaction_rule = "W or V"
+    anti.add_metabolites({met_a: 1, met_d: 1, met_b: -1, met_c: -1})
+    sym = cobra.Reaction("SYM")
+    sym.add_metabolites({met_a: 1, met_c: 1, met_b: -1, met_d: -1})
+    sym.lower_bound = 8.39
+    base.add_reactions([uni, anti, sym])
+    return base
+
+
 @pytest.mark.parametrize("model, num", [
     ("empty", 0),
     ("three_missing", 3),
@@ -395,9 +415,9 @@ def test_find_constrained_pure_metabolic_reactions(model, num):
 
 
 @pytest.mark.parametrize("model, num", [
-    ("ngam_present", 1),
-    ("ngam_and_atpsynthase", 0),
-    ("non_metabolic_reactions", 0)
+    ("transport_gpr_constrained", 1),
+    ("transport_gpr", 0),
+    ("ngam_and_atpsynthase", 0)
 ], indirect=["model"])
 def test_find_constrained_transport_reactions(model, num):
     """Expect num of contrained metabolic rxns to be identified correctly."""

--- a/tests/test_for_support/test_for_basic.py
+++ b/tests/test_for_support/test_for_basic.py
@@ -372,6 +372,8 @@ def test_enzyme_complex_presence(model, num):
     assert len(basic.find_protein_complexes(model)) == num
 
 
+# TODO: ngam_and_atpsynthase is not a proper positive control test model
+# It needs to be replaced with a new test.
 @pytest.mark.parametrize("model, num", [
     ("ngam_and_atpsynthase", 2),
     ("gpr_missing_with_exchange", 1),
@@ -388,8 +390,18 @@ def test_find_pure_metabolic_reactions(model, num):
     ("non_metabolic_reactions", 0)
 ], indirect=["model"])
 def test_find_constrained_pure_metabolic_reactions(model, num):
-    """Expect num of contrained metabolic rxns to be identified correctly."""
+    """Expect num of contrained transport rxns to be identified correctly."""
     assert len(basic.find_constrained_pure_metabolic_reactions(model)) == num
+
+
+@pytest.mark.parametrize("model, num", [
+    ("ngam_present", 1),
+    ("ngam_and_atpsynthase", 0),
+    ("non_metabolic_reactions", 0)
+], indirect=["model"])
+def test_find_constrained_transport_reactions(model, num):
+    """Expect num of contrained metabolic rxns to be identified correctly."""
+    assert len(basic.find_constrained_transport_reactions(model)) == num
 
 
 @pytest.mark.parametrize("model, num", [

--- a/tests/test_for_support/test_for_basic.py
+++ b/tests/test_for_support/test_for_basic.py
@@ -232,20 +232,6 @@ def non_metabolic_reactions(base):
 
 
 @register_with(MODEL_REGISTRY)
-def purely_metabolic_constrained_reactions(base):
-    """Provide a model of purely metabolic reactions with constrained bounds"""
-    met_g = cobra.Metabolite("atp_c", "C10H12N5O13P3", compartment="c")
-    met_h = cobra.Metabolite("adp_c", "C10H12N5O10P2", compartment="c")
-    met_j = cobra.Metabolite("h2o_c", "H2O", compartment="c")
-    met_k = cobra.Metabolite("pi_c", "HO4P", compartment="c")
-    met_l = cobra.Metabolite("h_c", "H", compartment="c")
-    rxn_1 = cobra.Reaction("ATPM", name="ATP maintenance requirement")
-    rxn_1.add_metabolites({met_h: 1.0, met_g: -1.0, met_j: -1.0, met_l: 1.0,
-                           met_k: 1.0})
-    base.add_reactions([rxn_1])
-
-
-@register_with(MODEL_REGISTRY)
 def transport_gpr(base):
     """Provide a model with a transport reaction without GPR."""
     met_a = cobra.Metabolite("co2_c", formula='CO2', compartment="c")
@@ -397,7 +383,7 @@ def test_find_pure_metabolic_reactions(model, num):
 
 
 @pytest.mark.parametrize("model, num", [
-    ("purely_metabolic_constrained_reactions", 1),
+    ("ngam_present", 1),
     ("ngam_and_atpsynthase", 0),
     ("non_metabolic_reactions", 0)
 ], indirect=["model"])

--- a/tests/test_for_support/test_for_basic.py
+++ b/tests/test_for_support/test_for_basic.py
@@ -23,6 +23,7 @@ import cobra
 import pytest
 
 import memote.support.basic as basic
+import memote.support.helpers as helpers
 from memote.utils import register_with
 
 MODEL_REGISTRY = dict()
@@ -410,8 +411,11 @@ def test_find_pure_metabolic_reactions(model, num):
     ("non_metabolic_reactions", 0)
 ], indirect=["model"])
 def test_find_constrained_pure_metabolic_reactions(model, num):
-    """Expect num of contrained transport rxns to be identified correctly."""
-    assert len(basic.find_constrained_pure_metabolic_reactions(model)) == num
+    """Expect num of contrained metabolic rxns to be identified correctly."""
+    pmr = basic.find_pure_metabolic_reactions(model)
+    contrained_pmr = set(
+        [rxn for rxn in pmr if basic.is_constrained_reaction(rxn)])
+    assert len(contrained_pmr) == num
 
 
 @pytest.mark.parametrize("model, num", [
@@ -420,8 +424,11 @@ def test_find_constrained_pure_metabolic_reactions(model, num):
     ("ngam_and_atpsynthase", 0)
 ], indirect=["model"])
 def test_find_constrained_transport_reactions(model, num):
-    """Expect num of contrained metabolic rxns to be identified correctly."""
-    assert len(basic.find_constrained_transport_reactions(model)) == num
+    """Expect num of contrained transport rxns to be identified correctly."""
+    transporters = set(helpers.find_transport_reactions(model))
+    constrained_transporters = set(
+        [rxn for rxn in transporters if basic.is_constrained_reaction(rxn)])
+    assert len(constrained_transporters) == num
 
 
 @pytest.mark.parametrize("model, num", [


### PR DESCRIPTION
* [x] fix #333 
* [x] description of feature/fix
* [x] tests added/passed
* [x] add an entry to the [next release](../HISTORY.rst)

Add a new function `find_constrained_pure_metabolic_reactions` to address #333 inside `basic.py`. Added `test_find_constrained_pure_metabolic_reactions` to `test_basic.py` and registered it in `memote/suite/templates/test_config.yml`. Also added unit test for the base function (also called `test_find_constrained_pure_metabolic_reactions`) in `test_for_basic.py`.

`find_constrained_pure_metabolic_reactions` simply looks through the set of all purely metabolic reactions and returns those which have a lower bound > 0. The only reaction found when testing on iJO1366 was on ATPM. However, this test is very much system-specific, so it has no mandatory 'pass' criteria.
