### PR TITLE
fix: rely on cobrapy's find_blocked_reactions

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -3,6 +3,7 @@ History
 
 Next Release
 ------------
+* Identify blocked reactions using the cobrapy built-in function.
 
 0.8.7 (2018-11-21)
 ------------------

--- a/memote/suite/tests/test_consistency.py
+++ b/memote/suite/tests/test_consistency.py
@@ -20,6 +20,7 @@
 from __future__ import absolute_import, division
 
 import pytest
+from cobra.flux_analysis import find_blocked_reactions
 
 import memote.support.consistency as consistency
 from memote.utils import annotate, truncate, get_ids, wrapper
@@ -167,9 +168,7 @@ def test_blocked_reactions(read_only_model):
 
     """
     ann = test_blocked_reactions.annotation
-    ann["data"] = get_ids(
-        consistency.find_universally_blocked_reactions(read_only_model)
-    )
+    ann["data"] = find_blocked_reactions(read_only_model, open_exchanges=True)
     ann["metric"] = len(ann["data"]) / len(read_only_model.reactions)
     ann["message"] = wrapper.fill(
         """There are {} ({:.2%}) blocked reactions in

--- a/memote/support/consistency.py
+++ b/memote/support/consistency.py
@@ -402,30 +402,6 @@ def find_charge_unbalanced_reactions(reactions):
         rxn for rxn in reactions if not con_helpers.is_charge_balanced(rxn)]
 
 
-def find_universally_blocked_reactions(model):
-    """
-    Find metabolic reactions that are blocked.
-
-    Parameters
-    ----------
-    model : cobra.Model
-        The metabolic model under investigation.
-
-    Notes
-    -----
-    Blocked reactions are those reactions that when optimized for cannot carry
-    any flux while all exchanges are open.
-
-    """
-    with model:
-        helpers.open_boundaries(model)
-        fva_result = flux_variability_analysis(model)
-
-    blocked = fva_result.loc[(fva_result["maximum"] == 0.0) &
-                             (fva_result["minimum"] == 0.0)]
-    return [model.reactions.get_by_id(name) for name in blocked.index]
-
-
 def find_stoichiometrically_balanced_cycles(model):
     u"""
     Find metabolic reactions in stoichiometrically balanced cycles (SBCs).

--- a/tests/test_for_support/test_for_consistency.py
+++ b/tests/test_for_support/test_for_consistency.py
@@ -92,30 +92,11 @@ def figure_2(base):
 
 
 @register_with(MODEL_REGISTRY)
-def free_reactions(base):
-    met_a = cobra.Metabolite("C", compartment= "e")
-    met_b = cobra.Metabolite("A", compartment= "e")
-    met_c = cobra.Metabolite("B", compartment= "e")
-    rxn1 = cobra.Reaction("Gen")
-    rxn1.add_metabolites({met_b: -1, met_a: 1, met_c: 1})
-    rxn2 = cobra.Reaction("Recap", lower_bound=-1000, upper_bound=1000)
-    rxn2.add_metabolites({met_c: -1, met_b: 1})
-    rxn3 = cobra.Reaction("EX_C_e", lower_bound=-1000, upper_bound=1000)
-    rxn3.add_metabolites({met_a: -1})
-    rxn4 = cobra.Reaction("EX_A_e", lower_bound=-1000, upper_bound=1000)
-    rxn4.add_metabolites({met_b: -1})
-    rxn5 = cobra.Reaction("EX_B_e", lower_bound=-1000, upper_bound=1000)
-    rxn5.add_metabolites({met_c: -1})
-    base.add_reactions([rxn1, rxn2, rxn3, rxn4, rxn5])
-    return base
-
-
-@register_with(MODEL_REGISTRY)
 def blocked_reactions(base):
-    met_a = cobra.Metabolite("C", compartment= "e")
-    met_b = cobra.Metabolite("A", compartment= "e")
-    met_c = cobra.Metabolite("B", compartment= "e")
-    met_d = cobra.Metabolite("D", compartment= "e")
+    met_a = cobra.Metabolite("C", compartment="e")
+    met_b = cobra.Metabolite("A", compartment="e")
+    met_c = cobra.Metabolite("B", compartment="e")
+    met_d = cobra.Metabolite("D", compartment="e")
     rxn1 = cobra.Reaction("Gen")
     rxn1.add_metabolites({met_d: -1, met_b: -1, met_a: 1, met_c: 1})
     rxn2 = cobra.Reaction("Recap", lower_bound=-1000, upper_bound=1000)
@@ -409,6 +390,7 @@ def loopy_toy_model(base):
     base.reactions.VB.bounds = 0, 1
     return base
 
+
 @register_with(MODEL_REGISTRY)
 def loopless_toy_model(base):
     base.add_metabolites([cobra.Metabolite(i) for i in "ABC"])
@@ -661,16 +643,6 @@ def test_find_mass_unbalanced_reactions(model, num):
     internal_rxns = con_helpers.get_internals(model)
     reactions = consistency.find_mass_unbalanced_reactions(internal_rxns)
     assert len(reactions) == num
-
-
-@pytest.mark.parametrize("model, num", [
-    ("free_reactions", 0),
-    ("blocked_reactions", 2),
-], indirect=["model"])
-def test_blocked_reactions(model, num):
-    """Expect all reactions to be able to carry flux."""
-    dict_of_blocked_rxns = consistency.find_universally_blocked_reactions(model)
-    assert len(dict_of_blocked_rxns) == num
 
 
 @pytest.mark.parametrize("model, num", [


### PR DESCRIPTION
* [x] fix #518 
* [x] Rely on the cobrapy provided function rather than a memote defined one.
* [x] Tests removed as we rely on cobrapy correctness.
* [x] add an entry to the [next release](../HISTORY.rst)
