### PR TITLE
Ignore commits in which the model was not changed with `memote run`, add option to trigger a test.

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -19,6 +19,9 @@ Next Release
 * In the diff report, fix a typo that allowed the diff button to depart the 
   defined colour scheme (blue -> red) to cyan.
 * Fix the snapshot report not showing environment information.
+* Set ``memote run`` to default to skipping commits where the model was not 
+  changed, but implement a flag that enables testing nonetheless. The flag is 
+  ``--test-unchanged``.
 
 0.8.6 (2018-09-13)
 ------------------

--- a/memote/suite/cli/runner.py
+++ b/memote/suite/cli/runner.py
@@ -178,7 +178,11 @@ def run(model, collect, filename, location, ignore_git, pytest_args, exclusive,
             manager.store(result, filename=filename)
         else:
             LOGGER.info("Checking out deployment branch.")
-            #
+            # If the repo HEAD is pointing at the most recent branch then
+            # GitPython's `repo.active_branch` works. Yet, if the repo is in
+            # detached HEAD state i.e. when a user has checked out a specific
+            # commit as opposed to a branch, this won't work and throw a
+            # TypeError, which we are circumventing below.
             try:
                 previous = repo.active_branch
                 previous_cmt = previous.commit

--- a/memote/suite/cli/runner.py
+++ b/memote/suite/cli/runner.py
@@ -117,13 +117,13 @@ def cli():
 @click.option("--deployment", default="gh-pages", show_default=True,
               help="Results will be read from and committed to the given "
                    "branch.")
-@click.option("--test-unchanged", default=False, is_flag=True,
-              show_default=True, help="Run memote on commits where "
+@click.option("--skip-unchanged", default=False, is_flag=True,
+              show_default=True, help="Skip memote run on commits where "
               "the model was not changed.")
 @click.argument("model", type=click.Path(exists=True, dir_okay=False),
                 envvar="MEMOTE_MODEL")
 def run(model, collect, filename, location, ignore_git, pytest_args, exclusive,
-        skip, solver, experimental, custom_tests, deployment, test_unchanged):
+        skip, solver, experimental, custom_tests, deployment, skip_unchanged):
     """
     Run the test suite on a single model and collect results.
 
@@ -152,7 +152,7 @@ def run(model, collect, filename, location, ignore_git, pytest_args, exclusive,
         pytest_args.append("-vv")
     # Check if the model was changed in this commit. Exit `memote run` if this
     # was not the case.
-    if not test_unchanged and repo is not None:
+    if skip_unchanged and repo is not None:
         commit = repo.head.commit
         staged_files = commit.stats.files
         if not basename(

--- a/memote/suite/cli/runner.py
+++ b/memote/suite/cli/runner.py
@@ -117,9 +117,9 @@ def cli():
 @click.option("--deployment", default="gh-pages", show_default=True,
               help="Results will be read from and committed to the given "
                    "branch.")
-@click.option("--skip-unchanged", default=False, is_flag=True,
-              show_default=True, help="Skip memote run on commits where "
-              "the model was not changed.")
+@click.option("--skip-unchanged", is_flag=True, show_default=True,
+              help="Skip memote run on commits where the model was not "
+                   "changed.")
 @click.argument("model", type=click.Path(exists=True, dir_okay=False),
                 envvar="MEMOTE_MODEL")
 def run(model, collect, filename, location, ignore_git, pytest_args, exclusive,

--- a/memote/suite/cli/runner.py
+++ b/memote/suite/cli/runner.py
@@ -23,7 +23,7 @@ import os
 import sys
 import logging
 from gzip import GzipFile
-from os.path import join, isfile
+from os.path import join, isfile, basename
 from multiprocessing import Process
 from getpass import getpass
 from time import sleep
@@ -117,10 +117,13 @@ def cli():
 @click.option("--deployment", default="gh-pages", show_default=True,
               help="Results will be read from and committed to the given "
                    "branch.")
+@click.option("--ignore-unchanged", is_flag=True, show_default=True,
+              help="Skip running memote on commits where the model was not "
+                   "changed.")
 @click.argument("model", type=click.Path(exists=True, dir_okay=False),
                 envvar="MEMOTE_MODEL", callback=callbacks.validate_model)
 def run(model, collect, filename, location, ignore_git, pytest_args, exclusive,
-        skip, solver, experimental, custom_tests, deployment):
+        skip, solver, experimental, custom_tests, deployment, ignore_unchanged):
     """
     Run the test suite on a single model and collect results.
 
@@ -147,6 +150,16 @@ def run(model, collect, filename, location, ignore_git, pytest_args, exclusive,
         pytest_args = ["--tb", "short"] + pytest_args
     if not any(is_verbose(a) for a in pytest_args):
         pytest_args.append("-vv")
+    if ignore_unchanged and repo is not None:
+        commit = repo.active_branch.commit
+        staged_files = commit.stats.files
+        if not basename(
+            model
+        ) in [basename(path) for path in staged_files.keys()]:
+            LOGGER.info(
+                "The model was not modified in commit '{}'. Memote wont run. "
+                "This is the default setting.".format(commit))
+            sys.exit(0)
     # Add further directories to search for tests.
     pytest_args.extend(custom_tests)
     model.solver = solver

--- a/memote/suite/results/history_manager.py
+++ b/memote/suite/results/history_manager.py
@@ -26,6 +26,7 @@ from six import iteritems, iterkeys
 from sqlalchemy.orm.exc import NoResultFound
 
 from memote.suite.results import MemoteResult
+from memote.utils import is_modified
 
 __all__ = ("HistoryManager",)
 
@@ -75,7 +76,7 @@ class HistoryManager(object):
             history = [latest] + list(latest.iter_parents())
             for commit in history:
                 # Find model in committed files.
-                if model not in commit.stats.files:
+                if not is_modified(model, commit):
                     LOGGER.info(
                         "The model was not modified in commit '{}'. "
                         "Skipping.".format(commit))

--- a/memote/support/basic.py
+++ b/memote/support/basic.py
@@ -24,6 +24,7 @@ from itertools import combinations
 from pylru import lrudecorator
 
 import memote.support.helpers as helpers
+from memote.utils import filter_none
 
 __all__ = ("check_metabolites_formula_presence",)
 
@@ -135,7 +136,7 @@ def find_ngam(model):
                  'ngam', 'non-growth', 'associated']
 
     refined_candidates = [rxn for rxn in candidates if any(
-        string in rxn.name.lower() for string in buzzwords
+        string in filter_none(rxn.name, '').lower() for string in buzzwords
     )]
 
     if refined_candidates:

--- a/memote/support/helpers.py
+++ b/memote/support/helpers.py
@@ -318,9 +318,8 @@ def find_biomass_reaction(model):
 
     biomass_met = []
     for met in model.metabolites:
-        if met.id.lower().startswith('biomass') or met.name.lower().startswith(
-            'biomass'
-        ):
+        if met.id.lower().startswith('biomass') \
+          or utils.filter_none(met.name, '').lower().startswith('biomass'):
             biomass_met.append(met)
     if biomass_met == 1:
         biomass_met_matches = set(

--- a/memote/support/helpers.py
+++ b/memote/support/helpers.py
@@ -318,8 +318,8 @@ def find_biomass_reaction(model):
 
     biomass_met = []
     for met in model.metabolites:
-        if met.id.lower().startswith('biomass') \
-          or utils.filter_none(met.name, '').lower().startswith('biomass'):
+        if 'biomass' in met.id.lower() or (
+                met.name is not None and 'biomass' in met.name.lower()):
             biomass_met.append(met)
     if biomass_met == 1:
         biomass_met_matches = set(

--- a/memote/utils.py
+++ b/memote/utils.py
@@ -22,7 +22,6 @@ from __future__ import absolute_import
 import json
 import logging
 from builtins import dict, str
-from os.path import basename
 from textwrap import TextWrapper
 
 from future.utils import raise_with_traceback
@@ -281,8 +280,4 @@ def is_modified(path, commit):
         Whether or not the given path is among the modified files.
 
     """
-    path = basename(path)
-    return any(path == basename(f) for f in commit.stats.files)
-    # TODO: Checking the full relative path is faster and specifies file
-    # correctly.
-    # return path in commit.stats.files
+    return path in commit.stats.files

--- a/memote/utils.py
+++ b/memote/utils.py
@@ -22,16 +22,18 @@ from __future__ import absolute_import
 import json
 import logging
 from builtins import dict, str
-from six import string_types
+from os.path import basename
+from textwrap import TextWrapper
 
 from future.utils import raise_with_traceback
 from numpydoc.docscrape import NumpyDocString
-from textwrap import TextWrapper
+from six import string_types
 from depinfo import print_dependencies
 
 __all__ = ("register_with", "annotate", "get_ids",
            "get_ids_and_bounds", "truncate", "wrapper",
-           "log_json_incompatible_types", "show_versions", "jsonify")
+           "log_json_incompatible_types", "show_versions", "jsonify",
+           "is_modified")
 
 LOGGER = logging.getLogger(__name__)
 
@@ -260,3 +262,27 @@ def flatten(list_of_lists):
         else:
             flat_list.append(tuple(sublist))
     return flat_list
+
+
+def is_modified(path, commit):
+    """
+    Test whether a given file was modified in a specific commit.
+
+    Parameters
+    ----------
+    path : str
+        The path of a file to be checked.
+    commit : git.Commit
+        A git commit object.
+
+    Returns
+    -------
+    bool
+        Whether or not the given path is among the modified files.
+
+    """
+    path = basename(path)
+    return any(path == basename(f) for f in commit.stats.files)
+    # TODO: Checking the full relative path is faster and specifies file
+    # correctly.
+    # return path in commit.stats.files

--- a/memote/utils.py
+++ b/memote/utils.py
@@ -139,6 +139,14 @@ def get_ids_and_bounds(iterable):
             elem in iterable]
 
 
+def filter_none(attribute, default):
+    """Handle attributes of model components that are optional in SBML."""
+    if attribute is None:
+        return default
+    else:
+        return attribute
+
+
 def truncate(sequence):
     """
     Create a potentially shortened text display of a list.

--- a/setup.cfg
+++ b/setup.cfg
@@ -7,7 +7,7 @@ parse = (?P<major>\d+)
 	\.(?P<minor>\d+)
 	\.(?P<patch>\d+)
 	(?P<release>[a]?)(?P<num>\d*)
-serialize = 
+serialize =
 	{major}.{minor}.{patch}{release}{num}
 	{major}.{minor}.{patch}
 
@@ -17,7 +17,7 @@ url = https://github.com/opencobra/memote
 download_url = https://pypi.org/pypi/memote/
 author = Moritz E. Beber
 author_email = morbeb@biosustain.dtu.dk
-classifiers = 
+classifiers =
 	Development Status :: 5 - Production/Stable
 	Intended Audience :: Developers
 	Intended Audience :: Science/Research
@@ -33,7 +33,7 @@ classifiers =
 license = Apache Software License Version 2.0
 description = the genome-scale metabolic model test suite
 long_description = file: README.rst
-keywords = 
+keywords =
 	memote
 	metabolic
 	constrained-based
@@ -45,8 +45,8 @@ keywords =
 
 [options]
 zip_safe = False
-install_requires = 
-	click
+install_requires =
+	click<7.0
 	click-configfile
 	click-log
 	six
@@ -71,7 +71,7 @@ install_requires =
 	goodtables==1.0.0
 	depinfo
 python_requires = >=2.7,!=3.1,!=3.2,!=3.3,!=3.4
-tests_require = 
+tests_require =
 	pytest>=3.1
 	pytest-raises
 	pytest-cov
@@ -81,25 +81,25 @@ tests_require =
 packages = find:
 
 [options.package_data]
-memote.experimental.schemata = 
+memote.experimental.schemata =
 	*.json
-memote.suite = 
+memote.suite =
 	tests/*.py
-memote.suite.templates = 
+memote.suite.templates =
 	*.html
 	*.yml
-memote.support.data = 
+memote.support.data =
 	*.csv
 	*.json
 
 [options.entry_points]
-console_scripts = 
+console_scripts =
 	memote = memote.suite.cli.runner:cli
 
 [bumpversion:part:release]
 optional_value = placeholder
 first_value = placeholder
-values = 
+values =
 	placeholder
 	a
 
@@ -127,7 +127,7 @@ universal = 1
 
 [flake8]
 max-line-length = 80
-exclude = 
+exclude =
 	__init__.py
 	docs
 

--- a/tests/test_for_suite/test_for_cli/conftest.py
+++ b/tests/test_for_suite/test_for_cli/conftest.py
@@ -20,6 +20,7 @@ from __future__ import absolute_import
 from builtins import str
 from os.path import basename
 from shutil import copyfile
+from git import Repo
 
 import pytest
 from click.testing import CliRunner
@@ -36,3 +37,15 @@ def model_file(small_file, tmpdir_factory):
         basename(small_file)))
     copyfile(small_file, filename)
     return filename
+
+
+@pytest.fixture(scope="session")
+def mock_repo(tmpdir_factory):
+    """
+    Clones the mock repo https://github.com/ChristianLieven/memote-mock-repo.
+
+    """
+    path = str(tmpdir_factory.mktemp("mock-repo"))
+    repo = Repo.clone_from(
+        'https://github.com/ChristianLieven/memote-mock-repo.git', path)
+    return path, repo

--- a/tests/test_for_suite/test_for_cli/test_for_runner.py
+++ b/tests/test_for_suite/test_for_cli/test_for_runner.py
@@ -21,6 +21,7 @@ from __future__ import absolute_import
 
 from builtins import str
 from os.path import exists
+import os
 
 import pytest
 
@@ -52,7 +53,7 @@ def test_run_output(runner, model_file):
 
 
 @pytest.mark.skip(reason="TODO: Need to provide input somehow.")
-def test_run_output(runner, tmpdir):
+def test_run_output_TODO(runner, tmpdir):
     """Expect a simple run to function."""
     output = str(tmpdir)
     result = runner.invoke(cli, [
@@ -60,3 +61,33 @@ def test_run_output(runner, tmpdir):
     assert result.exit_code == 0
     assert exists(output)
     # TODO: Check complete template structure.
+
+
+def test_run_test_unchanged_false(runner, mock_repo):
+    """Expect `memote run` to exit when invoked on a commit with no changes."""
+    previous_wd = os.getcwd()
+    os.chdir(mock_repo[0])
+    repo = mock_repo[1]
+    repo.git.checkout('eb959dd016aaa71fcef96f00b94ce045d6af8f4c')
+    result = runner.invoke(cli, ["run", "--location", "results/", "test.xml"])
+    assert result.exit_code == 0
+    repo.git.checkout('gh-pages')
+    number_of_result_files = len(os.listdir(mock_repo[0]+'/results/'))
+    os.chdir(previous_wd)
+    assert number_of_result_files == 3
+
+
+def test_run_test_unchanged_true(runner, mock_repo):
+    """Expect `memote run` to run when invoked on a commit with no changes."""
+    previous_wd = os.getcwd()
+    os.chdir(mock_repo[0])
+    repo = mock_repo[1]
+    repo.git.checkout('eb959dd016aaa71fcef96f00b94ce045d6af8f4c')
+    result = runner.invoke(cli, ["run", "--location",
+                                 "results/", "--test-unchanged",
+                                 "test.xml"])
+    assert result.exit_code == 0
+    repo.git.checkout('gh-pages')
+    number_of_result_files = len(os.listdir(mock_repo[0]+'/results/'))
+    os.chdir(previous_wd)
+    assert number_of_result_files == 4

--- a/tests/test_for_suite/test_for_cli/test_for_runner.py
+++ b/tests/test_for_suite/test_for_cli/test_for_runner.py
@@ -73,6 +73,13 @@ def test_run_skip_unchanged_false(runner, mock_repo):
     assert result.exit_code == 0
     repo.git.checkout('gh-pages')
     number_of_result_files = len(os.listdir(mock_repo[0]+'/results/'))
+    # Clean up the one commit made to the gh-pages branch.
+    repo.git.reset("HEAD~")
+    # Remove the results file that has been created by `memote run`.
+    os.remove(
+        mock_repo[0] +
+        "/results/eb959dd016aaa71fcef96f00b94ce045d6af8f4c.json"
+    )
     os.chdir(previous_wd)
     assert number_of_result_files == 4
 

--- a/tests/test_for_suite/test_for_cli/test_for_runner.py
+++ b/tests/test_for_suite/test_for_cli/test_for_runner.py
@@ -19,9 +19,9 @@
 
 from __future__ import absolute_import
 
-from builtins import str
-from os.path import exists
 import os
+from builtins import str
+from os.path import exists, join
 
 import pytest
 
@@ -69,17 +69,12 @@ def test_run_skip_unchanged_false(runner, mock_repo):
     os.chdir(mock_repo[0])
     repo = mock_repo[1]
     repo.git.checkout('eb959dd016aaa71fcef96f00b94ce045d6af8f4c')
-    result = runner.invoke(cli, ["run", "--location", "results/", "test.xml"])
+    result = runner.invoke(cli, ["run", "--location", "results", "test.xml"])
     assert result.exit_code == 0
     repo.git.checkout('gh-pages')
-    number_of_result_files = len(os.listdir(mock_repo[0]+'/results/'))
+    number_of_result_files = len(os.listdir(join(mock_repo[0], 'results')))
     # Clean up the one commit made to the gh-pages branch.
-    repo.git.reset("HEAD~")
-    # Remove the results file that has been created by `memote run`.
-    os.remove(
-        mock_repo[0] +
-        "/results/eb959dd016aaa71fcef96f00b94ce045d6af8f4c.json"
-    )
+    repo.git.reset("HEAD~", hard=True)
     os.chdir(previous_wd)
     assert number_of_result_files == 4
 
@@ -91,10 +86,10 @@ def test_run_skip_unchanged_true(runner, mock_repo):
     repo = mock_repo[1]
     repo.git.checkout('eb959dd016aaa71fcef96f00b94ce045d6af8f4c')
     result = runner.invoke(cli, ["run", "--location",
-                                 "results/", "--skip-unchanged",
+                                 "results", "--skip-unchanged",
                                  "test.xml"])
     assert result.exit_code == 0
     repo.git.checkout('gh-pages')
-    number_of_result_files = len(os.listdir(mock_repo[0]+'/results/'))
+    number_of_result_files = len(os.listdir(join(mock_repo[0], 'results')))
     os.chdir(previous_wd)
     assert number_of_result_files == 3

--- a/tests/test_for_suite/test_for_cli/test_for_runner.py
+++ b/tests/test_for_suite/test_for_cli/test_for_runner.py
@@ -63,8 +63,8 @@ def test_run_output_TODO(runner, tmpdir):
     # TODO: Check complete template structure.
 
 
-def test_run_test_unchanged_false(runner, mock_repo):
-    """Expect `memote run` to exit when invoked on a commit with no changes."""
+def test_run_skip_unchanged_false(runner, mock_repo):
+    """Expect `memote run` to run when invoked on a commit with no changes."""
     previous_wd = os.getcwd()
     os.chdir(mock_repo[0])
     repo = mock_repo[1]
@@ -74,20 +74,20 @@ def test_run_test_unchanged_false(runner, mock_repo):
     repo.git.checkout('gh-pages')
     number_of_result_files = len(os.listdir(mock_repo[0]+'/results/'))
     os.chdir(previous_wd)
-    assert number_of_result_files == 3
+    assert number_of_result_files == 4
 
 
-def test_run_test_unchanged_true(runner, mock_repo):
-    """Expect `memote run` to run when invoked on a commit with no changes."""
+def test_run_skip_unchanged_true(runner, mock_repo):
+    """Expect `memote run` to skip when invoked on a commit with no changes."""
     previous_wd = os.getcwd()
     os.chdir(mock_repo[0])
     repo = mock_repo[1]
     repo.git.checkout('eb959dd016aaa71fcef96f00b94ce045d6af8f4c')
     result = runner.invoke(cli, ["run", "--location",
-                                 "results/", "--test-unchanged",
+                                 "results/", "--skip-unchanged",
                                  "test.xml"])
     assert result.exit_code == 0
     repo.git.checkout('gh-pages')
     number_of_result_files = len(os.listdir(mock_repo[0]+'/results/'))
     os.chdir(previous_wd)
-    assert number_of_result_files == 4
+    assert number_of_result_files == 3


### PR DESCRIPTION
* [x] fix #500 
* [x] description: Set ``memote run`` to default to skipping commits where the model was not 
  changed, but implement a flag that enables testing nonetheless. The flag is 
  ``--test-unchanged``.
* [x] tests added/passed: `test_run_test_unchanged_false`, `test_run_test_unchanged_true`
* [x] add an entry to the [next release](../HISTORY.rst)
