### PR TITLE
Clarified model id test

### DIFF
--- a/memote/suite/tests/test_basic.py
+++ b/memote/suite/tests/test_basic.py
@@ -30,7 +30,7 @@ def test_model_id_presence(read_only_model):
     """
     Expect that the model has an identifier.
 
-    The MIRIAM guidelines require a model to be named. While it is not
+    The MIRIAM guidelines require a model to be identified via an ID. While it is not
     required, the ID will be displayed on the memote reports, which helps to
     distinguish the output clearly.
     """

--- a/memote/suite/tests/test_basic.py
+++ b/memote/suite/tests/test_basic.py
@@ -30,9 +30,9 @@ def test_model_id_presence(read_only_model):
     """
     Expect that the model has an identifier.
 
-    The MIRIAM guidelines require a model to be identified via an ID. While it is not
-    required, the ID will be displayed on the memote reports, which helps to
-    distinguish the output clearly.
+    The MIRIAM guidelines require a model to be identified via an ID. 
+    While it is not required, the ID will be displayed on the memote 
+    reports, which helps to distinguish the output clearly.
     """
     ann = test_model_id_presence.annotation
     assert hasattr(read_only_model, "id")

--- a/memote/suite/tests/test_basic.py
+++ b/memote/suite/tests/test_basic.py
@@ -30,8 +30,8 @@ def test_model_id_presence(read_only_model):
     """
     Expect that the model has an identifier.
 
-    The MIRIAM guidelines require a model to be identified via an ID. 
-    While it is not required, the ID will be displayed on the memote 
+    The MIRIAM guidelines require a model to be identified via an ID.
+    While it is not required, the ID will be displayed on the memote
     reports, which helps to distinguish the output clearly.
     """
     ann = test_model_id_presence.annotation


### PR DESCRIPTION
"model to be named" is ambiguous and implies that the SBML `name` attribute should be set on the model.
By clearly stating that the model should be identified via ID this is clearer.

* [ ] fix #x (issue number)
* [ ] description of feature/fix
* [ ] tests added/passed
* [ ] add an entry to the [next release](../HISTORY.rst)
