### PR TITLE
Feat/check duplicate mets in comps

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -28,6 +28,8 @@ Next Release
 * Add unit tests for ``matrix.py`` in file ``test_for_matrix.py``.
 * Add tests ``find_metabolites_not_produced_with_open_bounds`` and
   ``find_metabolites_not_consumed_with_open_bounds``
+* Add test ``find_duplicate_metabolites_in_compartments`` to detect duplicate
+  metabolites in identical compartments
 
 0.6.2 (2018-03-12)
 ------------------

--- a/memote/suite/templates/test_config.yml
+++ b/memote/suite/templates/test_config.yml
@@ -47,6 +47,7 @@ cards:
     title: "Basic Information"
     cases:
     - test_find_unique_metabolites
+    - test_find_duplicate_metabolites_in_compartments
     - test_find_transport_reactions
     - test_find_constrained_transport_reactions
     - test_find_pure_metabolic_reactions

--- a/memote/suite/tests/test_basic.py
+++ b/memote/suite/tests/test_basic.py
@@ -446,3 +446,25 @@ def test_find_unique_metabolites(read_only_model):
         total of {} ({:.2%}) unique metabolites in the model: {}""".format(
             len(ann["data"]), ann["metric"], truncate(ann["data"])))
     assert len(ann["data"]) < len(read_only_model.metabolites), ann["message"]
+
+
+@annotate(title="Number of Unique Metabolites", type="count")
+def test_find_duplicate_metabolites_in_compartments(read_only_model):
+    """
+    Expect there to be zero duplicate metabolites in the same compartments.
+
+    Metabolites may be transported into different compartments, and so models
+    may have metabolites such H2O or ATP in multiple compartments. However,
+    within a compartment, there should be no such duplicate metabolites. This
+    test therefore expects that every metabolite in any particular compartment
+    has unique inchikey values.
+    """
+    ann = test_find_duplicate_metabolites_in_compartments.annotation
+    ann["data"] = basic.find_duplicate_metabolites_in_compartments(
+        read_only_model)
+    ann["metric"] = len(ann["data"]) / len(read_only_model.metabolites)
+    ann["message"] = wrapper.fill(
+        """There are a total of {} ({:.2%}) metabolites in the model which
+        have duplicates in the same compartment: {}""".format(
+            len(ann["data"]), ann["metric"], truncate(ann["data"])))
+    assert len(ann["data"]) == 0, ann["message"]

--- a/memote/suite/tests/test_basic.py
+++ b/memote/suite/tests/test_basic.py
@@ -375,34 +375,6 @@ def test_find_constrained_transport_reactions(read_only_model):
                                                truncate(ann["data"])))
 
 
-@annotate(title="Fraction of Transport Reactions without GPR", type="percent")
-def test_transport_reaction_gpr_presence(read_only_model):
-    """
-    Expect a small fraction of transport reactions not to have a GPR rule.
-
-    As it is hard to identify the exact transport processes within a cell,
-    transport reactions are often added purely for modeling purposes.
-    Highlighting where assumptions have been made vs where
-    there is proof may help direct the efforts to improve transport and
-    transport energetics of the tested metabolic model.
-    However, transport reactions without GPR may also be valid:
-    Diffusion, or known reactions with yet undiscovered genes likely lack GPR.
-    """
-    # TODO: Update threshold with improved insight from meta study.
-    ann = test_transport_reaction_gpr_presence.annotation
-    ann["data"] = get_ids(
-        basic.check_transport_reaction_gpr_presence(read_only_model)
-    )
-    ann["metric"] = len(ann["data"]) / len(
-        helpers.find_transport_reactions(read_only_model)
-    )
-    ann["message"] = wrapper.fill(
-        """There are a total of {} transport reactions ({:.2%} of all
-        transport reactions) without GPR:
-        {}""".format(len(ann["data"]), ann["metric"], truncate(ann["data"])))
-    assert ann["metric"] < 0.2, ann["message"]
-
-
 @annotate(title="Number of Reversible Oxygen-Containing Reactions",
           type="count")
 def test_find_reversible_oxygen_reactions(read_only_model):
@@ -468,3 +440,31 @@ def test_find_duplicate_metabolites_in_compartments(read_only_model):
         have duplicates in the same compartment: {}""".format(
             len(ann["data"]), ann["metric"], truncate(ann["data"])))
     assert len(ann["data"]) == 0, ann["message"]
+
+
+@annotate(title="Fraction of Transport Reactions without GPR", type="percent")
+def test_transport_reaction_gpr_presence(read_only_model):
+    """
+    Expect a small fraction of transport reactions not to have a GPR rule.
+
+    As it is hard to identify the exact transport processes within a cell,
+    transport reactions are often added purely for modeling purposes.
+    Highlighting where assumptions have been made vs where
+    there is proof may help direct the efforts to improve transport and
+    transport energetics of the tested metabolic model.
+    However, transport reactions without GPR may also be valid:
+    Diffusion, or known reactions with yet undiscovered genes likely lack GPR.
+    """
+    # TODO: Update threshold with improved insight from meta study.
+    ann = test_transport_reaction_gpr_presence.annotation
+    ann["data"] = get_ids(
+        basic.check_transport_reaction_gpr_presence(read_only_model)
+    )
+    ann["metric"] = len(ann["data"]) / len(
+        helpers.find_transport_reactions(read_only_model)
+    )
+    ann["message"] = wrapper.fill(
+        """There are a total of {} transport reactions ({:.2%} of all
+        transport reactions) without GPR:
+        {}""".format(len(ann["data"]), ann["metric"], truncate(ann["data"])))
+    assert ann["metric"] < 0.2, ann["message"]

--- a/memote/suite/tests/test_basic.py
+++ b/memote/suite/tests/test_basic.py
@@ -454,18 +454,17 @@ def test_find_duplicate_metabolites_in_compartments(read_only_model):
     """
     Expect there to be zero duplicate metabolites in the same compartments.
 
-    Metabolites may be transported into different compartments, and so models
-    may have metabolites such H2O or ATP in multiple compartments. However,
-    within a compartment, there should be no such duplicate metabolites. This
+    The main reason for having this test is to clean up merged models or models
+    from automated reconstruction pipelines as these are prone to having
+    identical metabolites from different namespaces (hence different IDs). This
     test therefore expects that every metabolite in any particular compartment
     has unique inchikey values.
     """
     ann = test_find_duplicate_metabolites_in_compartments.annotation
     ann["data"] = basic.find_duplicate_metabolites_in_compartments(
         read_only_model)
-    ann["metric"] = len(ann["data"]) / len(read_only_model.metabolites)
     ann["message"] = wrapper.fill(
-        """There are a total of {} ({:.2%}) metabolites in the model which
+        """There are a total of {} metabolites in the model which
         have duplicates in the same compartment: {}""".format(
-            len(ann["data"]), ann["metric"], truncate(ann["data"])))
+            len(ann["data"]), truncate(ann["data"])))
     assert len(ann["data"]) == 0, ann["message"]

--- a/memote/suite/tests/test_basic.py
+++ b/memote/suite/tests/test_basic.py
@@ -375,6 +375,34 @@ def test_find_constrained_transport_reactions(read_only_model):
                                                truncate(ann["data"])))
 
 
+@annotate(title="Fraction of Transport Reactions without GPR", type="percent")
+def test_transport_reaction_gpr_presence(read_only_model):
+    """
+    Expect a small fraction of transport reactions not to have a GPR rule.
+
+    As it is hard to identify the exact transport processes within a cell,
+    transport reactions are often added purely for modeling purposes.
+    Highlighting where assumptions have been made vs where
+    there is proof may help direct the efforts to improve transport and
+    transport energetics of the tested metabolic model.
+    However, transport reactions without GPR may also be valid:
+    Diffusion, or known reactions with yet undiscovered genes likely lack GPR.
+    """
+    # TODO: Update threshold with improved insight from meta study.
+    ann = test_transport_reaction_gpr_presence.annotation
+    ann["data"] = get_ids(
+        basic.check_transport_reaction_gpr_presence(read_only_model)
+    )
+    ann["metric"] = len(ann["data"]) / len(
+        helpers.find_transport_reactions(read_only_model)
+    )
+    ann["message"] = wrapper.fill(
+        """There are a total of {} transport reactions ({:.2%} of all
+        transport reactions) without GPR:
+        {}""".format(len(ann["data"]), ann["metric"], truncate(ann["data"])))
+    assert ann["metric"] < 0.2, ann["message"]
+
+
 @annotate(title="Number of Reversible Oxygen-Containing Reactions",
           type="count")
 def test_find_reversible_oxygen_reactions(read_only_model):
@@ -440,31 +468,3 @@ def test_find_duplicate_metabolites_in_compartments(read_only_model):
         have duplicates in the same compartment: {}""".format(
             len(ann["data"]), ann["metric"], truncate(ann["data"])))
     assert len(ann["data"]) == 0, ann["message"]
-
-
-@annotate(title="Fraction of Transport Reactions without GPR", type="percent")
-def test_transport_reaction_gpr_presence(read_only_model):
-    """
-    Expect a small fraction of transport reactions not to have a GPR rule.
-
-    As it is hard to identify the exact transport processes within a cell,
-    transport reactions are often added purely for modeling purposes.
-    Highlighting where assumptions have been made vs where
-    there is proof may help direct the efforts to improve transport and
-    transport energetics of the tested metabolic model.
-    However, transport reactions without GPR may also be valid:
-    Diffusion, or known reactions with yet undiscovered genes likely lack GPR.
-    """
-    # TODO: Update threshold with improved insight from meta study.
-    ann = test_transport_reaction_gpr_presence.annotation
-    ann["data"] = get_ids(
-        basic.check_transport_reaction_gpr_presence(read_only_model)
-    )
-    ann["metric"] = len(ann["data"]) / len(
-        helpers.find_transport_reactions(read_only_model)
-    )
-    ann["message"] = wrapper.fill(
-        """There are a total of {} transport reactions ({:.2%} of all
-        transport reactions) without GPR:
-        {}""".format(len(ann["data"]), ann["metric"], truncate(ann["data"])))
-    assert ann["metric"] < 0.2, ann["message"]

--- a/memote/suite/tests/test_basic.py
+++ b/memote/suite/tests/test_basic.py
@@ -448,7 +448,8 @@ def test_find_unique_metabolites(read_only_model):
     assert len(ann["data"]) < len(read_only_model.metabolites), ann["message"]
 
 
-@annotate(title="Number of Unique Metabolites", type="count")
+@annotate(title="Number of Duplicate Metabolites in Identical Compartments",
+          type="count")
 def test_find_duplicate_metabolites_in_compartments(read_only_model):
     """
     Expect there to be zero duplicate metabolites in the same compartments.

--- a/memote/support/basic.py
+++ b/memote/support/basic.py
@@ -240,6 +240,28 @@ def find_unique_metabolites(model):
     return set(met.id.split("_", 1)[0] for met in model.metabolites)
 
 
+def find_duplicate_metabolites_in_compartments(model):
+    """
+    Return list of metabolites with duplicates in the same compartment.
+
+    All comparments in models should have a unique set of metabolites. This
+    functions checks for and returns a list of tuples contaning the duplicate
+    metabolites. An example of this would be finding compounds with IDs ATP1
+    and ATP2 in the cytosolic compartment, with both having identical InChI
+    annotations.
+
+    Parameters
+    ----------
+    model : cobra.Model
+        The metabolic model under investigation
+
+    """
+    for comparment in model.comparments:
+        ann_mets = [(met, met.annotation) for met in model.metabolites
+                    if met.comparment == comparment]
+        for ann_met in ann_mets:
+            
+
 def check_transport_reaction_gpr_presence(model):
     """Return the list of transport reactions that have no associated gpr."""
     return [rxn for rxn in helpers.find_transport_reactions(model)

--- a/memote/support/basic.py
+++ b/memote/support/basic.py
@@ -260,12 +260,13 @@ def find_duplicate_metabolites_in_compartments(model):
     duplicates = []
     for comparment in model.comparments:
         ann_mets = [(met, met.annotation) for met in model.metabolites
-                    if met.comparment == comparment]
+                    if met.comparment == comparment and
+                    "InChI" in met.annotation]
         for a, b in combinations(ann_mets, 2):
-            if a[1] == b[1] and a[1] != {} and b[1] != {}:
+            if a[1]["InChI"] == b[1]["InChI"]:
                 duplicates.append((a[0], b[0]))
     return duplicates
-            
+
 
 def check_transport_reaction_gpr_presence(model):
     """Return the list of transport reactions that have no associated gpr."""

--- a/memote/support/basic.py
+++ b/memote/support/basic.py
@@ -20,6 +20,7 @@
 from __future__ import absolute_import
 
 import logging
+from itertools import combinations
 
 import memote.support.helpers as helpers
 
@@ -256,10 +257,14 @@ def find_duplicate_metabolites_in_compartments(model):
         The metabolic model under investigation
 
     """
+    duplicates = []
     for comparment in model.comparments:
         ann_mets = [(met, met.annotation) for met in model.metabolites
                     if met.comparment == comparment]
-        for ann_met in ann_mets:
+        for a, b in combinations(ann_mets, 2):
+            if a[1] == b[1] and a[1] != {} and b[1] != {}:
+                duplicates.append((a[0], b[0]))
+    return duplicates
             
 
 def check_transport_reaction_gpr_presence(model):

--- a/memote/support/basic.py
+++ b/memote/support/basic.py
@@ -261,9 +261,9 @@ def find_duplicate_metabolites_in_compartments(model):
     for comparment in model.comparments:
         ann_mets = [(met, met.annotation) for met in model.metabolites
                     if met.comparment == comparment and
-                    "InChI" in met.annotation]
+                    "inchikey" in met.annotation]
         for a, b in combinations(ann_mets, 2):
-            if a[1]["InChI"] == b[1]["InChI"]:
+            if a[1]["inchikey"] == b[1]["InChI"]:
                 duplicates.append((a[0], b[0]))
     return duplicates
 

--- a/memote/support/basic.py
+++ b/memote/support/basic.py
@@ -258,12 +258,12 @@ def find_duplicate_metabolites_in_compartments(model):
 
     """
     duplicates = []
-    for comparment in model.comparments:
+    for compartment in model.compartments:
         ann_mets = [(met, met.annotation) for met in model.metabolites
-                    if met.comparment == comparment and
+                    if met.compartment == compartment and
                     "inchikey" in met.annotation]
         for a, b in combinations(ann_mets, 2):
-            if a[1]["inchikey"] == b[1]["InChI"]:
+            if a[1]["inchikey"] == b[1]["inchikey"]:
                 duplicates.append((a[0], b[0]))
     return duplicates
 


### PR DESCRIPTION
* [x] fix #241 
* [x] description of feature/fix
* [x] tests added/passed
* [x] add an entry to the [next release](../HISTORY.rst)

Add tests that check for duplicate metabolites in the same compartment (i.e. 2 ATP metabolites in the cytosolic compartment). This check is performed using inchikey annotations.
