### PR TITLE
refactor: selectively compute history

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -3,11 +3,13 @@ History
 
 Next Release
 ------------
+* Allow users to selective recompute the history of results.
+* Skip commits in the history that did not change the model file.
 * Change format_type on experimental tests from `count` to `percent`
 * Fix typo in `test_basic.py` that lead to tests returning `null` which breaks
   the diff report frontend.
 * Update the diff report to properly show errored and skipped tests
-* Fix issues with asynchronicity on the diff report 
+* Fix issues with asynchronicity on the diff report.
 
 0.8.0 (2018-06-22)
 ------------------

--- a/memote/suite/cli/runner.py
+++ b/memote/suite/cli/runner.py
@@ -258,7 +258,12 @@ def history(model, solver, location, pytest_args, commits, skip,
         history.build_branch_structure()
     for commit in history.iter_commits():
         repo.git.checkout(commit)
-        # TODO: Skip this commit if model was not touched.
+        modified = {blob[0] for blob in repo.index.entries}
+        if model not in modified:
+            LOGGER.info(
+                "The model was not modified in commit '{}'. Skipping.".format(
+                    commit))
+            continue
         LOGGER.info(
             "Running the test suite for commit '{}'.".format(commit))
         proc = Process(

--- a/memote/suite/cli/runner.py
+++ b/memote/suite/cli/runner.py
@@ -233,6 +233,7 @@ def history(model, solver, location, pytest_args, commits, skip,
        model repositories.
     2. By giving memote specific commit hashes, it will re-compute test results
        for those only.
+
     """
     if "--tb" not in pytest_args:
         pytest_args = ["--tb", "no"] + pytest_args
@@ -352,18 +353,6 @@ def online(note, github_repository, github_username):
     repo.index.add([".travis.yml"])
     repo.index.commit("chore: add encrypted GitHub access token")
     repo.remotes.origin.push(all=True)
-
-
-@cli.command(context_settings=CONTEXT_SETTINGS)
-@click.help_option("--help", "-h")
-@click.argument("message")
-def save(message):
-    """
-    Save current model changes with the given message.
-
-    If a remote repository 'origin' exists the changes will also be uploaded.
-    """
-    raise NotImplementedError(u"Coming soon™.")
 
 
 cli.add_command(report)

--- a/memote/suite/results/history_manager.py
+++ b/memote/suite/results/history_manager.py
@@ -120,3 +120,8 @@ class HistoryManager(object):
         assert self._results is not None, \
             "Please call the method `load_history` first."
         return self._results.get(commit, default)
+
+    def __contains__(self, commit):
+        assert self._results is not None, \
+            "Please call the method `load_history` first."
+        return commit in self._results

--- a/memote/suite/results/history_manager.py
+++ b/memote/suite/results/history_manager.py
@@ -116,6 +116,7 @@ class HistoryManager(object):
         return self._results.get(commit, default)
 
     def __contains__(self, commit):
+        """Test for the existence of a result for a commit."""
         assert self._results is not None, \
             "Please call the method `load_history` first."
         return commit in self._results

--- a/memote/suite/results/history_manager.py
+++ b/memote/suite/results/history_manager.py
@@ -58,13 +58,8 @@ class HistoryManager(object):
         super(HistoryManager, self).__init__(**kwargs)
         self._repo = repository
         self.manager = manager
-        self._latest = self._repo.active_branch
         self._history = None
         self._results = None
-
-    def reset(self):
-        """Reset the git repository to head of the previously active branch."""
-        self._repo.git.checkout(self._latest)
 
     def build_branch_structure(self):
         """Inspect and record the repo's branches and their history."""
@@ -87,7 +82,6 @@ class HistoryManager(object):
                     sub["author"] = commit.author.name
                     sub["email"] = commit.author.email
         LOGGER.debug("%s", json.dumps(self._history, indent=2))
-        self.reset()
 
     def iter_branches(self):
         """Iterate over branch names and their commit histories."""

--- a/memote/suite/results/repo_result_manager.py
+++ b/memote/suite/results/repo_result_manager.py
@@ -125,8 +125,6 @@ class RepoResultManager(ResultManager):
 
         """
         git_info = self.record_git_info(commit)
-        LOGGER.critical(git_info)
-        LOGGER.critical(self._backend)
         self.add_git(result.meta, git_info)
         filename = self.get_filename(git_info)
         super(RepoResultManager, self).store(


### PR DESCRIPTION
* [x] fix #132 
* [x] description of feature/fix
* [x] tests added/passed
* [x] add an entry to the [next release](../HISTORY.rst)

`memote history` now skips commits that didn't modify the model file. Users can choose to overwrite existing results or not.