### PR TITLE
Fix/find transport reactions

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -16,6 +16,7 @@ Next Release
 * Fix some typos
 * Add history report view and connect it to `memote report history` call.
 * ``find_direct_metabolites`` detects and removes false positives.
+* ``find_transport_reactions`` detects reactions using forumlae and annotations
 
 0.6.2 (2018-03-12)
 ------------------

--- a/memote/suite/templates/test_config.yml
+++ b/memote/suite/templates/test_config.yml
@@ -60,7 +60,6 @@ cards:
     - test_transport_reaction_gpr_presence
     - test_metabolites_charge_presence
     - test_metabolites_formula_presence
-    - test_transport_reaction_presence
     - test_metabolites_presence
     - test_reactions_presence
     - test_genes_presence

--- a/memote/suite/tests/test_basic.py
+++ b/memote/suite/tests/test_basic.py
@@ -295,8 +295,7 @@ def test_find_transport_reactions(read_only_model):
     metabolites across a lipid bi-layer. This test reports how many
     of these reactions, which transports metabolites from one compartment
     to another, are present in the model, as at least one transport reaction
-    must be present for cells to take up food and nutrients and/or excrete
-    waste.
+    must be present for cells to take up nutrients and/or excrete waste.
 
     A transport reaction is defined as follows:
     1. It contains metabolites from at least 2 compartments and

--- a/memote/suite/tests/test_basic.py
+++ b/memote/suite/tests/test_basic.py
@@ -315,7 +315,16 @@ def test_find_constrained_pure_metabolic_reactions(read_only_model):
 
 @annotate(title="Number of Transport Reactions", type="count")
 def test_find_transport_reactions(read_only_model):
-    """Expect >= 1 transport reactions are present in the read_only_model."""
+    """
+    Expect >= 1 transport reactions are present in the read_only_model.
+
+    Cellular metabolism in any organism usually involves the transport of
+    metabolites across a lipid bi-layer. This test reports how many
+    of these reactions, which transports metabolites from one compartment
+    to another, are present in the model, as at least one transport reaction
+    must be present for cells to take up food and nutrients and/or excrete 
+    waste.
+    """
     ann = test_find_transport_reactions.annotation
     ann["data"] = get_ids(helpers.find_transport_reactions(read_only_model))
     ann["metric"] = len(ann["data"]) / len(read_only_model.reactions)
@@ -339,9 +348,23 @@ def test_find_constrained_transport_reactions(read_only_model):
     'pass' criteria.
 
     A transport reaction is defined as follows:
-    1. It contains metabolites from at least two compartments and
-    2. at least one metabolite undergoes no chemical conversion, i.e.,
+    1. It contains metabolites from at least 2 compartments and
+    2. at least 1 metabolite undergoes no chemical reaction, i.e.,
     the formula stays the same on both sides of the equation.
+
+    A notable exception is transport via PTS, which is defined as follows:
+    1. The transported metabolite(s) come from the ``e`` compartment into the
+    ``c`` compartment and
+    2. the metabolite in the ``e`` compartment enters into the ``c``
+    compartment through the exchange of a phosphate.
+
+    An example of tranport via PTS would be
+    pep(c) + glucose(e) -> glucose-6-phosphate(c) + pyr(c)
+
+    Transport via PTS is only detected when a formula field exists for all
+    metabolites in a particular reaction. If this is not the case, transport
+    reactions are identified through annotations, which cannot detect transport
+    via PTS.
     """
     ann = test_find_constrained_transport_reactions.annotation
     transporters = helpers.find_transport_reactions(read_only_model)

--- a/memote/suite/tests/test_basic.py
+++ b/memote/suite/tests/test_basic.py
@@ -324,6 +324,26 @@ def test_find_transport_reactions(read_only_model):
     to another, are present in the model, as at least one transport reaction
     must be present for cells to take up food and nutrients and/or excrete 
     waste.
+
+    A transport reaction is defined as follows:
+    1. It contains metabolites from at least 2 compartments and
+    2. at least 1 metabolite undergoes no chemical reaction, i.e.,
+    the formula stays the same on both sides of the equation.
+
+    A notable exception is transport via PTS, which is defined as follows:
+    1. The transported metabolite(s) come from the ``e`` compartment into the
+    ``c`` compartment and
+    2. the metabolite in the ``e`` compartment enters into the ``c``
+    compartment through the exchange of a phosphate.
+
+    An example of tranport via PTS would be
+    pep(c) + glucose(e) -> glucose-6-phosphate(c) + pyr(c)
+
+    Transport via PTS is only detected when a formula field exists for all
+    metabolites in a particular reaction. If this is not the case, transport
+    reactions are identified through annotations, which cannot detect transport
+    via PTS.
+
     """
     ann = test_find_transport_reactions.annotation
     ann["data"] = get_ids(helpers.find_transport_reactions(read_only_model))

--- a/memote/suite/tests/test_basic.py
+++ b/memote/suite/tests/test_basic.py
@@ -102,11 +102,26 @@ def test_transport_reaction_presence(read_only_model):
     to another.
 
     A transport reaction is defined as follows:
-    1. It contains metabolites from at least two compartments and
-    2. at least one metabolite undergoes no chemical conversion, i.e.,
-    the formula stays the same on both sides of the equation.
+    1. It contains metabolites from at least 2 compartments and
+    2. at least 1 metabolite undergoes no chemical reaction, i.e.,
+    the formula and/or annotation stays the same on both sides of the equation.
 
-    This test will not be able to identify transport via the PTS System.
+    A notable exception is transport via PTS, which also contains the following
+    restriction:
+    3. The transported metabolite(s) are transported into a compartment through
+    the exchange of a phosphate.
+
+    An example of tranport via PTS would be
+    pep(c) + glucose(e) -> glucose-6-phosphate(c) + pyr(c)
+
+    Reactions similar to transport via PTS (referred to as "modified transport
+    reactions") follow a similar pattern:
+    A[x] + B-R[y] -> A-R[y] + B[y]
+
+    Such modified transport reactions can be detected, but only when a formula
+    field exists for all metabolites in a particular reaction. If this is not
+    the case, transport reactions are identified through annotations, which
+    cannot detect modified tranport reactions.
     """
     ann = test_transport_reaction_presence.annotation
     ann["data"] = get_ids(helpers.find_transport_reactions(read_only_model))

--- a/memote/suite/tests/test_basic.py
+++ b/memote/suite/tests/test_basic.py
@@ -312,7 +312,7 @@ def test_find_transport_reactions(read_only_model):
 
     Reactions similar to transport via PTS (referred to as "modified transport
     reactions") follow a similar pattern:
-    A[x] + B-R[y] -> A-R[y] + B[y]
+    A(x) + B-R(y) -> A-R(y) + B(y)
 
     Such modified transport reactions can be detected, but only when a formula
     field exists for all metabolites in a particular reaction. If this is not
@@ -357,7 +357,7 @@ def test_find_constrained_transport_reactions(read_only_model):
 
     Reactions similar to transport via PTS (referred to as "modified transport
     reactions") follow a similar pattern:
-    A[x] + B-R[y] -> A-R[y] + B[y]
+    A(x) + B-R(y) -> A-R(y) + B(y)
 
     Such modified transport reactions can be detected, but only when a formula
     field exists for all metabolites in a particular reaction. If this is not

--- a/memote/suite/tests/test_basic.py
+++ b/memote/suite/tests/test_basic.py
@@ -322,7 +322,7 @@ def test_find_transport_reactions(read_only_model):
     metabolites across a lipid bi-layer. This test reports how many
     of these reactions, which transports metabolites from one compartment
     to another, are present in the model, as at least one transport reaction
-    must be present for cells to take up food and nutrients and/or excrete 
+    must be present for cells to take up food and nutrients and/or excrete
     waste.
 
     A transport reaction is defined as follows:

--- a/memote/suite/tests/test_basic.py
+++ b/memote/suite/tests/test_basic.py
@@ -342,8 +342,6 @@ def test_find_constrained_transport_reactions(read_only_model):
     1. It contains metabolites from at least two compartments and
     2. at least one metabolite undergoes no chemical conversion, i.e.,
     the formula stays the same on both sides of the equation.
-
-    This test will not be able to identify transport via the PTS System.
     """
     ann = test_find_constrained_transport_reactions.annotation
     transporters = helpers.find_transport_reactions(read_only_model)

--- a/memote/suite/tests/test_basic.py
+++ b/memote/suite/tests/test_basic.py
@@ -91,48 +91,6 @@ def test_metabolites_presence(read_only_model):
     assert len(ann["data"]) >= 1, ann["message"]
 
 
-@annotate(title="Total Number of Transport Reactions", type="count")
-def test_transport_reaction_presence(read_only_model):
-    """
-    Expect more than one transport reaction to be defined in the model.
-
-    Cellular metabolism in any organism usually involves the transport of
-    metabolites across a lipid bi-layer. Hence, this test checks that there is
-    at least one reaction, which transports metabolites from one compartment
-    to another.
-
-    A transport reaction is defined as follows:
-    1. It contains metabolites from at least 2 compartments and
-    2. at least 1 metabolite undergoes no chemical reaction, i.e.,
-    the formula and/or annotation stays the same on both sides of the equation.
-
-    A notable exception is transport via PTS, which also contains the following
-    restriction:
-    3. The transported metabolite(s) are transported into a compartment through
-    the exchange of a phosphate.
-
-    An example of tranport via PTS would be
-    pep(c) + glucose(e) -> glucose-6-phosphate(c) + pyr(c)
-
-    Reactions similar to transport via PTS (referred to as "modified transport
-    reactions") follow a similar pattern:
-    A[x] + B-R[y] -> A-R[y] + B[y]
-
-    Such modified transport reactions can be detected, but only when a formula
-    field exists for all metabolites in a particular reaction. If this is not
-    the case, transport reactions are identified through annotations, which
-    cannot detect modified tranport reactions.
-    """
-    ann = test_transport_reaction_presence.annotation
-    ann["data"] = get_ids(helpers.find_transport_reactions(read_only_model))
-    ann["message"] = wrapper.fill(
-        """A total of {:d} ({:.2%}) transport reactions are defined in the
-        model, this excludes purely metabolic reactions, exchanges, or
-        pseudo-reactions: {}""".format(
-            len(ann["data"]), ann["metric"], truncate(ann["data"])))
-    assert len(ann["data"]) >= 1, ann["message"]
-
-
 @annotate(title="Metabolites without Formula", type="count")
 def test_metabolites_formula_presence(read_only_model):
     """
@@ -343,21 +301,24 @@ def test_find_transport_reactions(read_only_model):
     A transport reaction is defined as follows:
     1. It contains metabolites from at least 2 compartments and
     2. at least 1 metabolite undergoes no chemical reaction, i.e.,
-    the formula stays the same on both sides of the equation.
+    the formula and/or annotation stays the same on both sides of the equation.
 
-    A notable exception is transport via PTS, which is defined as follows:
-    1. The transported metabolite(s) come from the ``e`` compartment into the
-    ``c`` compartment and
-    2. the metabolite in the ``e`` compartment enters into the ``c``
-    compartment through the exchange of a phosphate.
+    A notable exception is transport via PTS, which also contains the following
+    restriction:
+    3. The transported metabolite(s) are transported into a compartment through
+    the exchange of a phosphate.
 
     An example of tranport via PTS would be
     pep(c) + glucose(e) -> glucose-6-phosphate(c) + pyr(c)
 
-    Transport via PTS is only detected when a formula field exists for all
-    metabolites in a particular reaction. If this is not the case, transport
-    reactions are identified through annotations, which cannot detect transport
-    via PTS.
+    Reactions similar to transport via PTS (referred to as "modified transport
+    reactions") follow a similar pattern:
+    A[x] + B-R[y] -> A-R[y] + B[y]
+
+    Such modified transport reactions can be detected, but only when a formula
+    field exists for all metabolites in a particular reaction. If this is not
+    the case, transport reactions are identified through annotations, which
+    cannot detect modified tranport reactions.
 
     """
     ann = test_find_transport_reactions.annotation
@@ -385,21 +346,24 @@ def test_find_constrained_transport_reactions(read_only_model):
     A transport reaction is defined as follows:
     1. It contains metabolites from at least 2 compartments and
     2. at least 1 metabolite undergoes no chemical reaction, i.e.,
-    the formula stays the same on both sides of the equation.
+    the formula and/or annotation stays the same on both sides of the equation.
 
-    A notable exception is transport via PTS, which is defined as follows:
-    1. The transported metabolite(s) come from the ``e`` compartment into the
-    ``c`` compartment and
-    2. the metabolite in the ``e`` compartment enters into the ``c``
-    compartment through the exchange of a phosphate.
+    A notable exception is transport via PTS, which also contains the following
+    restriction:
+    3. The transported metabolite(s) are transported into a compartment through
+    the exchange of a phosphate.
 
     An example of tranport via PTS would be
     pep(c) + glucose(e) -> glucose-6-phosphate(c) + pyr(c)
 
-    Transport via PTS is only detected when a formula field exists for all
-    metabolites in a particular reaction. If this is not the case, transport
-    reactions are identified through annotations, which cannot detect transport
-    via PTS.
+    Reactions similar to transport via PTS (referred to as "modified transport
+    reactions") follow a similar pattern:
+    A[x] + B-R[y] -> A-R[y] + B[y]
+
+    Such modified transport reactions can be detected, but only when a formula
+    field exists for all metabolites in a particular reaction. If this is not
+    the case, transport reactions are identified through annotations, which
+    cannot detect modified tranport reactions.
     """
     ann = test_find_constrained_transport_reactions.annotation
     transporters = helpers.find_transport_reactions(read_only_model)

--- a/memote/suite/tests/test_sbo.py
+++ b/memote/suite/tests/test_sbo.py
@@ -132,12 +132,15 @@ def test_metabolic_reaction_specific_sbo_presence(read_only_model):
 
 @annotate(title="Transport Reactions without SBO:0000185", type="count")
 def test_transport_reaction_specific_sbo_presence(read_only_model):
-    """Expect all transport reactions to be annotated with SBO:0000185.
+    """Expect all transport reactions to be annotated properly.
 
-    SBO:0000185 represents the term 'transport reaction'. Every transport
-    reaction that is not a pure metabolic or boundary reaction should be
-    annotated with this. The results shown are relative to the total of all
-    transport reactions.
+    'SBO:0000185', 'SBO:0000588', 'SBO:0000587', 'SBO:0000655', 'SBO:0000654',
+    'SBO:0000660', 'SBO:0000659', 'SBO:0000657', and 'SBO:0000658' represent
+    the terms 'transport reaction' and 'translocation reaction', in addition
+    to their children (more specific transport reaction labels). Every 
+    transport reaction that is not a pure metabolic or boundary reaction should
+    be annotated with one of these terms. The results shown are relative to the
+    total of all transport reactions.
     """
     ann = test_transport_reaction_specific_sbo_presence.annotation
     transports = helpers.find_transport_reactions(read_only_model)

--- a/memote/suite/tests/test_sbo.py
+++ b/memote/suite/tests/test_sbo.py
@@ -137,22 +137,24 @@ def test_transport_reaction_specific_sbo_presence(read_only_model):
     'SBO:0000185', 'SBO:0000588', 'SBO:0000587', 'SBO:0000655', 'SBO:0000654',
     'SBO:0000660', 'SBO:0000659', 'SBO:0000657', and 'SBO:0000658' represent
     the terms 'transport reaction' and 'translocation reaction', in addition
-    to their children (more specific transport reaction labels). Every 
+    to their children (more specific transport reaction labels). Every
     transport reaction that is not a pure metabolic or boundary reaction should
     be annotated with one of these terms. The results shown are relative to the
     total of all transport reactions.
     """
+    sbo_transport_terms = helpers.TRANSPORT_RXN_SBO_TERMS
     ann = test_transport_reaction_specific_sbo_presence.annotation
     transports = helpers.find_transport_reactions(read_only_model)
     ann["data"] = get_ids(sbo.check_component_for_specific_sbo_term(
-        transports, "SBO:0000185"))
+        transports, sbo_transport_terms))
     try:
         ann["metric"] = len(ann["data"]) / len(transports)
         ann["message"] = wrapper.fill(
             """A total of {} metabolic reactions ({:.2%} of all transport
-            reactions) lack annotation with the SBO term "SBO:0000185" for
+            reactions) lack annotation with one of the SBO terms: {} for
             'biochemical reaction': {}""".format(
-                len(ann["data"]), ann["metric"], truncate(ann["data"])))
+                len(ann["data"]), ann["metric"], sbo_transport_terms,
+                truncate(ann["data"])))
     except ZeroDivisionError:
         ann["metric"] = 1.0
         ann["message"] = "The model has no transport reactions."

--- a/memote/support/helpers.py
+++ b/memote/support/helpers.py
@@ -39,6 +39,11 @@ import memote.support.data
 
 LOGGER = logging.getLogger(__name__)
 
+TRANSPORT_RXN_SBO_TERMS = ['SBO:0000185', 'SBO:0000588', 'SBO:0000587',
+                           'SBO:0000655', 'SBO:0000654', 'SBO:0000660',
+                           'SBO:0000659', 'SBO:0000657', 'SBO:0000658']
+
+
 # Read the MetaNetX shortlist to identify specific metabolite IDs across
 # different namespaces.
 with open_text(memote.support.data, "met_id_shortlist.json",
@@ -156,15 +161,7 @@ def find_transport_reactions(model):
     sbo_matches = set([rxn for rxn in transport_rxn_candidates if
                        rxn.annotation is not None and
                        'SBO' in rxn.annotation and
-                       (rxn.annotation['SBO'] == 'SBO:0000185' or
-                        rxn.annotation['SBO'] == 'SBO:0000588' or
-                        rxn.annotation['SBO'] == 'SBO:0000587' or
-                        rxn.annotation['SBO'] == 'SBO:0000655' or
-                        rxn.annotation['SBO'] == 'SBO:0000654' or
-                        rxn.annotation['SBO'] == 'SBO:0000660' or
-                        rxn.annotation['SBO'] == 'SBO:0000659' or
-                        rxn.annotation['SBO'] == 'SBO:0000657' or
-                        rxn.annotation['SBO'] == 'SBO:0000658')])
+                       rxn.annotation['SBO'] in TRANSPORT_RXN_SBO_TERMS])
     if len(sbo_matches) > 0:
         transport_reactions += list(sbo_matches)
     # Find unlabeled transport reactions via formula or annotation checks

--- a/memote/support/helpers.py
+++ b/memote/support/helpers.py
@@ -138,11 +138,12 @@ def find_transport_reactions(model):
     transport_rxn_candidates = set(model.reactions) - set(model.exchanges) \
         - set(find_biomass_reaction(model))
     for rxn in transport_rxn_candidates:
-        find_transport_reactions_with_formulae
-        find_transport_reactions_with_annotations
+        find_transport_reactions_with_formulae(model, rxn, transport_reactions)
+        find_transport_reactions_with_annotations(model, rxn,
+                                                  transport_reactions)
 
 
-def find_transport_reactions_with_formulae(model, rxn):
+def find_transport_reactions_with_formulae(model, rxn, transport_reactions):
     """
     Return a list of all transport reactions.
 
@@ -188,10 +189,8 @@ def find_transport_reactions_with_formulae(model, rxn):
             rxn not in find_biomass_reaction(model):
         transport_reactions.append(rxn)
 
-    return transport_reactions
 
-
-def find_transport_reactions_with_annotations(model, rxn):
+def find_transport_reactions_with_annotations(model, rxn, transport_reactions):
     """
     Return a list of all transport reactions.
 
@@ -210,7 +209,6 @@ def find_transport_reactions_with_annotations(model, rxn):
     This function will not identify transport via the PTS System.
 
     """
-    transport_reactions = []
     reactants = set([(k, tuple(v)) for met in rxn.reactants
                      for k, v in iteritems(met.annotation)
                      if met.id is not "H"])
@@ -225,9 +223,7 @@ def find_transport_reactions_with_annotations(model, rxn):
     # charges effecting a change in protonation) are weeded out.
     transported_mets = reactants & products
     if len(transported_mets) > 0:
-        transport_reactions.append[rxn]
-
-    return transport_reactions
+        transport_reactions.append(rxn)
 
 
 def find_converting_reactions(model, pair):

--- a/memote/support/helpers.py
+++ b/memote/support/helpers.py
@@ -141,7 +141,7 @@ def find_transport_reactions(model):
         pass
 
 
-def find_transport_reactions_with_formulae(model):
+def find_transport_reactions_with_formulae(model, rxn):
     """
     Return a list of all transport reactions.
 
@@ -161,37 +161,36 @@ def find_transport_reactions_with_formulae(model):
 
     """
     transport_reactions = []
-    for rxn in model.reactions:
-        # Collecting criteria to classify transporters by.
-        rxn_reactants = set([met.formula for met in rxn.reactants])
-        rxn_products = set([met.formula for met in rxn.products])
-        # Looking for formulas that stay the same on both side of the reaction.
-        transported_mets = \
-            [formula for formula in rxn_reactants if formula in rxn_products]
-        # Collect information on the elemental differences between
-        # compartments in the reaction.
-        delta_dicts = find_transported_elements(rxn)
-        non_zero_array = [v for (k, v) in iteritems(delta_dicts) if v != 0]
-        # Weeding out reactions such as oxidoreductases where no net
-        # transport of Hydrogen is occurring, but rather just an exchange of
-        # electrons or charges effecting a change in protonation.
-        if set(transported_mets) != set('H') and list(
-            delta_dicts.keys()
-        ) == ['H']:
-            pass
-        # All other reactions for which the amount of transported elements is
-        # not zero, which are not part of the model's exchange nor
-        # biomass reactions, are defined as transport reactions.
-        # This includes reactions where the transported metabolite reacts with
-        # a carrier molecule.
-        elif sum(non_zero_array) and rxn not in model.exchanges and \
-                rxn not in find_biomass_reaction(model):
-            transport_reactions.append(rxn)
+    # Collecting criteria to classify transporters by.
+    rxn_reactants = set([met.formula for met in rxn.reactants])
+    rxn_products = set([met.formula for met in rxn.products])
+    # Looking for formulas that stay the same on both side of the reaction.
+    transported_mets = \
+        [formula for formula in rxn_reactants if formula in rxn_products]
+    # Collect information on the elemental differences between
+    # compartments in the reaction.
+    delta_dicts = find_transported_elements(rxn)
+    non_zero_array = [v for (k, v) in iteritems(delta_dicts) if v != 0]
+    # Weeding out reactions such as oxidoreductases where no net
+    # transport of Hydrogen is occurring, but rather just an exchange of
+    # electrons or charges effecting a change in protonation.
+    if set(transported_mets) != set('H') and list(
+        delta_dicts.keys()
+    ) == ['H']:
+        pass
+    # All other reactions for which the amount of transported elements is
+    # not zero, which are not part of the model's exchange nor
+    # biomass reactions, are defined as transport reactions.
+    # This includes reactions where the transported metabolite reacts with
+    # a carrier molecule.
+    elif sum(non_zero_array) and rxn not in model.exchanges and \
+            rxn not in find_biomass_reaction(model):
+        transport_reactions.append(rxn)
 
     return transport_reactions
 
 
-def find_transport_reactions_with_annotations(model):
+def find_transport_reactions_with_annotations(model, rxn):
     """
     Return a list of all transport reactions.
 
@@ -211,22 +210,21 @@ def find_transport_reactions_with_annotations(model):
 
     """
     transport_reactions = []
-    for rxn in model.reactions:
-        reactants = set([(k, tuple(v)) for met in rxn.reactants
-                         for k, v in iteritems(met.annotation)
-                         if met.id is not "H"])
-        products = set([(k, tuple(v)) for met in rxn.products
-                        for k, v in iteritems(met.annotation)
-                        if met.id is not "H"])
-        # Find intersection between reactant annotations and
-        # product annotations to find common metabolites between them,
-        # satisfying the requirements for a transport reaction. Reactions such
-        # as those involving oxidoreductases (where no net transport of
-        # Hydrogen is occurring, but rather just an exchange of electrons or
-        # charges effecting a change in protonation) are weeded out.
-        transported_mets = reactants & products
-        if len(transported_mets) > 0:
-            transport_reactions.append[rxn]
+    reactants = set([(k, tuple(v)) for met in rxn.reactants
+                     for k, v in iteritems(met.annotation)
+                     if met.id is not "H"])
+    products = set([(k, tuple(v)) for met in rxn.products
+                    for k, v in iteritems(met.annotation)
+                    if met.id is not "H"])
+    # Find intersection between reactant annotations and
+    # product annotations to find common metabolites between them,
+    # satisfying the requirements for a transport reaction. Reactions such
+    # as those involving oxidoreductases (where no net transport of
+    # Hydrogen is occurring, but rather just an exchange of electrons or
+    # charges effecting a change in protonation) are weeded out.
+    transported_mets = reactants & products
+    if len(transported_mets) > 0:
+        transport_reactions.append[rxn]
 
     return transport_reactions
 

--- a/memote/support/helpers.py
+++ b/memote/support/helpers.py
@@ -179,7 +179,7 @@ def find_transport_reactions(model):
 
 def is_transport_reaction_formulae(rxn):
     """
-    True if rxn is a transport reaction (from formulae), False otherwise.
+    Return boolean given if rxn is a transport reaction (from formulae).
 
     Parameters
     ----------
@@ -221,7 +221,7 @@ def is_transport_reaction_formulae(rxn):
 
 def is_transport_reaction_annotations(rxn):
     """
-    True if rxn is a transport reaction (from annotations), False otherwise.
+    Return boolean given if rxn is a transport reaction (from annotations).
 
     Parameters
     ----------

--- a/memote/support/helpers.py
+++ b/memote/support/helpers.py
@@ -165,6 +165,46 @@ def find_transport_reactions(model):
     return transport_reactions
 
 
+def find_transport_reactions_with_annotations(model):
+    """
+    Return a list of all transport reactions.
+
+    Parameters
+    ----------
+    model : cobra.Model
+        The metabolic model under investigation.
+
+    Notes
+    -----
+    A transport reaction is defined as follows:
+    1. It contains metabolites from at least 2 compartments and
+    2. at least 1 metabolite undergoes no chemical reaction, i.e.,
+    the formula stays the same on both sides of the equation.
+
+    This function will not identify transport via the PTS System.
+
+    """
+    transport_reactions = []
+    for rxn in model.reactions:
+        reactants = set([(k, tuple(v)) for met in rxn.reactants
+                         for k, v in iteritems(met.annotation)
+                         if met.id is not "H"])
+        products = set([(k, tuple(v)) for met in rxn.products
+                        for k, v in iteritems(met.annotation)
+                        if met.id is not "H"])
+        # Find intersection between reactant annotations and
+        # product annotations to find common metabolites between them,
+        # satisfying the requirements for a transport reaction. Reactions such
+        # as those involving oxidoreductases (where no net transport of
+        # Hydrogen is occurring, but rather just an exchange of electrons or
+        # charges effecting a change in protonation) are weeded out.
+        transported_mets = reactants & products
+        if len(transported_mets) > 0:
+            transport_reactions.append[rxn]
+
+    return transport_reactions
+
+
 def find_converting_reactions(model, pair):
     """
     Find all reactions which convert a given metabolite pair.

--- a/memote/support/helpers.py
+++ b/memote/support/helpers.py
@@ -156,7 +156,10 @@ def find_transport_reactions(model):
     sbo_matches = set([rxn for rxn in transport_rxn_candidates if
                        rxn.annotation is not None and
                        'SBO' in rxn.annotation and
-                       (rxn.annotation['SBO'] == 'SBO:0000655' or
+                       (rxn.annotation['SBO'] == 'SBO:0000185' or
+                        rxn.annotation['SBO'] == 'SBO:0000588' or
+                        rxn.annotation['SBO'] == 'SBO:0000587' or
+                        rxn.annotation['SBO'] == 'SBO:0000655' or
                         rxn.annotation['SBO'] == 'SBO:0000654' or
                         rxn.annotation['SBO'] == 'SBO:0000660' or
                         rxn.annotation['SBO'] == 'SBO:0000659' or

--- a/memote/support/helpers.py
+++ b/memote/support/helpers.py
@@ -142,24 +142,23 @@ def find_transport_reactions(model):
         find_transport_reactions_with_annotations(model, rxn,
                                                   transport_reactions)
 
+    return set(transport_reactions)
+
 
 def find_transport_reactions_with_formulae(model, rxn, transport_reactions):
     """
-    Return a list of all transport reactions.
+    Append to a list of all transport reactions if rxn is a transport reaction.
 
     Parameters
     ----------
     model : cobra.Model
         The metabolic model under investigation.
 
-    Notes
-    -----
-    A transport reaction is defined as follows:
-    1. It contains metabolites from at least 2 compartments and
-    2. at least 1 metabolite undergoes no chemical reaction, i.e.,
-    the formula stays the same on both sides of the equation.
+    rxn: cobra.Reaction
+        The metabolic reaction under investigation.
 
-    This function will not identify transport via the PTS System.
+    transport_reactions: list
+        A list of all transport reactions.
 
     """
     transport_reactions = []
@@ -192,21 +191,18 @@ def find_transport_reactions_with_formulae(model, rxn, transport_reactions):
 
 def find_transport_reactions_with_annotations(model, rxn, transport_reactions):
     """
-    Return a list of all transport reactions.
+    Append to a list of all transport reactions if rxn is a transport reaction.
 
     Parameters
     ----------
     model : cobra.Model
         The metabolic model under investigation.
 
-    Notes
-    -----
-    A transport reaction is defined as follows:
-    1. It contains metabolites from at least 2 compartments and
-    2. at least 1 metabolite undergoes no chemical reaction, i.e.,
-    the formula stays the same on both sides of the equation.
+    rxn: cobra.Reaction
+        The metabolic reaction under investigation.
 
-    This function will not identify transport via the PTS System.
+    transport_reactions: list
+        A list of all transport reactions.
 
     """
     reactants = set([(k, tuple(v)) for met in rxn.reactants

--- a/memote/support/helpers.py
+++ b/memote/support/helpers.py
@@ -161,7 +161,6 @@ def find_transport_reactions_with_formulae(model, rxn, transport_reactions):
         A list of all transport reactions.
 
     """
-    transport_reactions = []
     # Collecting criteria to classify transporters by.
     rxn_reactants = set([met.formula for met in rxn.reactants])
     rxn_products = set([met.formula for met in rxn.products])
@@ -207,10 +206,10 @@ def find_transport_reactions_with_annotations(model, rxn, transport_reactions):
     """
     reactants = set([(k, tuple(v)) for met in rxn.reactants
                      for k, v in iteritems(met.annotation)
-                     if met.id is not "H"])
+                     if met.id is not "H" and k is not None and v is not None])
     products = set([(k, tuple(v)) for met in rxn.products
                     for k, v in iteritems(met.annotation)
-                    if met.id is not "H"])
+                    if met.id is not "H" and k is not None and v is not None])
     # Find intersection between reactant annotations and
     # product annotations to find common metabolites between them,
     # satisfying the requirements for a transport reaction. Reactions such

--- a/memote/support/helpers.py
+++ b/memote/support/helpers.py
@@ -131,8 +131,6 @@ def find_transport_reactions(model):
     2. at least 1 metabolite undergoes no chemical reaction, i.e.,
     the formula stays the same on both sides of the equation.
 
-    This function will not identify transport via the PTS System.
-
     """
     transport_reactions = []
     transport_rxn_candidates = set(model.reactions) - set(model.exchanges) \

--- a/memote/support/helpers.py
+++ b/memote/support/helpers.py
@@ -129,21 +129,24 @@ def find_transport_reactions(model):
     A transport reaction is defined as follows:
     1. It contains metabolites from at least 2 compartments and
     2. at least 1 metabolite undergoes no chemical reaction, i.e.,
-    the formula stays the same on both sides of the equation.
+    the formula and/or annotation stays the same on both sides of the equation.
 
-    A notable exception is transport via PTS, which is defined as follows:
-    1. The transported metabolite(s) come from the ``e`` compartment into the
-    ``c`` compartment and
-    2. the metabolite in the ``e`` compartment enters into the ``c``
-    compartment through the exchange of a phosphate.
+    A notable exception is transport via PTS, which also contains the following
+    restriction:
+    3. The transported metabolite(s) are transported into a compartment through
+    the exchange of a phosphate.
 
     An example of tranport via PTS would be
     pep(c) + glucose(e) -> glucose-6-phosphate(c) + pyr(c)
 
-    Transport via PTS is only detected when a formula field exists for all
-    metabolites in a particular reaction. If this is not the case, transport
-    reactions are identified through annotations, which cannot detect transport
-    via PTS.
+    Reactions similar to transport via PTS (referred to as "modified transport
+    reactions") follow a similar pattern:
+    A[x] + B-R[y] -> A-R[y] + B[y]
+
+    Such modified transport reactions can be detected, but only when a formula
+    field exists for all metabolites in a particular reaction. If this is not
+    the case, transport reactions are identified through annotations, which
+    cannot detect modified tranport reactions.
 
     """
     transport_reactions = []

--- a/memote/support/helpers.py
+++ b/memote/support/helpers.py
@@ -168,9 +168,8 @@ def find_transport_reactions(model):
         if (None not in rxn_metabolites) or (len(rxn_metabolites) != 0):
             find_transport_reactions_with_formulae(
                 model, rxn, transport_reactions)
-        else:
-            find_transport_reactions_with_annotations(
-                model, rxn, transport_reactions)
+        find_transport_reactions_with_annotations(
+            model, rxn, transport_reactions)
 
     return set(transport_reactions)
 

--- a/memote/support/helpers.py
+++ b/memote/support/helpers.py
@@ -215,8 +215,7 @@ def find_transport_reactions_with_formulae(model, rxn, transport_reactions):
     # biomass reactions, are defined as transport reactions.
     # This includes reactions where the transported metabolite reacts with
     # a carrier molecule.
-    elif sum(non_zero_array) and rxn not in model.exchanges and \
-            rxn not in find_biomass_reaction(model):
+    elif sum(non_zero_array):
         transport_reactions.append(rxn)
 
 

--- a/memote/support/helpers.py
+++ b/memote/support/helpers.py
@@ -165,11 +165,11 @@ def find_transport_reactions(model):
     for rxn in transport_rxn_candidates:
         # Check if metabolites have formula field
         rxn_metabolites = set([met.formula for met in rxn.metabolites])
-        if None in rxn_metabolites or len(rxn_metabolites) == 0:
-            find_transport_reactions_with_annotations(
+        if (None not in rxn_metabolites) or (len(rxn_metabolites) != 0):
+            find_transport_reactions_with_formulae(
                 model, rxn, transport_reactions)
         else:
-            find_transport_reactions_with_formulae(
+            find_transport_reactions_with_annotations(
                 model, rxn, transport_reactions)
 
     return set(transport_reactions)

--- a/memote/support/helpers.py
+++ b/memote/support/helpers.py
@@ -134,10 +134,10 @@ def find_transport_reactions(model):
     A notable exception is transport via PTS, which is defined as follows:
     1. The transported metabolite(s) come from the ``e`` compartment into the
     ``c`` compartment and
-    2. the metabolite in the ``e`` compartment enters into the ``c`` 
+    2. the metabolite in the ``e`` compartment enters into the ``c``
     compartment through the exchange of a phosphate.
 
-    An example of tranport via PTS would be 
+    An example of tranport via PTS would be
     pep(c) + glucose(e) -> glucose-6-phosphate(c) + pyr(c)
 
     Transport via PTS is only detected when a formula field exists for all

--- a/memote/support/helpers.py
+++ b/memote/support/helpers.py
@@ -149,6 +149,19 @@ def find_transport_reactions(model):
     transport_reactions = []
     transport_rxn_candidates = set(model.reactions) - set(model.exchanges) \
         - set(find_biomass_reaction(model))
+    # Add all labeled transport reactions
+    sbo_matches = set([rxn for rxn in transport_rxn_candidates if
+                       rxn.annotation is not None and
+                       'SBO' in rxn.annotation and
+                       (rxn.annotation['SBO'] == 'SBO:0000655' or
+                        rxn.annotation['SBO'] == 'SBO:0000654' or
+                        rxn.annotation['SBO'] == 'SBO:0000660' or
+                        rxn.annotation['SBO'] == 'SBO:0000659' or
+                        rxn.annotation['SBO'] == 'SBO:0000657' or
+                        rxn.annotation['SBO'] == 'SBO:0000658')])
+    if len(sbo_matches) > 0:
+        transport_reactions += list(sbo_matches)
+    # Find unlabeled transport reactions via formula or annotation checks
     for rxn in transport_rxn_candidates:
         # Check if metabolites have formula field
         rxn_metabolites = set([met.formula for met in rxn.metabolites])

--- a/memote/support/helpers.py
+++ b/memote/support/helpers.py
@@ -137,6 +137,8 @@ def find_transport_reactions(model):
     transport_reactions = []
     transport_rxn_candidates = set(model.reactions) - set(model.exchanges) \
         - set(find_biomass_reaction(model))
+    for rxn in transport_rxn_candidates:
+        pass
 
 
 def find_transport_reactions_with_formulae(model):

--- a/memote/support/helpers.py
+++ b/memote/support/helpers.py
@@ -168,16 +168,16 @@ def find_transport_reactions(model):
     for rxn in transport_rxn_candidates:
         # Check if metabolites have formula field
         rxn_metabolites = set([met.formula for met in rxn.metabolites])
-        if (None not in rxn_metabolites) or (len(rxn_metabolites) != 0):
-            find_transport_reactions_with_formulae(
-                model, rxn, transport_reactions)
-        find_transport_reactions_with_annotations(
-            model, rxn, transport_reactions)
+        if (None not in rxn_metabolites) and (len(rxn_metabolites) != 0):
+            if is_transport_reaction_formulae(rxn):
+                transport_reactions.append(rxn)
+        if is_transport_reaction_annotations(rxn):
+            transport_reactions.append(rxn)
 
     return set(transport_reactions)
 
 
-def find_transport_reactions_with_formulae(model, rxn, transport_reactions):
+def is_transport_reaction_formulae(rxn):
     """
     Append to a list of all transport reactions if rxn is a transport reaction.
 
@@ -216,10 +216,10 @@ def find_transport_reactions_with_formulae(model, rxn, transport_reactions):
     # This includes reactions where the transported metabolite reacts with
     # a carrier molecule.
     elif sum(non_zero_array):
-        transport_reactions.append(rxn)
+        return True
 
 
-def find_transport_reactions_with_annotations(model, rxn, transport_reactions):
+def is_transport_reaction_annotations(rxn):
     """
     Append to a list of all transport reactions if rxn is a transport reaction.
 
@@ -249,7 +249,7 @@ def find_transport_reactions_with_annotations(model, rxn, transport_reactions):
     # charges effecting a change in protonation) are weeded out.
     transported_mets = reactants & products
     if len(transported_mets) > 0:
-        transport_reactions.append(rxn)
+        return True
 
 
 def find_converting_reactions(model, pair):

--- a/memote/support/helpers.py
+++ b/memote/support/helpers.py
@@ -179,7 +179,7 @@ def find_transport_reactions(model):
 
 def is_transport_reaction_formulae(rxn):
     """
-    Append to a list of all transport reactions if rxn is a transport reaction.
+    True if rxn is a transport reaction (from formulae), False otherwise.
 
     Parameters
     ----------
@@ -221,7 +221,7 @@ def is_transport_reaction_formulae(rxn):
 
 def is_transport_reaction_annotations(rxn):
     """
-    Append to a list of all transport reactions if rxn is a transport reaction.
+    True if rxn is a transport reaction (from annotations), False otherwise.
 
     Parameters
     ----------

--- a/memote/support/helpers.py
+++ b/memote/support/helpers.py
@@ -138,7 +138,8 @@ def find_transport_reactions(model):
     transport_rxn_candidates = set(model.reactions) - set(model.exchanges) \
         - set(find_biomass_reaction(model))
     for rxn in transport_rxn_candidates:
-        pass
+        find_transport_reactions_with_formulae
+        find_transport_reactions_with_annotations
 
 
 def find_transport_reactions_with_formulae(model, rxn):

--- a/memote/support/helpers.py
+++ b/memote/support/helpers.py
@@ -115,6 +115,30 @@ def find_transported_elements(rxn):
     return delta_dict
 
 
+def find_transport_reactions(model):
+    """
+    Return a list of all transport reactions.
+
+    Parameters
+    ----------
+    model : cobra.Model
+        The metabolic model under investigation.
+
+    Notes
+    -----
+    A transport reaction is defined as follows:
+    1. It contains metabolites from at least 2 compartments and
+    2. at least 1 metabolite undergoes no chemical reaction, i.e.,
+    the formula stays the same on both sides of the equation.
+
+    This function will not identify transport via the PTS System.
+
+    """
+    transport_reactions = []
+    transport_rxn_candidates = set(model.reactions) - set(model.exchanges) \
+        - set(find_biomass_reaction(model))
+
+
 def find_transport_reactions_with_formulae(model):
     """
     Return a list of all transport reactions.

--- a/memote/support/helpers.py
+++ b/memote/support/helpers.py
@@ -115,7 +115,7 @@ def find_transported_elements(rxn):
     return delta_dict
 
 
-def find_transport_reactions(model):
+def find_transport_reactions_with_formulae(model):
     """
     Return a list of all transport reactions.
 

--- a/memote/support/helpers.py
+++ b/memote/support/helpers.py
@@ -146,7 +146,7 @@ def find_transport_reactions(model):
 
     Reactions similar to transport via PTS (referred to as "modified transport
     reactions") follow a similar pattern:
-    A[x] + B-R[y] -> A-R[y] + B[y]
+    A(x) + B-R(y) -> A-R(y) + B(y)
 
     Such modified transport reactions can be detected, but only when a formula
     field exists for all metabolites in a particular reaction. If this is not
@@ -167,8 +167,8 @@ def find_transport_reactions(model):
     # Find unlabeled transport reactions via formula or annotation checks
     for rxn in transport_rxn_candidates:
         # Check if metabolites have formula field
-        rxn_metabolites = set([met.formula for met in rxn.metabolites])
-        if (None not in rxn_metabolites) and (len(rxn_metabolites) != 0):
+        rxn_mets = set([met.formula for met in rxn.metabolites])
+        if (None not in rxn_mets) and (len(rxn_mets) != 0):
             if is_transport_reaction_formulae(rxn):
                 transport_reactions.append(rxn)
         if is_transport_reaction_annotations(rxn):

--- a/memote/support/helpers.py
+++ b/memote/support/helpers.py
@@ -476,7 +476,7 @@ def find_interchange_biomass_reactions(model, biomass=None):
     """
     # exchanges in this case also refer to sink and demand reactions
     exchanges = set(model.exchanges)
-    transporters = set(find_transport_reactions(model))
+    transporters = find_transport_reactions(model)
     if biomass is None:
         biomass = set(find_biomass_reaction(model))
     return exchanges | transporters | biomass

--- a/memote/support/sbo.py
+++ b/memote/support/sbo.py
@@ -45,7 +45,7 @@ def find_components_without_sbo_terms(model, components):
             elem.annotation is None or 'SBO' not in elem.annotation]
 
 
-def check_component_for_specific_sbo_terms(items, term):
+def check_component_for_specific_sbo_term(items, term):
     """
     Identify model components that lack a specific SBO term(s).
 

--- a/memote/support/sbo.py
+++ b/memote/support/sbo.py
@@ -54,8 +54,9 @@ def check_component_for_specific_sbo_term(items, term):
     items : list
         A list of model components i.e. reactions to be checked for a specific
         SBO term.
-    term : str
-        A string denoting a valid SBO term matching the regex '^SBO:\d{7}$'.
+    term : str or list of str
+        A string denoting a valid SBO term matching the regex '^SBO:\d{7}$'
+        or a list containing such string elements.
 
     Returns
     -------
@@ -66,4 +67,4 @@ def check_component_for_specific_sbo_term(items, term):
     return [elem for elem in items if
             elem.annotation is None or
             'SBO' not in elem.annotation or
-            elem.annotation['SBO'] != term]
+            elem.annotation['SBO'] not in term]

--- a/memote/support/sbo.py
+++ b/memote/support/sbo.py
@@ -45,9 +45,9 @@ def find_components_without_sbo_terms(model, components):
             elem.annotation is None or 'SBO' not in elem.annotation]
 
 
-def check_component_for_specific_sbo_term(items, term):
+def check_component_for_specific_sbo_terms(items, term):
     """
-    Identify model components that lack a specific SBO term.
+    Identify model components that lack a specific SBO term(s).
 
     Parameters
     ----------

--- a/memote/support/syntax.py
+++ b/memote/support/syntax.py
@@ -62,7 +62,7 @@ def find_rxn_id_compartment_suffix(model, suffix):
         the `suffix` appended.
 
     """
-    transport_rxns = set(helpers.find_transport_reactions(model))
+    transport_rxns = helpers.find_transport_reactions(model)
     exchange_demand_rxns = set(model.exchanges)
 
     comp_pattern = re.compile(

--- a/tests/test_for_support/test_for_basic.py
+++ b/tests/test_for_support/test_for_basic.py
@@ -453,7 +453,7 @@ def test_find_constrained_pure_metabolic_reactions(model, num):
 ], indirect=["model"])
 def test_find_constrained_transport_reactions(model, num):
     """Expect num of contrained transport rxns to be identified correctly."""
-    transporters = set(helpers.find_transport_reactions(model))
+    transporters = helpers.find_transport_reactions(model)
     constrained_transporters = set(
         [rxn for rxn in transporters if basic.is_constrained_reaction(rxn)])
     assert len(constrained_transporters) == num

--- a/tests/test_for_support/test_for_helpers.py
+++ b/tests/test_for_support/test_for_helpers.py
@@ -296,6 +296,29 @@ def energy_transfer_annotations(base):
 
 
 @register_with(MODEL_REGISTRY)
+def labeled_reaction(base):
+    """Provide a model with a labeled tranport reaction."""
+    a = cobra.Metabolite("a")
+    b = cobra.Metabolite("b")
+    rxn = cobra.Reaction("rxn")
+    rxn.annotation["SBO"] = "SBO:0000655"
+    rxn.add_metabolites({a: -1, b: 1})
+    base.add_reactions([rxn])
+    return base
+
+
+@register_with(MODEL_REGISTRY)
+def unlabeled_reaction(base):
+    """Provide a model with a labeled tranport reaction."""
+    a = cobra.Metabolite("a")
+    b = cobra.Metabolite("b")
+    rxn = cobra.Reaction("rxn")
+    rxn.add_metabolites({a: -1, b: 1})
+    base.add_reactions([rxn])
+    return base
+
+
+@register_with(MODEL_REGISTRY)
 def converting_reactions(base):
     """Provide a model with a couple of converting reaction."""
     a = cobra.Metabolite("atp_c", compartment="c")
@@ -476,7 +499,9 @@ def biomass_metabolite(base):
     ("energy_transfer_formulae", 0),
     ("energy_transfer_annotations", 0),
     ("phosphotransferase_system_formulae", 1),
-    ("phosphotransferase_system_annotations", 0)
+    ("phosphotransferase_system_annotations", 0),
+    ("labeled_reaction", 1),
+    ("unlabeled_reaction", 0)
 ], indirect=["model"])
 def test_find_transport_reactions(model, num):
     """Expect amount of transporters to be identified correctly."""

--- a/tests/test_for_support/test_for_helpers.py
+++ b/tests/test_for_support/test_for_helpers.py
@@ -52,10 +52,23 @@ def uni_anti_symport_annotations(base):
     met_b = cobra.Metabolite("co2_e", compartment="e")
     met_c = cobra.Metabolite("na_c", compartment="c")
     met_d = cobra.Metabolite("na_e", compartment="e")
-    met_a.annotation["formula"] = "CO2"
-    met_b.annotation["formula"] = "CO2"
-    met_c.annotation["formula"] = "Na"
-    met_d.annotation["formula"] = "Na"
+
+    met_a.annotation["bigg.metabolite"] = "co2"
+    met_a.annotation["metanetx.chemical"] = "MNXM13"
+    met_a.annotation["seed.compound"] = "cpd00011"
+
+    met_b.annotation["bigg.metabolite"] = "co2"
+    met_b.annotation["metanetx.chemical"] = "MNXM13"
+    met_b.annotation["seed.compound"] = "cpd00011"
+
+    met_c.annotation["bigg.metabolite"] = "na1"
+    met_c.annotation["metanetx.chemical"] = "MNXM27"
+    met_c.annotation["seed.compound"] = "cpd00971"
+
+    met_d.annotation["bigg.metabolite"] = "na1"
+    met_d.annotation["metanetx.chemical"] = "MNXM27"
+    met_d.annotation["seed.compound"] = "cpd00971"
+
     uni = cobra.Reaction("UNI")
     uni.add_metabolites({met_a: 1, met_b: -1})
     anti = cobra.Reaction("ANTI")
@@ -93,13 +106,83 @@ def abc_pump_annotations(base):
     h2o = cobra.Metabolite("h2o_c", compartment="c")
     aso_c = cobra.Metabolite("aso3_c", compartment="c")
     aso_e = cobra.Metabolite("aso3_e", compartment="e")
-    atp.annotation["formula"] = "C10H12N5O13P3"
-    adp.annotation["formula"] = "C10H12N5O10P2"
-    h.annotation["formula"] = "H"
-    pi.annotation["formula"] = "HO4P"
-    h2o.annotation["formula"] = "H2O"
-    aso_c.annotation["formula"] = "AsO3"
-    aso_e.annotation["formula"] = "AsO3"
+
+    atp.annotation["bigg.metabolite"] = "atp"
+    atp.annotation["biocyc"] = ["META:ATP", "META:CPD0-1634"]
+    atp.annotation["chebi"] = ["CHEBI:10789", "CHEBI:10841", "CHEBI:13236",
+                               "CHEBI:15422", "CHEBI:22249", "CHEBI:2359",
+                               "CHEBI:237958", "CHEBI:30616", "CHEBI:40938",
+                               "CHEBI:57299"]
+    atp.annotation["kegg.compound"] = "C00002"
+    atp.annotation["kegg.drug"] = "D08646"
+    atp.annotation["metanetx.chemical"] = "MNXM13"
+    atp.annotation["seed.compound"] = "cpd00011"
+
+    adp.annotation["bigg.metabolite"] = "adp"
+    adp.annotation["biocyc"] = ["META:ADP", "META:CPD0-1651"]
+    adp.annotation["chebi"] = ["CHEBI:13222", "CHEBI:16761", "CHEBI:22244",
+                               "CHEBI:2342", "CHEBI:40553", "CHEBI:456216",
+                               "CHEBI:87518"]
+    adp.annotation["kegg.compound"] = ["C00008", "G11113"]
+    adp.annotation["metanetx.chemical"] = "MNXM7"
+    adp.annotation["seed.compound"] = "cpd00008"
+
+    h.annotation["bigg.metabolite"] = "h"
+    h.annotation["biocyc"] = "META:PROTON"
+    h.annotation["chebi"] = ["CHEBI:10744", "CHEBI:13357", "CHEBI:15378",
+                             "CHEBI:24636", "CHEBI:29233", "CHEBI:29234",
+                             "CHEBI:5584"]
+    h.annotation["kegg.compound"] = "C00080"
+    h.annotation["metanetx.chemical"] = "MNXM1"
+    h.annotation["seed.compound"] = "cpd00067"
+
+    pi.annotation["bigg.metabolite"] = "pi"
+    pi.annotation["biocyc"] = ["META:CPD-16459", "META:CPD-9010",
+                               "META:PHOSPHATE-GROUP", "META:Pi"]
+    pi.annotation["chebi"] = ["CHEBI:14791", "CHEBI:18367", "CHEBI:26078",
+                              "CHEBI:29137", "CHEBI:29139", "CHEBI:35780",
+                              "CHEBI:39739", "CHEBI:39745", "CHEBI:43470",
+                              "CHEBI:43474", "CHEBI:45024", "CHEBI:7793"]
+    pi.annotation["kegg.compound"] = ["C00009", "C13558"]
+    pi.annotation["kegg.drug"] = "D05467"
+    pi.annotation["metanetx.chemical"] = "MNXM9"
+    pi.annotation["seed.compound"] = ["cpd00009", "cpd27787"]
+
+    h2o.annotation["bigg.metabolite"] = "h2o"
+    h2o.annotation["biocyc"] = ["META:CPD-15815", "META:HYDROXYL-GROUP", 
+                                "META:OH", "META:OXONIUM", "META:WATER"]
+    h2o.annotation["chebi"] = ["CHEBI:10743", "CHEBI:13352", "CHEBI:13365",
+                               "CHEBI:13419", "CHEBI:15377", "CHEBI:16234",
+                               "CHEBI:27313", "CHEBI:29356", "CHEBI:29373",
+                               "CHEBI:29374", "CHEBI:29375", "CHEBI:29412",
+                               "CHEBI:30490", "CHEBI:33806", "CHEBI:33811",
+                               "CHEBI:33813", "CHEBI:41979", "CHEBI:41981",
+                               "CHEBI:42043", "CHEBI:42857", "CHEBI:43228",
+                               "CHEBI:44292", "CHEBI:44641", "CHEBI:44701",
+                               "CHEBI:44819", "CHEBI:5585", "CHEBI:5594"]
+    h2o.annotation["kegg.compound"] = [ "C00001", "C01328", "C18714"]
+    h2o.annotation["kegg.drug"] = ["D00001", "D03703", "D06322"]
+    h2o.annotation["metanetx.chemical"] = "MNXM2"
+    h2o.annotation["seed.compound"] = ["cpd00001", "cpd15275", "cpd27222"]
+
+    aso_c.annotation["bigg.metabolite"] = "aso3"
+    aso_c.annotation["biocyc"] = ["META:CPD0-2040", "META:CPD-763"]
+    aso_c.annotation["chebi"] = ["CHEBI:13857", "CHEBI:22635", "CHEBI:2846",
+                                 "CHEBI:29242", "CHEBI:29243", "CHEBI:29866",
+                                 "CHEBI:49899", "CHEBI:49900"]
+    aso_c.annotation["kegg.compound"] = "C06697"
+    aso_c.annotation["metanetx.chemical"] = "MNXM658"
+    aso_c.annotation["seed.compound"] = ["cpd04098", "cpd26385"]
+
+    aso_e.annotation["bigg.metabolite"] = "aso3"
+    aso_e.annotation["biocyc"] = ["META:CPD0-2040", "META:CPD-763"]
+    aso_e.annotation["chebi"] = ["CHEBI:13857", "CHEBI:22635", "CHEBI:2846",
+                                 "CHEBI:29242", "CHEBI:29243", "CHEBI:29866",
+                                 "CHEBI:49899", "CHEBI:49900"]
+    aso_e.annotation["kegg.compound"] = "C06697"
+    aso_e.annotation["metanetx.chemical"] = "MNXM658"
+    aso_e.annotation["seed.compound"] = ["cpd04098", "cpd26385"]
+
     pump = cobra.Reaction("PUMP")
     pump.add_metabolites({aso_c: -1, atp: -1, h2o: -1,
                           adp: 1, h: 1, pi: 1, aso_e: 1})
@@ -132,12 +215,74 @@ def proton_pump_annotations(base):
     pi = cobra.Metabolite("pi_c", formula='HO4P', compartment="c")
     h2o = cobra.Metabolite("h2o_c", formula='H2O', compartment="c")
     h_p = cobra.Metabolite("h_p", formula='H', compartment="p")
-    atp.annotation["formula"] = "C10H12N5O13P3"
-    adp.annotation["formula"] = "C10H12N5O10P2"
-    h_c.annotation["formula"] = "H"
-    pi.annotation["formula"] = "HO4P"
-    h2o.annotation["formula"] = "H2O"
-    h_p.annotation["formula"] = "H"
+
+    atp.annotation["bigg.metabolite"] = "atp"
+    atp.annotation["biocyc"] = ["META:ATP", "META:CPD0-1634"]
+    atp.annotation["chebi"] = ["CHEBI:10789", "CHEBI:10841", "CHEBI:13236",
+                               "CHEBI:15422", "CHEBI:22249", "CHEBI:2359",
+                               "CHEBI:237958", "CHEBI:30616", "CHEBI:40938",
+                               "CHEBI:57299"]
+    atp.annotation["kegg.compound"] = "C00002"
+    atp.annotation["kegg.drug"] = "D08646"
+    atp.annotation["metanetx.chemical"] = "MNXM13"
+    atp.annotation["seed.compound"] = "cpd00011"
+
+    adp.annotation["bigg.metabolite"] = "adp"
+    adp.annotation["biocyc"] = ["META:ADP", "META:CPD0-1651"]
+    adp.annotation["chebi"] = ["CHEBI:13222", "CHEBI:16761", "CHEBI:22244",
+                               "CHEBI:2342", "CHEBI:40553", "CHEBI:456216",
+                               "CHEBI:87518"]
+    adp.annotation["kegg.compound"] = ["C00008", "G11113"]
+    adp.annotation["metanetx.chemical"] = "MNXM7"
+    adp.annotation["seed.compound"] = "cpd00008"
+
+    h_c.annotation["bigg.metabolite"] = "h"
+    h_c.annotation["biocyc"] = "META:PROTON"
+    h_c.annotation["chebi"] = ["CHEBI:10744", "CHEBI:13357", "CHEBI:15378",
+                             "CHEBI:24636", "CHEBI:29233", "CHEBI:29234",
+                             "CHEBI:5584"]
+    h_c.annotation["kegg.compound"] = "C00080"
+    h_c.annotation["metanetx.chemical"] = "MNXM1"
+    h_c.annotation["seed.compound"] = "cpd00067"
+
+    pi.annotation["bigg.metabolite"] = "pi"
+    pi.annotation["biocyc"] = ["META:CPD-16459", "META:CPD-9010",
+                               "META:PHOSPHATE-GROUP", "META:Pi"]
+    pi.annotation["chebi"] = ["CHEBI:14791", "CHEBI:18367", "CHEBI:26078",
+                              "CHEBI:29137", "CHEBI:29139", "CHEBI:35780",
+                              "CHEBI:39739", "CHEBI:39745", "CHEBI:43470",
+                              "CHEBI:43474", "CHEBI:45024", "CHEBI:7793"]
+    pi.annotation["kegg.compound"] = ["C00009", "C13558"]
+    pi.annotation["kegg.drug"] = "D05467"
+    pi.annotation["metanetx.chemical"] = "MNXM9"
+    pi.annotation["seed.compound"] = ["cpd00009", "cpd27787"]
+
+    h2o.annotation["bigg.metabolite"] = "h2o"
+    h2o.annotation["biocyc"] = ["META:CPD-15815", "META:HYDROXYL-GROUP", 
+                                "META:OH", "META:OXONIUM", "META:WATER"]
+    h2o.annotation["chebi"] = ["CHEBI:10743", "CHEBI:13352", "CHEBI:13365",
+                               "CHEBI:13419", "CHEBI:15377", "CHEBI:16234",
+                               "CHEBI:27313", "CHEBI:29356", "CHEBI:29373",
+                               "CHEBI:29374", "CHEBI:29375", "CHEBI:29412",
+                               "CHEBI:30490", "CHEBI:33806", "CHEBI:33811",
+                               "CHEBI:33813", "CHEBI:41979", "CHEBI:41981",
+                               "CHEBI:42043", "CHEBI:42857", "CHEBI:43228",
+                               "CHEBI:44292", "CHEBI:44641", "CHEBI:44701",
+                               "CHEBI:44819", "CHEBI:5585", "CHEBI:5594"]
+    h2o.annotation["kegg.compound"] = [ "C00001", "C01328", "C18714"]
+    h2o.annotation["kegg.drug"] = ["D00001", "D03703", "D06322"]
+    h2o.annotation["metanetx.chemical"] = "MNXM2"
+    h2o.annotation["seed.compound"] = ["cpd00001", "cpd15275", "cpd27222"]
+
+    h_p.annotation["bigg.metabolite"] = "h"
+    h_p.annotation["biocyc"] = "META:PROTON"
+    h_p.annotation["chebi"] = ["CHEBI:10744", "CHEBI:13357", "CHEBI:15378",
+                             "CHEBI:24636", "CHEBI:29233", "CHEBI:29234",
+                             "CHEBI:5584"]
+    h_p.annotation["kegg.compound"] = "C00080"
+    h_p.annotation["metanetx.chemical"] = "MNXM1"
+    h_p.annotation["seed.compound"] = "cpd00067"
+
     pump = cobra.Reaction("PUMP")
     pump.add_metabolites({h_c: -4, adp: -1, pi: -1,
                           atp: 1, h2o: 1, h_p: 3})
@@ -167,10 +312,44 @@ def phosphotransferase_system_annotations(base):
     pyr = cobra.Metabolite("pyr_c", compartment="c")
     malt = cobra.Metabolite(",malt_e", compartment="e")
     malt6p = cobra.Metabolite("malt6p_c", compartment="c")
-    pep.annotation["formula"] = "C3H2O6P"
-    pyr.annotation["formula"] = "C3H3O3"
-    malt.annotation["formula"] = "C12H22O11"
-    malt6p.annotation["formula"] = "C12H21O14P"
+
+    pep.annotation["bigg.metabolite"] = "pep"
+    pep.annotation["biocyc"] = "META:PHOSPHO-ENOL-PYRUVATE"
+    pep.annotation["chebi"] = ["CHEBI:14812", "CHEBI:18021", "CHEBI:26054",
+                               "CHEBI:26055", "CHEBI:44894", "CHEBI:44897",
+                               "CHEBI:58702", "CHEBI:8147"]
+    pep.annotation["kegg.compound"] = "C00074"
+    pep.annotation["metanetx.chemical"] = "MNXM73"
+    pep.annotation["seed.compound"] = "cpd00061"
+
+    pyr.annotation["bigg.metabolite"] = "pyr"
+    pyr.annotation["biocyc"] = "META:PYRUVATE"
+    pyr.annotation["chebi"] = ["CHEBI:14987", "CHEBI:15361", "CHEBI:26462",
+                               "CHEBI:26466", "CHEBI:32816", "CHEBI:45253",
+                               "CHEBI:86354", "CHEBI:8685"]
+    pyr.annotation["kegg.compound"] = "C00022"
+    pyr.annotation["metanetx.chemical"] = "MNXM23"
+    pyr.annotation["seed.compound"] = "cpd00020"
+
+    malt.annotation["bigg.metabolite"] = "malt"
+    malt.annotation["biocyc"] = ["META:ALPHA-MALTOSE", "META:MALTOSE"]
+    malt.annotation["chebi"] = ["CHEBI:10300", "CHEBI:12340", "CHEBI:14568",
+                                "CHEBI:17306", "CHEBI:18167", "CHEBI:22463",
+                                "CHEBI:25144", "CHEBI:43893", "CHEBI:6668"]
+    malt.annotation["kegg.compound"] = ["C00208", "C00897", "G00275"]
+    malt.annotation["kegg.drug"] = "D00044"
+    malt.annotation["metanetx.chemical"] = "MNXM165"
+    malt.annotation["seed.compound"] = ["cpd00179", "cpd00665"]
+
+    malt6p.annotation["bigg.metabolite"] = "malt6p"
+    malt6p.annotation["biocyc"] = ["META:CPD-1244", "META:CPD-15982"]
+    malt6p.annotation["chebi"] = ["CHEBI:111006", "CHEBI:14569", "CHEBI:15703",
+                                  "CHEBI:25142", "CHEBI:57478", "CHEBI:6669",
+                                  "CHEBI:6670", "CHEBI:91177"]
+    malt6p.annotation["kegg.compound"] = ["C02995", "G10519"]
+    malt6p.annotation["metanetx.chemical"] = "MNXM2394"
+    malt6p.annotation["seed.compound"] = "cpd01919"
+
     pst = cobra.Reaction("PST")
     pst.add_metabolites({pep: -1, malt: -1, pyr: 1, malt6p: 1})
     base.add_reactions([pst])

--- a/tests/test_for_support/test_for_helpers.py
+++ b/tests/test_for_support/test_for_helpers.py
@@ -108,7 +108,7 @@ def abc_pump_annotations(base):
 
 
 @register_with(MODEL_REGISTRY)
-def proton_pump(base):
+def proton_pump_formulae(base):
     """Provide a model with an ABC proton pump reaction."""
     atp = cobra.Metabolite("atp_c", formula='C10H12N5O13P3', compartment="c")
     adp = cobra.Metabolite("adp_c", formula='C10H12N5O10P2', compartment="c")
@@ -124,7 +124,29 @@ def proton_pump(base):
 
 
 @register_with(MODEL_REGISTRY)
-def phosphotransferase_system(base):
+def proton_pump_annotations(base):
+    """Provide a model with an ABC proton pump reaction."""
+    atp = cobra.Metabolite("atp_c", formula='C10H12N5O13P3', compartment="c")
+    adp = cobra.Metabolite("adp_c", formula='C10H12N5O10P2', compartment="c")
+    h_c = cobra.Metabolite("h_c", formula='H', compartment="c")
+    pi = cobra.Metabolite("pi_c", formula='HO4P', compartment="c")
+    h2o = cobra.Metabolite("h2o_c", formula='H2O', compartment="c")
+    h_p = cobra.Metabolite("h_p", formula='H', compartment="p")
+    atp.annotation["formula"] = "C10H12N5O13P3"
+    adp.annotation["formula"] = "C10H12N5O10P2"
+    h_c.annotation["formula"] = "H"
+    pi.annotation["formula"] = "HO4P"
+    h2o.annotation["formula"] = "H2O"
+    h_p.annotation["formula"] = "H"
+    pump = cobra.Reaction("PUMP")
+    pump.add_metabolites({h_c: -4, adp: -1, pi: -1,
+                          atp: 1, h2o: 1, h_p: 3})
+    base.add_reactions([pump])
+    return base
+
+
+@register_with(MODEL_REGISTRY)
+def phosphotransferase_system_formulae(base):
     """Provide a model with a PTS transport reaction."""
     pep = cobra.Metabolite("pep_c", formula='C3H2O6P', compartment="c")
     pyr = cobra.Metabolite("pyr_c", formula='C3H3O3', compartment="c")
@@ -139,12 +161,47 @@ def phosphotransferase_system(base):
 
 
 @register_with(MODEL_REGISTRY)
-def energy_transfer(base):
+def phosphotransferase_system_annotations(base):
+    """Provide a model with a PTS transport reaction."""
+    pep = cobra.Metabolite("pep_c", compartment="c")
+    pyr = cobra.Metabolite("pyr_c", compartment="c")
+    malt = cobra.Metabolite(",malt_e", compartment="e")
+    malt6p = cobra.Metabolite(
+        "malt6p_c", formula='C12H21O14P', compartment="c"
+    )
+    pep.annotation["formula"] = "C3H2O6P"
+    pyr.annotation["formula"] = "C3H3O3"
+    malt.annotation["formula"] = "C12H22O11"
+    pst = cobra.Reaction("PST")
+    pst.add_metabolites({pep: -1, malt: -1, pyr: 1, malt6p: 1})
+    base.add_reactions([pst])
+    return base
+
+
+@register_with(MODEL_REGISTRY)
+def energy_transfer_formulae(base):
     """Provide a model with a membrane-spanning electron transfer reaction."""
     cytaox = cobra.Metabolite("cytaox_c", formula='X', compartment="c")
     cytared = cobra.Metabolite("cytared_c", formula='XH2', compartment="c")
     cytbox = cobra.Metabolite("cytbox_m", formula='X', compartment="m")
     cytbred = cobra.Metabolite("cytbred_m", formula='XH2', compartment="m")
+    et = cobra.Reaction("ET")
+    et.add_metabolites({cytaox: -1, cytbred: -1, cytared: 1, cytbox: 1})
+    base.add_reactions([et])
+    return base
+
+
+@register_with(MODEL_REGISTRY)
+def energy_transfer_annotations(base):
+    """Provide a model with a membrane-spanning electron transfer reaction."""
+    cytaox = cobra.Metabolite("cytaox_c", compartment="c")
+    cytared = cobra.Metabolite("cytared_c", compartment="c")
+    cytbox = cobra.Metabolite("cytbox_m", compartment="m")
+    cytbred = cobra.Metabolite("cytbred_m", compartment="m")
+    cytaox.annotation["formula"] = "X"
+    cytared.annotation["formula"] = "XH2"
+    cytbox.annotation["formula"] = "X"
+    cytbred.annotation["formula"] = "XH2"
     et = cobra.Reaction("ET")
     et.add_metabolites({cytaox: -1, cytbred: -1, cytared: 1, cytbox: 1})
     base.add_reactions([et])
@@ -324,10 +381,15 @@ def biomass_metabolite(base):
 
 @pytest.mark.parametrize("model, num", [
     ("uni_anti_symport_formulae", 3),
+    ("uni_anti_symport_annotations", 3),
     ("abc_pump_formulae", 1),
-    ("proton_pump", 1),
-    ("energy_transfer", 0),
-    ("phosphotransferase_system", 1)
+    ("abc_pump_annotations", 1),
+    ("proton_pump_formulae", 1),
+    ("proton_pump_annotations", 1),
+    ("energy_transfer_formulae", 0),
+    ("energy_transfer_annotations", 0),
+    ("phosphotransferase_system_formulae", 1)
+    ("phosphotransferase_system_annotations", 1)
 ], indirect=["model"])
 def test_find_transport_reactions(model, num):
     """Expect amount of transporters to be identified correctly."""

--- a/tests/test_for_support/test_for_helpers.py
+++ b/tests/test_for_support/test_for_helpers.py
@@ -475,7 +475,7 @@ def biomass_metabolite(base):
     ("proton_pump_annotations", 1),
     ("energy_transfer_formulae", 0),
     ("energy_transfer_annotations", 0),
-    ("phosphotransferase_system_formulae",),
+    ("phosphotransferase_system_formulae", 0),
     ("phosphotransferase_system_annotations", 0)
 ], indirect=["model"])
 def test_find_transport_reactions(model, num):

--- a/tests/test_for_support/test_for_helpers.py
+++ b/tests/test_for_support/test_for_helpers.py
@@ -54,20 +54,9 @@ def uni_anti_symport_annotations(base):
     met_d = cobra.Metabolite("na_e", compartment="e")
 
     met_a.annotation["bigg.metabolite"] = "co2"
-    met_a.annotation["metanetx.chemical"] = "MNXM13"
-    met_a.annotation["seed.compound"] = "cpd00011"
-
     met_b.annotation["bigg.metabolite"] = "co2"
-    met_b.annotation["metanetx.chemical"] = "MNXM13"
-    met_b.annotation["seed.compound"] = "cpd00011"
-
     met_c.annotation["bigg.metabolite"] = "na1"
-    met_c.annotation["metanetx.chemical"] = "MNXM27"
-    met_c.annotation["seed.compound"] = "cpd00971"
-
     met_d.annotation["bigg.metabolite"] = "na1"
-    met_d.annotation["metanetx.chemical"] = "MNXM27"
-    met_d.annotation["seed.compound"] = "cpd00971"
 
     uni = cobra.Reaction("UNI")
     uni.add_metabolites({met_a: 1, met_b: -1})
@@ -107,42 +96,13 @@ def abc_pump_annotations(base):
     aso_c = cobra.Metabolite("aso3_c", compartment="c")
     aso_e = cobra.Metabolite("aso3_e", compartment="e")
 
-    atp.annotation["bigg.metabolite"] = "atp"
     atp.annotation["biocyc"] = ["META:ATP", "META:CPD0-1634"]
-    atp.annotation["metanetx.chemical"] = "MNXM13"
-    atp.annotation["seed.compound"] = "cpd00011"
-
-    adp.annotation["bigg.metabolite"] = "adp"
     adp.annotation["biocyc"] = ["META:ADP", "META:CPD0-1651"]
-    adp.annotation["metanetx.chemical"] = "MNXM7"
-    adp.annotation["seed.compound"] = "cpd00008"
-
-    h.annotation["bigg.metabolite"] = "h"
     h.annotation["biocyc"] = "META:PROTON"
-    h.annotation["metanetx.chemical"] = "MNXM1"
-    h.annotation["seed.compound"] = "cpd00067"
-
-    pi.annotation["bigg.metabolite"] = "pi"
-    pi.annotation["biocyc"] = ["META:CPD-16459", "META:CPD-9010",
-                               "META:PHOSPHATE-GROUP", "META:Pi"]
-    pi.annotation["metanetx.chemical"] = "MNXM9"
-    pi.annotation["seed.compound"] = ["cpd00009", "cpd27787"]
-
-    h2o.annotation["bigg.metabolite"] = "h2o"
-    h2o.annotation["biocyc"] = ["META:CPD-15815", "META:HYDROXYL-GROUP", 
-                                "META:OH", "META:OXONIUM", "META:WATER"]
-    h2o.annotation["metanetx.chemical"] = "MNXM2"
-    h2o.annotation["seed.compound"] = ["cpd00001", "cpd15275", "cpd27222"]
-
-    aso_c.annotation["bigg.metabolite"] = "aso3"
+    pi.annotation["biocyc"] = ["META:CPD-16459", "META:CPD-9010"]
+    h2o.annotation["biocyc"] = ["META:CPD-15815", "META:HYDROXYL-GROUP"]
     aso_c.annotation["biocyc"] = ["META:CPD0-2040", "META:CPD-763"]
-    aso_c.annotation["metanetx.chemical"] = "MNXM658"
-    aso_c.annotation["seed.compound"] = ["cpd04098", "cpd26385"]
-
-    aso_e.annotation["bigg.metabolite"] = "aso3"
     aso_e.annotation["biocyc"] = ["META:CPD0-2040", "META:CPD-763"]
-    aso_e.annotation["metanetx.chemical"] = "MNXM658"
-    aso_e.annotation["seed.compound"] = ["cpd04098", "cpd26385"]
 
     pump = cobra.Reaction("PUMP")
     pump.add_metabolites({aso_c: -1, atp: -1, h2o: -1,
@@ -177,37 +137,12 @@ def proton_pump_annotations(base):
     h2o = cobra.Metabolite("h2o_c", formula='H2O', compartment="c")
     h_p = cobra.Metabolite("h_p", formula='H', compartment="p")
 
-    atp.annotation["bigg.metabolite"] = "atp"
     atp.annotation["biocyc"] = ["META:ATP", "META:CPD0-1634"]
-    atp.annotation["metanetx.chemical"] = "MNXM13"
-    atp.annotation["seed.compound"] = "cpd00011"
-
-    adp.annotation["bigg.metabolite"] = "adp"
     adp.annotation["biocyc"] = ["META:ADP", "META:CPD0-1651"]
-    adp.annotation["metanetx.chemical"] = "MNXM7"
-    adp.annotation["seed.compound"] = "cpd00008"
-
-    h_c.annotation["bigg.metabolite"] = "h"
     h_c.annotation["biocyc"] = "META:PROTON"
-    h_c.annotation["metanetx.chemical"] = "MNXM1"
-    h_c.annotation["seed.compound"] = "cpd00067"
-
-    pi.annotation["bigg.metabolite"] = "pi"
-    pi.annotation["biocyc"] = ["META:CPD-16459", "META:CPD-9010",
-                               "META:PHOSPHATE-GROUP", "META:Pi"]
-    pi.annotation["metanetx.chemical"] = "MNXM9"
-    pi.annotation["seed.compound"] = ["cpd00009", "cpd27787"]
-
-    h2o.annotation["bigg.metabolite"] = "h2o"
-    h2o.annotation["biocyc"] = ["META:CPD-15815", "META:HYDROXYL-GROUP", 
-                                "META:OH", "META:OXONIUM", "META:WATER"]
-    h2o.annotation["metanetx.chemical"] = "MNXM2"
-    h2o.annotation["seed.compound"] = ["cpd00001", "cpd15275", "cpd27222"]
-
-    h_p.annotation["bigg.metabolite"] = "h"
+    pi.annotation["biocyc"] = ["META:CPD-16459", "META:CPD-9010"]
+    h2o.annotation["biocyc"] = ["META:CPD-15815", "META:HYDROXYL-GROUP"]
     h_p.annotation["biocyc"] = "META:PROTON"
-    h_p.annotation["metanetx.chemical"] = "MNXM1"
-    h_p.annotation["seed.compound"] = "cpd00067"
 
     pump = cobra.Reaction("PUMP")
     pump.add_metabolites({h_c: -4, adp: -1, pi: -1,
@@ -239,25 +174,10 @@ def phosphotransferase_system_annotations(base):
     malt = cobra.Metabolite(",malt_e", compartment="e")
     malt6p = cobra.Metabolite("malt6p_c", compartment="c")
 
-    pep.annotation["bigg.metabolite"] = "pep"
     pep.annotation["biocyc"] = "META:PHOSPHO-ENOL-PYRUVATE"
-    pep.annotation["metanetx.chemical"] = "MNXM73"
-    pep.annotation["seed.compound"] = "cpd00061"
-
-    pyr.annotation["bigg.metabolite"] = "pyr"
     pyr.annotation["biocyc"] = "META:PYRUVATE"
-    pyr.annotation["metanetx.chemical"] = "MNXM23"
-    pyr.annotation["seed.compound"] = "cpd00020"
-
-    malt.annotation["bigg.metabolite"] = "malt"
     malt.annotation["biocyc"] = ["META:ALPHA-MALTOSE", "META:MALTOSE"]
-    malt.annotation["metanetx.chemical"] = "MNXM165"
-    malt.annotation["seed.compound"] = ["cpd00179", "cpd00665"]
-
-    malt6p.annotation["bigg.metabolite"] = "malt6p"
     malt6p.annotation["biocyc"] = ["META:CPD-1244", "META:CPD-15982"]
-    malt6p.annotation["metanetx.chemical"] = "MNXM2394"
-    malt6p.annotation["seed.compound"] = "cpd01919"
 
     pst = cobra.Reaction("PST")
     pst.add_metabolites({pep: -1, malt: -1, pyr: 1, malt6p: 1})

--- a/tests/test_for_support/test_for_helpers.py
+++ b/tests/test_for_support/test_for_helpers.py
@@ -297,7 +297,7 @@ def energy_transfer_annotations(base):
 
 @register_with(MODEL_REGISTRY)
 def labeled_reaction(base):
-    """Provide a model with a labeled tranport reaction."""
+    """Provide a model with a labeled transport reaction."""
     a = cobra.Metabolite("a")
     b = cobra.Metabolite("b")
     rxn = cobra.Reaction("rxn")
@@ -309,7 +309,7 @@ def labeled_reaction(base):
 
 @register_with(MODEL_REGISTRY)
 def unlabeled_reaction(base):
-    """Provide a model with a labeled tranport reaction."""
+    """Provide a model with a labeled transport reaction."""
     a = cobra.Metabolite("a")
     b = cobra.Metabolite("b")
     rxn = cobra.Reaction("rxn")

--- a/tests/test_for_support/test_for_helpers.py
+++ b/tests/test_for_support/test_for_helpers.py
@@ -475,7 +475,7 @@ def biomass_metabolite(base):
     ("proton_pump_annotations", 1),
     ("energy_transfer_formulae", 0),
     ("energy_transfer_annotations", 0),
-    ("phosphotransferase_system_formulae", 0),
+    ("phosphotransferase_system_formulae", 1),
     ("phosphotransferase_system_annotations", 0)
 ], indirect=["model"])
 def test_find_transport_reactions(model, num):

--- a/tests/test_for_support/test_for_helpers.py
+++ b/tests/test_for_support/test_for_helpers.py
@@ -29,7 +29,7 @@ MODEL_REGISTRY = dict()
 
 
 @register_with(MODEL_REGISTRY)
-def uni_anti_symport(base):
+def uni_anti_symport_formulae(base):
     """Provide a model with 3 simple transport reactions."""
     met_a = cobra.Metabolite("co2_c", formula='CO2', compartment="c")
     met_b = cobra.Metabolite("co2_e", formula='CO2', compartment="e")
@@ -46,7 +46,28 @@ def uni_anti_symport(base):
 
 
 @register_with(MODEL_REGISTRY)
-def abc_pump(base):
+def uni_anti_symport_annotations(base):
+    """Provide a model with 3 simple transport reactions."""
+    met_a = cobra.Metabolite("co2_c", compartment="c")
+    met_b = cobra.Metabolite("co2_e", compartment="e")
+    met_c = cobra.Metabolite("na_c", compartment="c")
+    met_d = cobra.Metabolite("na_e", compartment="e")
+    met_a.annotation["formula"] = "CO2"
+    met_b.annotation["formula"] = "CO2"
+    met_c.annotation["formula"] = "Na"
+    met_d.annotation["formula"] = "Na"
+    uni = cobra.Reaction("UNI")
+    uni.add_metabolites({met_a: 1, met_b: -1})
+    anti = cobra.Reaction("ANTI")
+    anti.add_metabolites({met_a: 1, met_d: 1, met_b: -1, met_c: -1})
+    sym = cobra.Reaction("SYM")
+    sym.add_metabolites({met_a: 1, met_c: 1, met_b: -1, met_d: -1})
+    base.add_reactions([uni, anti, sym])
+    return base
+
+
+@register_with(MODEL_REGISTRY)
+def abc_pump_formulae(base):
     """Provide a model with an ABC transport reaction."""
     atp = cobra.Metabolite("atp_c", formula='C10H12N5O13P3', compartment="c")
     adp = cobra.Metabolite("adp_c", formula='C10H12N5O10P2', compartment="c")
@@ -55,6 +76,30 @@ def abc_pump(base):
     h2o = cobra.Metabolite("h2o_c", formula='H2O', compartment="c")
     aso_c = cobra.Metabolite("aso3_c", formula='AsO3', compartment="c")
     aso_e = cobra.Metabolite("aso3_e", formula='AsO3', compartment="e")
+    pump = cobra.Reaction("PUMP")
+    pump.add_metabolites({aso_c: -1, atp: -1, h2o: -1,
+                          adp: 1, h: 1, pi: 1, aso_e: 1})
+    base.add_reactions([pump])
+    return base
+
+
+@register_with(MODEL_REGISTRY)
+def abc_pump_annotations(base):
+    """Provide a model with an ABC transport reaction."""
+    atp = cobra.Metabolite("atp_c", compartment="c")
+    adp = cobra.Metabolite("adp_c", compartment="c")
+    h = cobra.Metabolite("h_c", compartment="c")
+    pi = cobra.Metabolite("pi_c", compartment="c")
+    h2o = cobra.Metabolite("h2o_c", compartment="c")
+    aso_c = cobra.Metabolite("aso3_c", compartment="c")
+    aso_e = cobra.Metabolite("aso3_e", compartment="e")
+    atp.annotation["formula"] = "C10H12N5O13P3"
+    adp.annotation["formula"] = "C10H12N5O10P2"
+    h.annotation["formula"] = "H"
+    pi.annotation["formula"] = "HO4P"
+    h2o.annotation["formula"] = "H2O"
+    aso_c.annotation["formula"] = "AsO3"
+    aso_e.annotation["formula"] = "AsO3"
     pump = cobra.Reaction("PUMP")
     pump.add_metabolites({aso_c: -1, atp: -1, h2o: -1,
                           adp: 1, h: 1, pi: 1, aso_e: 1})
@@ -278,8 +323,8 @@ def biomass_metabolite(base):
 
 
 @pytest.mark.parametrize("model, num", [
-    ("uni_anti_symport", 3),
-    ("abc_pump", 1),
+    ("uni_anti_symport_formulae", 3),
+    ("abc_pump_formulae", 1),
     ("proton_pump", 1),
     ("energy_transfer", 0),
     ("phosphotransferase_system", 1)

--- a/tests/test_for_support/test_for_helpers.py
+++ b/tests/test_for_support/test_for_helpers.py
@@ -109,77 +109,38 @@ def abc_pump_annotations(base):
 
     atp.annotation["bigg.metabolite"] = "atp"
     atp.annotation["biocyc"] = ["META:ATP", "META:CPD0-1634"]
-    atp.annotation["chebi"] = ["CHEBI:10789", "CHEBI:10841", "CHEBI:13236",
-                               "CHEBI:15422", "CHEBI:22249", "CHEBI:2359",
-                               "CHEBI:237958", "CHEBI:30616", "CHEBI:40938",
-                               "CHEBI:57299"]
-    atp.annotation["kegg.compound"] = "C00002"
-    atp.annotation["kegg.drug"] = "D08646"
     atp.annotation["metanetx.chemical"] = "MNXM13"
     atp.annotation["seed.compound"] = "cpd00011"
 
     adp.annotation["bigg.metabolite"] = "adp"
     adp.annotation["biocyc"] = ["META:ADP", "META:CPD0-1651"]
-    adp.annotation["chebi"] = ["CHEBI:13222", "CHEBI:16761", "CHEBI:22244",
-                               "CHEBI:2342", "CHEBI:40553", "CHEBI:456216",
-                               "CHEBI:87518"]
-    adp.annotation["kegg.compound"] = ["C00008", "G11113"]
     adp.annotation["metanetx.chemical"] = "MNXM7"
     adp.annotation["seed.compound"] = "cpd00008"
 
     h.annotation["bigg.metabolite"] = "h"
     h.annotation["biocyc"] = "META:PROTON"
-    h.annotation["chebi"] = ["CHEBI:10744", "CHEBI:13357", "CHEBI:15378",
-                             "CHEBI:24636", "CHEBI:29233", "CHEBI:29234",
-                             "CHEBI:5584"]
-    h.annotation["kegg.compound"] = "C00080"
     h.annotation["metanetx.chemical"] = "MNXM1"
     h.annotation["seed.compound"] = "cpd00067"
 
     pi.annotation["bigg.metabolite"] = "pi"
     pi.annotation["biocyc"] = ["META:CPD-16459", "META:CPD-9010",
                                "META:PHOSPHATE-GROUP", "META:Pi"]
-    pi.annotation["chebi"] = ["CHEBI:14791", "CHEBI:18367", "CHEBI:26078",
-                              "CHEBI:29137", "CHEBI:29139", "CHEBI:35780",
-                              "CHEBI:39739", "CHEBI:39745", "CHEBI:43470",
-                              "CHEBI:43474", "CHEBI:45024", "CHEBI:7793"]
-    pi.annotation["kegg.compound"] = ["C00009", "C13558"]
-    pi.annotation["kegg.drug"] = "D05467"
     pi.annotation["metanetx.chemical"] = "MNXM9"
     pi.annotation["seed.compound"] = ["cpd00009", "cpd27787"]
 
     h2o.annotation["bigg.metabolite"] = "h2o"
     h2o.annotation["biocyc"] = ["META:CPD-15815", "META:HYDROXYL-GROUP", 
                                 "META:OH", "META:OXONIUM", "META:WATER"]
-    h2o.annotation["chebi"] = ["CHEBI:10743", "CHEBI:13352", "CHEBI:13365",
-                               "CHEBI:13419", "CHEBI:15377", "CHEBI:16234",
-                               "CHEBI:27313", "CHEBI:29356", "CHEBI:29373",
-                               "CHEBI:29374", "CHEBI:29375", "CHEBI:29412",
-                               "CHEBI:30490", "CHEBI:33806", "CHEBI:33811",
-                               "CHEBI:33813", "CHEBI:41979", "CHEBI:41981",
-                               "CHEBI:42043", "CHEBI:42857", "CHEBI:43228",
-                               "CHEBI:44292", "CHEBI:44641", "CHEBI:44701",
-                               "CHEBI:44819", "CHEBI:5585", "CHEBI:5594"]
-    h2o.annotation["kegg.compound"] = [ "C00001", "C01328", "C18714"]
-    h2o.annotation["kegg.drug"] = ["D00001", "D03703", "D06322"]
     h2o.annotation["metanetx.chemical"] = "MNXM2"
     h2o.annotation["seed.compound"] = ["cpd00001", "cpd15275", "cpd27222"]
 
     aso_c.annotation["bigg.metabolite"] = "aso3"
     aso_c.annotation["biocyc"] = ["META:CPD0-2040", "META:CPD-763"]
-    aso_c.annotation["chebi"] = ["CHEBI:13857", "CHEBI:22635", "CHEBI:2846",
-                                 "CHEBI:29242", "CHEBI:29243", "CHEBI:29866",
-                                 "CHEBI:49899", "CHEBI:49900"]
-    aso_c.annotation["kegg.compound"] = "C06697"
     aso_c.annotation["metanetx.chemical"] = "MNXM658"
     aso_c.annotation["seed.compound"] = ["cpd04098", "cpd26385"]
 
     aso_e.annotation["bigg.metabolite"] = "aso3"
     aso_e.annotation["biocyc"] = ["META:CPD0-2040", "META:CPD-763"]
-    aso_e.annotation["chebi"] = ["CHEBI:13857", "CHEBI:22635", "CHEBI:2846",
-                                 "CHEBI:29242", "CHEBI:29243", "CHEBI:29866",
-                                 "CHEBI:49899", "CHEBI:49900"]
-    aso_e.annotation["kegg.compound"] = "C06697"
     aso_e.annotation["metanetx.chemical"] = "MNXM658"
     aso_e.annotation["seed.compound"] = ["cpd04098", "cpd26385"]
 
@@ -218,68 +179,33 @@ def proton_pump_annotations(base):
 
     atp.annotation["bigg.metabolite"] = "atp"
     atp.annotation["biocyc"] = ["META:ATP", "META:CPD0-1634"]
-    atp.annotation["chebi"] = ["CHEBI:10789", "CHEBI:10841", "CHEBI:13236",
-                               "CHEBI:15422", "CHEBI:22249", "CHEBI:2359",
-                               "CHEBI:237958", "CHEBI:30616", "CHEBI:40938",
-                               "CHEBI:57299"]
-    atp.annotation["kegg.compound"] = "C00002"
-    atp.annotation["kegg.drug"] = "D08646"
     atp.annotation["metanetx.chemical"] = "MNXM13"
     atp.annotation["seed.compound"] = "cpd00011"
 
     adp.annotation["bigg.metabolite"] = "adp"
     adp.annotation["biocyc"] = ["META:ADP", "META:CPD0-1651"]
-    adp.annotation["chebi"] = ["CHEBI:13222", "CHEBI:16761", "CHEBI:22244",
-                               "CHEBI:2342", "CHEBI:40553", "CHEBI:456216",
-                               "CHEBI:87518"]
-    adp.annotation["kegg.compound"] = ["C00008", "G11113"]
     adp.annotation["metanetx.chemical"] = "MNXM7"
     adp.annotation["seed.compound"] = "cpd00008"
 
     h_c.annotation["bigg.metabolite"] = "h"
     h_c.annotation["biocyc"] = "META:PROTON"
-    h_c.annotation["chebi"] = ["CHEBI:10744", "CHEBI:13357", "CHEBI:15378",
-                             "CHEBI:24636", "CHEBI:29233", "CHEBI:29234",
-                             "CHEBI:5584"]
-    h_c.annotation["kegg.compound"] = "C00080"
     h_c.annotation["metanetx.chemical"] = "MNXM1"
     h_c.annotation["seed.compound"] = "cpd00067"
 
     pi.annotation["bigg.metabolite"] = "pi"
     pi.annotation["biocyc"] = ["META:CPD-16459", "META:CPD-9010",
                                "META:PHOSPHATE-GROUP", "META:Pi"]
-    pi.annotation["chebi"] = ["CHEBI:14791", "CHEBI:18367", "CHEBI:26078",
-                              "CHEBI:29137", "CHEBI:29139", "CHEBI:35780",
-                              "CHEBI:39739", "CHEBI:39745", "CHEBI:43470",
-                              "CHEBI:43474", "CHEBI:45024", "CHEBI:7793"]
-    pi.annotation["kegg.compound"] = ["C00009", "C13558"]
-    pi.annotation["kegg.drug"] = "D05467"
     pi.annotation["metanetx.chemical"] = "MNXM9"
     pi.annotation["seed.compound"] = ["cpd00009", "cpd27787"]
 
     h2o.annotation["bigg.metabolite"] = "h2o"
     h2o.annotation["biocyc"] = ["META:CPD-15815", "META:HYDROXYL-GROUP", 
                                 "META:OH", "META:OXONIUM", "META:WATER"]
-    h2o.annotation["chebi"] = ["CHEBI:10743", "CHEBI:13352", "CHEBI:13365",
-                               "CHEBI:13419", "CHEBI:15377", "CHEBI:16234",
-                               "CHEBI:27313", "CHEBI:29356", "CHEBI:29373",
-                               "CHEBI:29374", "CHEBI:29375", "CHEBI:29412",
-                               "CHEBI:30490", "CHEBI:33806", "CHEBI:33811",
-                               "CHEBI:33813", "CHEBI:41979", "CHEBI:41981",
-                               "CHEBI:42043", "CHEBI:42857", "CHEBI:43228",
-                               "CHEBI:44292", "CHEBI:44641", "CHEBI:44701",
-                               "CHEBI:44819", "CHEBI:5585", "CHEBI:5594"]
-    h2o.annotation["kegg.compound"] = [ "C00001", "C01328", "C18714"]
-    h2o.annotation["kegg.drug"] = ["D00001", "D03703", "D06322"]
     h2o.annotation["metanetx.chemical"] = "MNXM2"
     h2o.annotation["seed.compound"] = ["cpd00001", "cpd15275", "cpd27222"]
 
     h_p.annotation["bigg.metabolite"] = "h"
     h_p.annotation["biocyc"] = "META:PROTON"
-    h_p.annotation["chebi"] = ["CHEBI:10744", "CHEBI:13357", "CHEBI:15378",
-                             "CHEBI:24636", "CHEBI:29233", "CHEBI:29234",
-                             "CHEBI:5584"]
-    h_p.annotation["kegg.compound"] = "C00080"
     h_p.annotation["metanetx.chemical"] = "MNXM1"
     h_p.annotation["seed.compound"] = "cpd00067"
 
@@ -315,38 +241,21 @@ def phosphotransferase_system_annotations(base):
 
     pep.annotation["bigg.metabolite"] = "pep"
     pep.annotation["biocyc"] = "META:PHOSPHO-ENOL-PYRUVATE"
-    pep.annotation["chebi"] = ["CHEBI:14812", "CHEBI:18021", "CHEBI:26054",
-                               "CHEBI:26055", "CHEBI:44894", "CHEBI:44897",
-                               "CHEBI:58702", "CHEBI:8147"]
-    pep.annotation["kegg.compound"] = "C00074"
     pep.annotation["metanetx.chemical"] = "MNXM73"
     pep.annotation["seed.compound"] = "cpd00061"
 
     pyr.annotation["bigg.metabolite"] = "pyr"
     pyr.annotation["biocyc"] = "META:PYRUVATE"
-    pyr.annotation["chebi"] = ["CHEBI:14987", "CHEBI:15361", "CHEBI:26462",
-                               "CHEBI:26466", "CHEBI:32816", "CHEBI:45253",
-                               "CHEBI:86354", "CHEBI:8685"]
-    pyr.annotation["kegg.compound"] = "C00022"
     pyr.annotation["metanetx.chemical"] = "MNXM23"
     pyr.annotation["seed.compound"] = "cpd00020"
 
     malt.annotation["bigg.metabolite"] = "malt"
     malt.annotation["biocyc"] = ["META:ALPHA-MALTOSE", "META:MALTOSE"]
-    malt.annotation["chebi"] = ["CHEBI:10300", "CHEBI:12340", "CHEBI:14568",
-                                "CHEBI:17306", "CHEBI:18167", "CHEBI:22463",
-                                "CHEBI:25144", "CHEBI:43893", "CHEBI:6668"]
-    malt.annotation["kegg.compound"] = ["C00208", "C00897", "G00275"]
-    malt.annotation["kegg.drug"] = "D00044"
     malt.annotation["metanetx.chemical"] = "MNXM165"
     malt.annotation["seed.compound"] = ["cpd00179", "cpd00665"]
 
     malt6p.annotation["bigg.metabolite"] = "malt6p"
     malt6p.annotation["biocyc"] = ["META:CPD-1244", "META:CPD-15982"]
-    malt6p.annotation["chebi"] = ["CHEBI:111006", "CHEBI:14569", "CHEBI:15703",
-                                  "CHEBI:25142", "CHEBI:57478", "CHEBI:6669",
-                                  "CHEBI:6670", "CHEBI:91177"]
-    malt6p.annotation["kegg.compound"] = ["C02995", "G10519"]
     malt6p.annotation["metanetx.chemical"] = "MNXM2394"
     malt6p.annotation["seed.compound"] = "cpd01919"
 
@@ -376,10 +285,10 @@ def energy_transfer_annotations(base):
     cytared = cobra.Metabolite("cytared_c", compartment="c")
     cytbox = cobra.Metabolite("cytbox_m", compartment="m")
     cytbred = cobra.Metabolite("cytbred_m", compartment="m")
-    cytaox.annotation["formula"] = "X"
-    cytared.annotation["formula"] = "XH2"
-    cytbox.annotation["formula"] = "X"
-    cytbred.annotation["formula"] = "XH2"
+    cytaox.annotation["kegg.compound"] = "NAD"
+    cytared.annotation["kegg.compound"] = "NADH"
+    cytbox.annotation["kegg.compound"] = "UBIQUINONE-ox"
+    cytbred.annotation["kegg.compound"] = "UBIQUINONE-red"
     et = cobra.Reaction("ET")
     et.add_metabolites({cytaox: -1, cytbred: -1, cytared: 1, cytbox: 1})
     base.add_reactions([et])
@@ -566,7 +475,7 @@ def biomass_metabolite(base):
     ("proton_pump_annotations", 1),
     ("energy_transfer_formulae", 0),
     ("energy_transfer_annotations", 0),
-    ("phosphotransferase_system_formulae", 0),
+    ("phosphotransferase_system_formulae",),
     ("phosphotransferase_system_annotations", 0)
 ], indirect=["model"])
 def test_find_transport_reactions(model, num):

--- a/tests/test_for_support/test_for_helpers.py
+++ b/tests/test_for_support/test_for_helpers.py
@@ -566,8 +566,8 @@ def biomass_metabolite(base):
     ("proton_pump_annotations", 1),
     ("energy_transfer_formulae", 0),
     ("energy_transfer_annotations", 0),
-    ("phosphotransferase_system_formulae", 1),
-    ("phosphotransferase_system_annotations", 1)
+    ("phosphotransferase_system_formulae", 0),
+    ("phosphotransferase_system_annotations", 0)
 ], indirect=["model"])
 def test_find_transport_reactions(model, num):
     """Expect amount of transporters to be identified correctly."""

--- a/tests/test_for_support/test_for_helpers.py
+++ b/tests/test_for_support/test_for_helpers.py
@@ -388,7 +388,7 @@ def biomass_metabolite(base):
     ("proton_pump_annotations", 1),
     ("energy_transfer_formulae", 0),
     ("energy_transfer_annotations", 0),
-    ("phosphotransferase_system_formulae", 1)
+    ("phosphotransferase_system_formulae", 1),
     ("phosphotransferase_system_annotations", 1)
 ], indirect=["model"])
 def test_find_transport_reactions(model, num):

--- a/tests/test_for_support/test_for_helpers.py
+++ b/tests/test_for_support/test_for_helpers.py
@@ -166,12 +166,11 @@ def phosphotransferase_system_annotations(base):
     pep = cobra.Metabolite("pep_c", compartment="c")
     pyr = cobra.Metabolite("pyr_c", compartment="c")
     malt = cobra.Metabolite(",malt_e", compartment="e")
-    malt6p = cobra.Metabolite(
-        "malt6p_c", formula='C12H21O14P', compartment="c"
-    )
+    malt6p = cobra.Metabolite("malt6p_c", compartment="c")
     pep.annotation["formula"] = "C3H2O6P"
     pyr.annotation["formula"] = "C3H3O3"
     malt.annotation["formula"] = "C12H22O11"
+    malt6p.annotation["formula"] = "C12H21O14P"
     pst = cobra.Reaction("PST")
     pst.add_metabolites({pep: -1, malt: -1, pyr: 1, malt6p: 1})
     base.add_reactions([pst])


### PR DESCRIPTION
* [x] fix #390, #384
* [x] description of feature/fix
* [x] tests added/passed
* [x] add an entry to the [next release](../HISTORY.rst)

Transport reactions were previously found using only the `formula` field of metabolite objects in reactions. This fix also catches transport reactions where the `formula` field may be absent or malformed as long as the metabolites in question have a proper `annotation` field.