### PR TITLE
Clarified wording on genes, species and reactions test

### DIFF
--- a/memote/suite/tests/test_basic.py
+++ b/memote/suite/tests/test_basic.py
@@ -43,7 +43,7 @@ def test_model_id_presence(read_only_model):
 @annotate(title="Total Number of Genes", type="count")
 def test_genes_presence(read_only_model):
     """
-    Expect that more than one gene is defined in the model.
+    Expect that at least one gene is defined in the model.
 
     A metabolic model can still be a useful tool without any
     genes, however there are certain methods which rely on the presence of
@@ -61,7 +61,7 @@ def test_genes_presence(read_only_model):
 @annotate(title="Total Number of Reactions", type="count")
 def test_reactions_presence(read_only_model):
     """
-    Expect that more than one reaction is defined in the model.
+    Expect that at least one reaction is defined in the model.
 
     To be useful a metabolic model should consist at least of a few reactions.
     This test simply checks if there are more than one.
@@ -77,7 +77,7 @@ def test_reactions_presence(read_only_model):
 @annotate(title="Total Number of Metabolites", type="count")
 def test_metabolites_presence(read_only_model):
     """
-    Expect that more than one metabolite is defined in the model.
+    Expect that at least one metabolite is defined in the model.
 
     To be useful a metabolic model should consist at least of a few
     metabolites that are converted by reactions.

--- a/memote/suite/tests/test_basic.py
+++ b/memote/suite/tests/test_basic.py
@@ -64,7 +64,7 @@ def test_reactions_presence(read_only_model):
     Expect that at least one reaction is defined in the model.
 
     To be useful a metabolic model should consist at least of a few reactions.
-    This test simply checks if there are more than one.
+    This test simply checks if there are more than zero reactions.
     """
     ann = test_reactions_presence.annotation
     assert hasattr(read_only_model, "reactions")
@@ -81,7 +81,7 @@ def test_metabolites_presence(read_only_model):
 
     To be useful a metabolic model should consist at least of a few
     metabolites that are converted by reactions.
-    This test simply checks if there are more than one metabolites defined.
+    This test simply checks if there are more than zero metabolites.
     """
     ann = test_metabolites_presence.annotation
     assert hasattr(read_only_model, "metabolites")

--- a/memote/support/helpers.py
+++ b/memote/support/helpers.py
@@ -459,7 +459,7 @@ def find_exchange_rxns(model):
 
 def find_interchange_biomass_reactions(model, biomass=None):
     """
-    Return the set of all tranport, boundary, and biomass reactions in a model.
+    Return the set of all transport, boundary, and biomass reactions in a model.
 
     These reactions are incorporated in models simply for to allow
     metabolites into the correct compartments for vital system reactions to


### PR DESCRIPTION
You are doing `>=1` tests but wrote `more than one`, this is incorrect.
Change to "at least one" or "more than zero".

* [ ] fix #x (issue number)
* [ ] description of feature/fix
* [ ] tests added/passed
* [ ] add an entry to the [next release](../HISTORY.rst)
