### PR TITLE
fix: pin cobra version to latest stable

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -7,7 +7,7 @@ parse = (?P<major>\d+)
 	\.(?P<minor>\d+)
 	\.(?P<patch>\d+)
 	(?P<release>[a]?)(?P<num>\d*)
-serialize = 
+serialize =
 	{major}.{minor}.{patch}{release}{num}
 	{major}.{minor}.{patch}
 
@@ -17,7 +17,7 @@ url = https://github.com/opencobra/memote
 download_url = https://pypi.org/pypi/memote/
 author = Moritz E. Beber
 author_email = morbeb@biosustain.dtu.dk
-classifiers = 
+classifiers =
 	Development Status :: 5 - Production/Stable
 	Intended Audience :: Developers
 	Intended Audience :: Science/Research
@@ -33,7 +33,7 @@ classifiers =
 license = Apache Software License Version 2.0
 description = the genome-scale metabolic model test suite
 long_description = file: README.rst
-keywords = 
+keywords =
 	memote
 	metabolic
 	constrained-based
@@ -45,7 +45,7 @@ keywords =
 
 [options]
 zip_safe = False
-install_requires = 
+install_requires =
 	click
 	click-configfile
 	click-log
@@ -57,7 +57,7 @@ install_requires =
 	Jinja2
 	jinja2-ospath
 	cookiecutter
-	cobra>=0.9.1
+	cobra==0.12.0
 	python-libsbml
 	ruamel.yaml<0.15
 	travispy
@@ -71,7 +71,7 @@ install_requires =
 	goodtables==1.0.0
 	depinfo
 python_requires = >=2.7,!=3.1,!=3.2,!=3.3,!=3.4
-tests_require = 
+tests_require =
 	pytest>=3.1
 	pytest-raises
 	pytest-cov
@@ -81,25 +81,25 @@ tests_require =
 packages = find:
 
 [options.package_data]
-memote.experimental.schemata = 
+memote.experimental.schemata =
 	*.json
-memote.suite = 
+memote.suite =
 	tests/*.py
-memote.suite.templates = 
+memote.suite.templates =
 	*.html
 	*.yml
-memote.support.data = 
+memote.support.data =
 	*.csv
 	*.json
 
 [options.entry_points]
-console_scripts = 
+console_scripts =
 	memote = memote.suite.cli.runner:cli
 
 [bumpversion:part:release]
 optional_value = placeholder
 first_value = placeholder
-values = 
+values =
 	placeholder
 	a
 
@@ -127,7 +127,7 @@ universal = 1
 
 [flake8]
 max-line-length = 80
-exclude = 
+exclude =
 	__init__.py
 	docs
 


### PR DESCRIPTION
Pinned the cobrapy version to 0.12.0 since the new release (0.12.1/ 0.13.0) cause breaking changes, which would require a larger refactor.



Opened #445 to keep track of this issue.