### PR TITLE
Feat/gene annotation tests

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -16,6 +16,8 @@ Next Release
 * Fix some typos
 * Add history report view and connect it to `memote report history` call.
 * ``find_direct_metabolites`` detects and removes false positives.
+* Add tests for detecting gene annotations (and verifying they are in 
+  MIRIAM style)
 
 0.6.2 (2018-03-12)
 ------------------

--- a/memote/suite/tests/test_annotation.py
+++ b/memote/suite/tests/test_annotation.py
@@ -70,10 +70,10 @@ def test_reaction_annotation_presence(read_only_model):
     assert len(ann["data"]) == 0, ann["message"]
 
 
-@annotate(title="Gene Products without Annotation", type="count")
+@annotate(title="Genes/Gene-Products without Annotation", type="count")
 def test_gene_product_annotation_presence(read_only_model):
     """
-    Expect all gene products to have a non-empty annotation attribute.
+    Expect all genes/gene products to have a non-empty annotation attribute.
 
     This test checks if any annotations at all are present in the SBML
     annotations field (extended by FBC package) for each gene product,
@@ -87,8 +87,9 @@ def test_gene_product_annotation_presence(read_only_model):
         read_only_model, "genes"))
     ann["metric"] = len(ann["data"]) / len(read_only_model.genes)
     ann["message"] = wrapper.fill(
-        """A total of {} gene products ({:.2%}) lack any form of annotation:
-        {}""".format(len(ann["data"]), ann["metric"], truncate(ann["data"])))
+        """A total of {} genes/gene-products ({:.2%}) lack any form of
+        annotation: {}""".format(
+            len(ann["data"]), ann["metric"], truncate(ann["data"])))
     assert len(ann["data"]) == 0, ann["message"]
 
 
@@ -165,11 +166,11 @@ def test_reaction_annotation_overview(read_only_model, db):
 
 
 @pytest.mark.parametrize("db", list(annotation.GENE_PRODUCT_ANNOTATIONS))
-@annotate(title="Missing Gene Product Annotations Per Database",
+@annotate(title="Missing Gene/Gene-Product Annotations Per Database",
           type="percent", message=dict(), data=dict(), metric=dict())
 def test_gene_product_annotation_overview(read_only_model, db):
     """
-    Expect all gene products to have annotations from common databases.
+    Expect all genes/gene-products to have annotations from common databases.
 
     Specific database cross-references are paramount to mapping information.
     To provide references to as many databases as possible helps to make the
@@ -194,7 +195,7 @@ def test_gene_product_annotation_overview(read_only_model, db):
         read_only_model.genes, db))
     ann["metric"][db] = len(ann["data"][db]) / len(read_only_model.genes)
     ann["message"][db] = wrapper.fill(
-        """The following {} gene products ({:.2%}) lack annotation for {}:
+        """The following {} gene/gene-products ({:.2%}) lack annotation for {}:
         {}""".format(len(ann["data"][db]), ann["metric"][db], db,
                      truncate(ann["data"][db])))
     assert len(ann["data"][db]) == 0, ann["message"][db]
@@ -283,11 +284,11 @@ def test_reaction_annotation_wrong_ids(read_only_model, db):
 
 
 @pytest.mark.parametrize("db", annotation.GENE_PRODUCT_ANNOTATIONS)
-@annotate(title="Wrong Gene Product Annotations Per Database",
+@annotate(title="Wrong Gene/Gene-Product Annotations Per Database",
           type="percent", message=dict(), data=dict(), metric=dict())
 def test_gene_product_annotation_wrong_ids(read_only_model, db):
     """
-    Expect all annotations of gene products to be in the correct format.
+    Expect all annotations of genes/gene-products to be in the correct format.
 
     To identify databases and the identifiers belonging to them, computational
     tools rely on the presence of specific patterns. Only when these patterns
@@ -307,7 +308,7 @@ def test_gene_product_annotation_wrong_ids(read_only_model, db):
                 read_only_model.genes, db)))
     ann["metric"][db] = 1.0
     ann["message"][db] = wrapper.fill(
-        """There are no gene products annotations for the {} database.
+        """There are no gene or gene-product annotations for the {} database.
         """.format(db))
     assert len(total) > 0, ann["message"][db]
     ann["data"][db] = get_ids(
@@ -315,9 +316,9 @@ def test_gene_product_annotation_wrong_ids(read_only_model, db):
             read_only_model.genes, "genes", db))
     ann["metric"][db] = len(ann["data"][db]) / len(read_only_model.genes)
     ann["message"][db] = wrapper.fill(
-        """The provided gene product annotations for the {} database do not
-        match the regular expression patterns defined on identifiers.org. A
-        total of {} gene product annotations ({:.2%}) needs to be
+        """The provided gene/gene-product annotations for the {} database do
+        not match the regular expression patterns defined on identifiers.org.
+        A total of {} gene product annotations ({:.2%}) needs to be
         fixed: {}""".format(
             db, len(ann["data"][db]), ann["metric"][db],
             truncate(ann["data"][db])))

--- a/memote/suite/tests/test_annotation.py
+++ b/memote/suite/tests/test_annotation.py
@@ -70,6 +70,28 @@ def test_reaction_annotation_presence(read_only_model):
     assert len(ann["data"]) == 0, ann["message"]
 
 
+@annotate(title="Reactions without Annotation", type="count")
+def test_gene_product_annotation_presence(read_only_model):
+    """
+    Expect all gene products to have a non-empty annotation attribute
+
+    This test checks if any annotations at all are present in the SBML
+    annotations field (extended by FBC package) for each gene product,
+    irrespective of the type of annotation i.e. specific database,
+    cross-references, ontology terms, additional information. For this test to
+    pass the model is expected to have genes and each of them should have some
+    form of annotation.
+    """
+    ann = test_reaction_annotation_presence.annotation
+    ann["data"] = get_ids(annotation.find_components_without_annotation(
+        read_only_model, "genes"))
+    ann["metric"] = len(ann["data"]) / len(read_only_model.reactions)
+    ann["message"] = wrapper.fill(
+        """A total of {} gene products ({:.2%}) lack any form of annotation:
+        {}""".format(len(ann["data"]), ann["metric"], truncate(ann["data"])))
+    assert len(ann["data"]) == 0, ann["message"]
+
+
 @pytest.mark.parametrize("db", list(annotation.METABOLITE_ANNOTATIONS))
 @annotate(title="Missing Metabolite Annotations Per Database",
           type="percent", message=dict(), data=dict(), metric=dict())

--- a/memote/suite/tests/test_annotation.py
+++ b/memote/suite/tests/test_annotation.py
@@ -70,10 +70,10 @@ def test_reaction_annotation_presence(read_only_model):
     assert len(ann["data"]) == 0, ann["message"]
 
 
-@annotate(title="Genes/Gene-Products without Annotation", type="count")
+@annotate(title="Genes without Annotation", type="count")
 def test_gene_product_annotation_presence(read_only_model):
     """
-    Expect all genes/gene products to have a non-empty annotation attribute.
+    Expect all genes to have a non-empty annotation attribute.
 
     This test checks if any annotations at all are present in the SBML
     annotations field (extended by FBC package) for each gene product,
@@ -87,7 +87,7 @@ def test_gene_product_annotation_presence(read_only_model):
         read_only_model, "genes"))
     ann["metric"] = len(ann["data"]) / len(read_only_model.genes)
     ann["message"] = wrapper.fill(
-        """A total of {} genes/gene-products ({:.2%}) lack any form of
+        """A total of {} genes ({:.2%}) lack any form of
         annotation: {}""".format(
             len(ann["data"]), ann["metric"], truncate(ann["data"])))
     assert len(ann["data"]) == 0, ann["message"]
@@ -166,11 +166,11 @@ def test_reaction_annotation_overview(read_only_model, db):
 
 
 @pytest.mark.parametrize("db", list(annotation.GENE_PRODUCT_ANNOTATIONS))
-@annotate(title="Missing Gene/Gene-Product Annotations Per Database",
+@annotate(title="Missing Gene Annotations Per Database",
           type="percent", message=dict(), data=dict(), metric=dict())
 def test_gene_product_annotation_overview(read_only_model, db):
     """
-    Expect all genes/gene-products to have annotations from common databases.
+    Expect all genes to have annotations from common databases.
 
     Specific database cross-references are paramount to mapping information.
     To provide references to as many databases as possible helps to make the
@@ -195,7 +195,7 @@ def test_gene_product_annotation_overview(read_only_model, db):
         read_only_model.genes, db))
     ann["metric"][db] = len(ann["data"][db]) / len(read_only_model.genes)
     ann["message"][db] = wrapper.fill(
-        """The following {} gene/gene-products ({:.2%}) lack annotation for {}:
+        """The following {} genes ({:.2%}) lack annotation for {}:
         {}""".format(len(ann["data"][db]), ann["metric"][db], db,
                      truncate(ann["data"][db])))
     assert len(ann["data"][db]) == 0, ann["message"][db]
@@ -284,7 +284,7 @@ def test_reaction_annotation_wrong_ids(read_only_model, db):
 
 
 @pytest.mark.parametrize("db", annotation.GENE_PRODUCT_ANNOTATIONS)
-@annotate(title="Wrong Gene/Gene-Product Annotations Per Database",
+@annotate(title="Wrong Gene Annotations Per Database",
           type="percent", message=dict(), data=dict(), metric=dict())
 def test_gene_product_annotation_wrong_ids(read_only_model, db):
     """
@@ -308,7 +308,7 @@ def test_gene_product_annotation_wrong_ids(read_only_model, db):
                 read_only_model.genes, db)))
     ann["metric"][db] = 1.0
     ann["message"][db] = wrapper.fill(
-        """There are no gene or gene-product annotations for the {} database.
+        """There are no gene annotations for the {} database.
         """.format(db))
     assert len(total) > 0, ann["message"][db]
     ann["data"][db] = get_ids(

--- a/memote/suite/tests/test_annotation.py
+++ b/memote/suite/tests/test_annotation.py
@@ -82,7 +82,7 @@ def test_gene_product_annotation_presence(read_only_model):
     pass the model is expected to have genes and each of them should have some
     form of annotation.
     """
-    ann = test_reaction_annotation_presence.annotation
+    ann = test_gene_product_annotation_presence.annotation
     ann["data"] = get_ids(annotation.find_components_without_annotation(
         read_only_model, "genes"))
     ann["metric"] = len(ann["data"]) / len(read_only_model.genes)
@@ -189,7 +189,7 @@ def test_gene_product_annotation_overview(read_only_model, db):
     it should be possible, however, to obtain cross-references to at least
     one of the databases for all gene products consistently.
     """
-    ann = test_reaction_annotation_overview.annotation
+    ann = test_gene_product_annotation_overview.annotation
     ann["data"][db] = get_ids(annotation.generate_component_annotation_overview(
         read_only_model.genes, db))
     ann["metric"][db] = len(ann["data"][db]) / len(read_only_model.genes)
@@ -300,7 +300,7 @@ def test_gene_product_annotation_wrong_ids(read_only_model, db):
     `annotation.py`. This test does not carry out a web query for the composed
     URI, it merely controls that the regex patterns match the identifiers.
     """
-    ann = test_reaction_annotation_wrong_ids.annotation
+    ann = test_gene_product_annotation_wrong_ids.annotation
     ann["data"][db] = total = get_ids(
         set(read_only_model.genes).difference(
             annotation.generate_component_annotation_overview(
@@ -312,7 +312,7 @@ def test_gene_product_annotation_wrong_ids(read_only_model, db):
     assert len(total) > 0, ann["message"][db]
     ann["data"][db] = get_ids(
         annotation.generate_component_annotation_miriam_match(
-            read_only_model.reactions, "genes", db))
+            read_only_model.genes, "genes", db))
     ann["metric"][db] = len(ann["data"][db]) / len(read_only_model.genes)
     ann["message"][db] = wrapper.fill(
         """The provided gene product annotations for the {} database do not

--- a/memote/suite/tests/test_annotation.py
+++ b/memote/suite/tests/test_annotation.py
@@ -70,7 +70,7 @@ def test_reaction_annotation_presence(read_only_model):
     assert len(ann["data"]) == 0, ann["message"]
 
 
-@annotate(title="Reactions without Annotation", type="count")
+@annotate(title="Gene Products without Annotation", type="count")
 def test_gene_product_annotation_presence(read_only_model):
     """
     Expect all gene products to have a non-empty annotation attribute
@@ -85,7 +85,7 @@ def test_gene_product_annotation_presence(read_only_model):
     ann = test_reaction_annotation_presence.annotation
     ann["data"] = get_ids(annotation.find_components_without_annotation(
         read_only_model, "genes"))
-    ann["metric"] = len(ann["data"]) / len(read_only_model.reactions)
+    ann["metric"] = len(ann["data"]) / len(read_only_model.genes)
     ann["message"] = wrapper.fill(
         """A total of {} gene products ({:.2%}) lack any form of annotation:
         {}""".format(len(ann["data"]), ann["metric"], truncate(ann["data"])))

--- a/memote/suite/tests/test_annotation.py
+++ b/memote/suite/tests/test_annotation.py
@@ -164,6 +164,42 @@ def test_reaction_annotation_overview(read_only_model, db):
     assert len(ann["data"][db]) == 0, ann["message"][db]
 
 
+@pytest.mark.parametrize("db", list(annotation.GENE_PRODUCT_ANNOTATIONS))
+@annotate(title="Missing Gene Product Annotations Per Database",
+          type="percent", message=dict(), data=dict(), metric=dict())
+def test_gene_product_annotation_overview(read_only_model, db):
+    """
+    Expect all gene products to have annotations from common databases.
+
+    Specific database cross-references are paramount to mapping information.
+    To provide references to as many databases as possible helps to make the
+    metabolic model more accessible to other researchers. This does not only
+    facilitate the use of a model in a broad array of computational pipelines,
+    it also promotes the metabolic model itself to become an organism-specific
+    knowledge base.
+
+    For this test to pass, each gene product annotation should contain
+    cross-references to a number of databases (listed in `annotation.py`).
+    For each database this test checks for the presence of its corresponding
+    namespace ID to comply with the MIRIAM guidelines i.e. they have to match
+    those defined on https://identifiers.org/.
+
+    Since each database is quite different and some potentially incomplete, it
+    may not be feasible to achieve 100% coverage for each of them. Generally
+    it should be possible, however, to obtain cross-references to at least
+    one of the databases for all gene products consistently.
+    """
+    ann = test_reaction_annotation_overview.annotation
+    ann["data"][db] = get_ids(annotation.generate_component_annotation_overview(
+        read_only_model.genes, db))
+    ann["metric"][db] = len(ann["data"][db]) / len(read_only_model.genes)
+    ann["message"][db] = wrapper.fill(
+        """The following {} gene products ({:.2%}) lack annotation for {}:
+        {}""".format(len(ann["data"][db]), ann["metric"][db], db,
+                     truncate(ann["data"][db])))
+    assert len(ann["data"][db]) == 0, ann["message"][db]
+
+
 @pytest.mark.parametrize("db", list(annotation.METABOLITE_ANNOTATIONS))
 @annotate(title="Wrong Metabolite Annotations Per Database",
           type="percent", message=dict(), data=dict(), metric=dict())

--- a/memote/support/annotation.py
+++ b/memote/support/annotation.py
@@ -31,7 +31,7 @@ LOGGER = logging.getLogger(__name__)
 
 # MIRIAM (http://www.ebi.ac.uk/miriam/) styled identifiers for
 # common databases that are currently included are:
-# DB            gen,rxn,met         url
+#   DB             gen,rxn,met              url
 #
 # 'MetaNetX'            ['rxn','met']       'http://www.metanetx.org'
 # 'Kegg'                ['gen','rxn','met'] 'http://www.kegg.jp/'
@@ -50,10 +50,13 @@ LOGGER = logging.getLogger(__name__)
 # 'PubChem'     ['met']         'https://pubchem.ncbi.nlm.nih.gov/'
 # 'RefSeq'      ['gen']         'http://www.ncbi.nlm.nih.gov/projects/RefSeq/'
 # 'Uniprot'     ['gen']         'http://www.uniprot.org/'
-# 'EC-Code'     ['gen']         'https://www.ebi.ac.uk/enzymeportal'
+# 'EC-Code'     ['rxn']         'https://www.ebi.ac.uk/enzymeportal'
 # 'EcoGene'     ['gen']         'http://ecogene.org/'
 # 'NCBI GI'     ['gen']         'http://www.ncbi.nlm.nih.gov/protein/'
 # 'NCBI Gene'   ['gen']         'http://ncbigene.bio2rdf.org/fct'
+# 'CCDS'        ['gen']         'http://www.ncbi.nlm.nih.gov/CCDS/'
+# 'HPRD'        ['gen']         'http://www.hprd.org/'
+# 'ASAP'        ['gen']         'http://asap.ahabs.wisc.edu/asap/home.php'
 
 REACTION_ANNOTATIONS = OrderedDict([
     ('rhea', re.compile(r"^\d{5}$")),
@@ -94,9 +97,13 @@ METABOLITE_ANNOTATIONS = OrderedDict([
 GENE_ANNOTATIONS = OrderedDict([
     ('refseq', re.compile(r"^((AC|AP|NC|NG|NM|NP|NR|NT|NW|XM|XP|XR|YP|ZP)_\d+|(NZ\_[A-Z]{4}\d+))(\.\d+)?$")),
     ('uniprot', re.compile(r"^([A-N,R-Z][0-9]([A-Z][A-Z, 0-9][A-Z, 0-9][0-9]){1,2})|([O,P,Q][0-9][A-Z, 0-9][A-Z, 0-9][A-Z, 0-9][0-9])(\.\d+)?$")),
-    ('ec-code', re.compile(r"^\d+\.-\.-\.-|\d+\.\d+\.-\.-|\d+\.\d+\.\d+\.-|\d+\.\d+\.\d+\.(n)?\d+$"))
     ('ecogene', re.compile(r"^EG\d+$")),
-    ('kegg.gene', re.compile(r"^\w+:[\w\d\.-]*$"))
+    ('kegg.gene', re.compile(r"^\w+:[\w\d\.-]*$")),
+    ('ncbigi', re.compile(r"^(GI|gi)\:\d+$")),
+    ('ncbigene', re.compile(r"^\d+$")),
+    ('ccds', re.compile(r"^CCDS\d+\.\d+$")),
+    ('hprd', re.compile(r"^\d+$")),
+    ('asap', re.compile(r"^[A-Za-z0-9-]+$"))
 ])
 
 

--- a/memote/support/annotation.py
+++ b/memote/support/annotation.py
@@ -31,9 +31,9 @@ LOGGER = logging.getLogger(__name__)
 
 # MIRIAM (http://www.ebi.ac.uk/miriam/) styled identifiers for
 # common databases that are currently included are:
-# DB    rxn,met,gen url
+# DB    gen,rxn,met url
 # 'MetaNetX'  ['rxn','met'] 'http://www.metanetx.org'
-# 'Kegg'  ['rxn','met'] 'http://www.kegg.jp/'
+# 'Kegg'  ['gen','rxn','met'] 'http://www.kegg.jp/'
 # 'SEED'  ['met']  'http://modelseed.org/'
 # 'InChIKey'  ['met'] 'http://cactus.nci.nih.gov/chemical/structure'
 # 'ChEBI' ['met'] 'http://bioportal.bioontology.org/ontologies/CHEBI'
@@ -46,11 +46,9 @@ LOGGER = logging.getLogger(__name__)
 # 'BiGG'    ['rxn','met']   'http://bigg.ucsd.edu/universal/'
 # 'PubChem' ['met'] 'https://pubchem.ncbi.nlm.nih.gov/'
 # 'RefSeq' ['gen'] 'http://www.ncbi.nlm.nih.gov/projects/RefSeq/'
-# 'Uniprot' ['?'] 'http://www.uniprot.org/'
-# 'EC-Code' ['?'] 'https://www.ebi.ac.uk/enzymeportal'
-# 'BRENDA (maybe)'
+# 'Uniprot' ['gen'] 'http://www.uniprot.org/'
+# 'EC-Code' ['gen'] 'https://www.ebi.ac.uk/enzymeportal'
 # 'EcoGene' ['gen'] 'http://ecogene.org/'
-# 'Kegg (maybe)'
 
 
 REACTION_ANNOTATIONS = OrderedDict([
@@ -91,19 +89,10 @@ METABOLITE_ANNOTATIONS = OrderedDict([
 
 GENE_ANNOTATIONS = OrderedDict([
     ('refseq', re.compile(r"^((AC|AP|NC|NG|NM|NP|NR|NT|NW|XM|XP|XR|YP|ZP)_\d+|(NZ\_[A-Z]{4}\d+))(\.\d+)?$")),
-    # Does this belong?
     ('uniprot', re.compile(r"^([A-N,R-Z][0-9]([A-Z][A-Z, 0-9][A-Z, 0-9][0-9]){1,2})|([O,P,Q][0-9][A-Z, 0-9][A-Z, 0-9][A-Z, 0-9][0-9])(\.\d+)?$")),
-    # Does this belong?
     ('ec-code', re.compile(r"^\d+\.-\.-\.-|\d+\.\d+\.-\.-|\d+\.\d+\.\d+\.-|\d+\.\d+\.\d+\.(n)?\d+$"))
-    # Does this belong?
-    ('brenda', re.compile(
-        r"^\d+\.-\.-\.-|\d+\.\d+\.-\.-|"
-        r"\d+\.\d+\.\d+\.-|"
-        r"\d+\.\d+\.\d+\.(n)?\d+$")),
-    # Does this belong?
     ('ecogene', re.compile(r"^EG\d+$")),
-    # Is this right?
-    ('kegg.gene', re.compile(r"^([CHDEGTMKR]\d+)|(\w+:[\w\d\.-]*)|([a-z]{3,5})|(\w{2,4}\d{5})$"))
+    ('kegg.gene', re.compile(r"^\w+:[\w\d\.-]*$"))
 ])
 
 

--- a/memote/support/annotation.py
+++ b/memote/support/annotation.py
@@ -58,7 +58,7 @@ LOGGER = logging.getLogger(__name__)
 # 'HPRD'        ['gen']         'http://www.hprd.org/'
 # 'ASAP'        ['gen']         'http://asap.ahabs.wisc.edu/asap/home.php'
 
-GENE_ANNOTATIONS = OrderedDict([
+GENE_PRODUCT_ANNOTATIONS = OrderedDict([
     ('refseq', re.compile(
         r"^((AC|AP|NC|NG|NM|NP|NR|NT|"
         r"NW|XM|XP|XR|YP|ZP)_\d+|"

--- a/memote/support/annotation.py
+++ b/memote/support/annotation.py
@@ -33,10 +33,9 @@ LOGGER = logging.getLogger(__name__)
 # common databases that are currently included are:
 #   DB             gen,rxn,met              url
 #
-# 'MetaNetX'            ['rxn','met']       'http://www.metanetx.org'
-# 'Kegg'                ['gen','rxn','met'] 'http://www.kegg.jp/'
-# 'SEED'                ['met']             'http://modelseed.org/'
-# 'EnzymeNomenclature'  ['rxn']             'http://www.enzyme-database.org/'
+# 'MetaNetX'    ['rxn','met']       'http://www.metanetx.org'
+# 'Kegg'        ['gen','rxn','met'] 'http://www.kegg.jp/'
+# 'SEED'        ['met']             'http://modelseed.org/'
 #
 # 'InChIKey'    ['met']     'http://cactus.nci.nih.gov/chemical/structure'
 # 'ChEBI'       ['met']     'http://bioportal.bioontology.org/ontologies/CHEBI'
@@ -50,13 +49,35 @@ LOGGER = logging.getLogger(__name__)
 # 'PubChem'     ['met']         'https://pubchem.ncbi.nlm.nih.gov/'
 # 'RefSeq'      ['gen']         'http://www.ncbi.nlm.nih.gov/projects/RefSeq/'
 # 'Uniprot'     ['gen']         'http://www.uniprot.org/'
-# 'EC-Code'     ['rxn']         'https://www.ebi.ac.uk/enzymeportal'
+# 'EC-Code'     ['rxn']         'http://www.enzyme-database.org/'
 # 'EcoGene'     ['gen']         'http://ecogene.org/'
 # 'NCBI GI'     ['gen']         'http://www.ncbi.nlm.nih.gov/protein/'
 # 'NCBI Gene'   ['gen']         'http://ncbigene.bio2rdf.org/fct'
+# 'NCBI Protein'['gen']         'http://www.ncbi.nlm.nih.gov/protein'
 # 'CCDS'        ['gen']         'http://www.ncbi.nlm.nih.gov/CCDS/'
 # 'HPRD'        ['gen']         'http://www.hprd.org/'
 # 'ASAP'        ['gen']         'http://asap.ahabs.wisc.edu/asap/home.php'
+
+GENE_ANNOTATIONS = OrderedDict([
+    ('refseq', re.compile(
+        r"^((AC|AP|NC|NG|NM|NP|NR|NT|"
+        r"NW|XM|XP|XR|YP|ZP)_\d+|"
+        r"(NZ\_[A-Z]{4}\d+))(\.\d+)?$")),
+    ('uniprot', re.compile(
+        r"^([A-N,R-Z][0-9]([A-Z][A-Z, 0-9]"
+        r"[A-Z, 0-9][0-9]){1,2})|([O,P,Q]"
+        r"[0-9][A-Z, 0-9][A-Z, 0-9][A-Z, 0-9]"
+        r"[0-9])(\.\d+)?$")),
+    ('ecogene', re.compile(r"^EG\d+$")),
+    ('kegg.gene', re.compile(r"^\w+:[\w\d\.-]*$")),
+    ('ncbigi', re.compile(r"^(GI|gi)\:\d+$")),
+    ('ncbigene', re.compile(r"^\d+$")),
+    ('ncbiprotein', re.compile(r"^(\w+\d+(\.\d+)?)|(NP_\d+)$")),
+    ('ccds', re.compile(r"^CCDS\d+\.\d+$")),
+    ('hprd', re.compile(r"^\d+$")),
+    ('asap', re.compile(r"^[A-Za-z0-9-]+$"))
+])
+
 
 REACTION_ANNOTATIONS = OrderedDict([
     ('rhea', re.compile(r"^\d{5}$")),
@@ -91,19 +112,6 @@ METABOLITE_ANNOTATIONS = OrderedDict([
     ('bigg.metabolite', re.compile(r"^[a-z_A-Z0-9]+$")),
     ('biocyc', re.compile(
         r"^[A-Z-0-9]+(?<!CHEBI)(\:)?[A-Za-z0-9+_.%-]+$"))
-])
-
-
-GENE_ANNOTATIONS = OrderedDict([
-    ('refseq', re.compile(r"^((AC|AP|NC|NG|NM|NP|NR|NT|NW|XM|XP|XR|YP|ZP)_\d+|(NZ\_[A-Z]{4}\d+))(\.\d+)?$")),
-    ('uniprot', re.compile(r"^([A-N,R-Z][0-9]([A-Z][A-Z, 0-9][A-Z, 0-9][0-9]){1,2})|([O,P,Q][0-9][A-Z, 0-9][A-Z, 0-9][A-Z, 0-9][0-9])(\.\d+)?$")),
-    ('ecogene', re.compile(r"^EG\d+$")),
-    ('kegg.gene', re.compile(r"^\w+:[\w\d\.-]*$")),
-    ('ncbigi', re.compile(r"^(GI|gi)\:\d+$")),
-    ('ncbigene', re.compile(r"^\d+$")),
-    ('ccds', re.compile(r"^CCDS\d+\.\d+$")),
-    ('hprd', re.compile(r"^\d+$")),
-    ('asap', re.compile(r"^[A-Za-z0-9-]+$"))
 ])
 
 

--- a/memote/support/annotation.py
+++ b/memote/support/annotation.py
@@ -31,25 +31,29 @@ LOGGER = logging.getLogger(__name__)
 
 # MIRIAM (http://www.ebi.ac.uk/miriam/) styled identifiers for
 # common databases that are currently included are:
-# DB    gen,rxn,met url
-# 'MetaNetX'  ['rxn','met'] 'http://www.metanetx.org'
-# 'Kegg'  ['gen','rxn','met'] 'http://www.kegg.jp/'
-# 'SEED'  ['met']  'http://modelseed.org/'
-# 'InChIKey'  ['met'] 'http://cactus.nci.nih.gov/chemical/structure'
-# 'ChEBI' ['met'] 'http://bioportal.bioontology.org/ontologies/CHEBI'
-# 'EnzymeNomenclature'    ['rxn'] 'http://www.enzyme-database.org/'
-# 'BRENDA'    ['rxn']    'http://www.brenda-enzymes.org/'
-# 'RHEA'  ['rxn']  'http://www.rhea-db.org/'
-# 'HMDB'  ['met'] 'http://www.hmdb.ca/'
-# 'BioCyc'  ['rxn','met'] 'http://biocyc.org'
-# 'Reactome'    ['met'] 'http://www.reactome.org/'
-# 'BiGG'    ['rxn','met']   'http://bigg.ucsd.edu/universal/'
-# 'PubChem' ['met'] 'https://pubchem.ncbi.nlm.nih.gov/'
-# 'RefSeq' ['gen'] 'http://www.ncbi.nlm.nih.gov/projects/RefSeq/'
-# 'Uniprot' ['gen'] 'http://www.uniprot.org/'
-# 'EC-Code' ['gen'] 'https://www.ebi.ac.uk/enzymeportal'
-# 'EcoGene' ['gen'] 'http://ecogene.org/'
-
+# DB            gen,rxn,met         url
+#
+# 'MetaNetX'            ['rxn','met']       'http://www.metanetx.org'
+# 'Kegg'                ['gen','rxn','met'] 'http://www.kegg.jp/'
+# 'SEED'                ['met']             'http://modelseed.org/'
+# 'EnzymeNomenclature'  ['rxn']             'http://www.enzyme-database.org/'
+#
+# 'InChIKey'    ['met']     'http://cactus.nci.nih.gov/chemical/structure'
+# 'ChEBI'       ['met']     'http://bioportal.bioontology.org/ontologies/CHEBI'
+# 'BRENDA'      ['rxn']     'http://www.brenda-enzymes.org/'
+# 'RHEA'        ['rxn']     'http://www.rhea-db.org/'
+# 'HMDB'        ['met']     'http://www.hmdb.ca/'
+#
+# 'BioCyc'      ['rxn','met']   'http://biocyc.org'
+# 'Reactome'    ['met']         'http://www.reactome.org/'
+# 'BiGG'        ['rxn','met']   'http://bigg.ucsd.edu/universal/'
+# 'PubChem'     ['met']         'https://pubchem.ncbi.nlm.nih.gov/'
+# 'RefSeq'      ['gen']         'http://www.ncbi.nlm.nih.gov/projects/RefSeq/'
+# 'Uniprot'     ['gen']         'http://www.uniprot.org/'
+# 'EC-Code'     ['gen']         'https://www.ebi.ac.uk/enzymeportal'
+# 'EcoGene'     ['gen']         'http://ecogene.org/'
+# 'NCBI GI'     ['gen']         'http://www.ncbi.nlm.nih.gov/protein/'
+# 'NCBI Gene'   ['gen']         'http://ncbigene.bio2rdf.org/fct'
 
 REACTION_ANNOTATIONS = OrderedDict([
     ('rhea', re.compile(r"^\d{5}$")),

--- a/memote/support/annotation.py
+++ b/memote/support/annotation.py
@@ -45,6 +45,13 @@ LOGGER = logging.getLogger(__name__)
 # 'Reactome'    ['met'] 'http://www.reactome.org/'
 # 'BiGG'    ['rxn','met']   'http://bigg.ucsd.edu/universal/'
 # 'PubChem' ['met'] 'https://pubchem.ncbi.nlm.nih.gov/'
+# 'RefSeq' ['gen'] 'http://www.ncbi.nlm.nih.gov/projects/RefSeq/'
+# 'Uniprot' ['?'] 'http://www.uniprot.org/'
+# 'EC-Code' ['?'] 'https://www.ebi.ac.uk/enzymeportal'
+# 'BRENDA (maybe)'
+# 'EcoGene' ['gen'] 'http://ecogene.org/'
+# 'Kegg (maybe)'
+
 
 REACTION_ANNOTATIONS = OrderedDict([
     ('rhea', re.compile(r"^\d{5}$")),
@@ -79,6 +86,24 @@ METABOLITE_ANNOTATIONS = OrderedDict([
     ('bigg.metabolite', re.compile(r"^[a-z_A-Z0-9]+$")),
     ('biocyc', re.compile(
         r"^[A-Z-0-9]+(?<!CHEBI)(\:)?[A-Za-z0-9+_.%-]+$"))
+])
+
+
+GENE_ANNOTATIONS = OrderedDict([
+    ('refseq', re.compile(r"^((AC|AP|NC|NG|NM|NP|NR|NT|NW|XM|XP|XR|YP|ZP)_\d+|(NZ\_[A-Z]{4}\d+))(\.\d+)?$")),
+    # Does this belong?
+    ('uniprot', re.compile(r"^([A-N,R-Z][0-9]([A-Z][A-Z, 0-9][A-Z, 0-9][0-9]){1,2})|([O,P,Q][0-9][A-Z, 0-9][A-Z, 0-9][A-Z, 0-9][0-9])(\.\d+)?$")),
+    # Does this belong?
+    ('ec-code', re.compile(r"^\d+\.-\.-\.-|\d+\.\d+\.-\.-|\d+\.\d+\.\d+\.-|\d+\.\d+\.\d+\.(n)?\d+$"))
+    # Does this belong?
+    ('brenda', re.compile(
+        r"^\d+\.-\.-\.-|\d+\.\d+\.-\.-|"
+        r"\d+\.\d+\.\d+\.-|"
+        r"\d+\.\d+\.\d+\.(n)?\d+$")),
+    # Does this belong?
+    ('ecogene', re.compile(r"^EG\d+$")),
+    # Is this right?
+    ('kegg.gene', re.compile(r"^([CHDEGTMKR]\d+)|(\w+:[\w\d\.-]*)|([a-z]{3,5})|(\w{2,4}\d{5})$"))
 ])
 
 


### PR DESCRIPTION
* [x] partially fix #185 
* [x] description of feature/fix
* [x] tests added/passed
* [x] add an entry to the [next release](../HISTORY.rst)

Genes/gene products are not currently tested to ensure they have proper annotations. This PR adds two unit tests `test_gene_product_annotation_presence` (which tests to ensure all gene products in models are annotated) and `test_gene_product_annotation_overview` (which ensures all gene product annotations come from MIRIAM style common databases [KEGG, UniProt, etc.]).

Note: This does NOT add unit tests for testing consistency of gene IDs (belonging to refseq/ genbank namespace of target organism) nor for testing validity of gene annotation identifiers. These will be addressed in a future PR.