### PR TITLE
fix: get_ids_and_bounds now returns list of str

### DIFF
--- a/memote/utils.py
+++ b/memote/utils.py
@@ -127,7 +127,8 @@ def get_ids(iterable):
 
 def get_ids_and_bounds(iterable):
     """Retrieve the identifier and bounds of a  number of objects."""
-    return [(elem.id, elem.lower_bound, elem.upper_bound) for elem in iterable]
+    return [elem.lower_bound + "< " + elem.id + "< " + elem.upper_bound for
+            elem in iterable]
 
 
 def truncate(sequence):

--- a/memote/utils.py
+++ b/memote/utils.py
@@ -127,7 +127,7 @@ def get_ids(iterable):
 
 def get_ids_and_bounds(iterable):
     """Retrieve the identifier and bounds of a  number of objects."""
-    return [elem.lower_bound + "< " + elem.id + "< " + elem.upper_bound for
+    return ["{0.lower_bound} <= {0.id} <= {0.upper_bound}".format(elem) for
             elem in iterable]
 
 


### PR DESCRIPTION
* [x] description of feature/fix
* [ ] tests added/passed

`get_ids_and_bounds` used to return a list of tuples, which caused errors with the `truncate` function in `util.py`. It has been fixed to return a list of str, removing the `TypeError` exceptions being raised when running `memote run`