### PR TITLE
Refactor thermo

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -3,6 +3,8 @@ History
 
 Next Release
 ------------
+* Adjust the reversibility index test to not use name matching and increase 
+  the threshold slightly. Also adjust the description of the test.
 * Adjust tests to the change in the ``add_boundary`` interface.
 * Identify blocked reactions using the cobrapy built-in function.
 

--- a/memote/suite/templates/test_config.yml
+++ b/memote/suite/templates/test_config.yml
@@ -59,7 +59,7 @@ cards:
     - test_gene_protein_reaction_rule_presence
     - test_find_pure_metabolic_reactions
     - test_find_constrained_pure_metabolic_reactions
-    - test_find_incorrect_thermodynamic_reversibility
+    - test_find_candidate_irreversible_reactions
     - test_find_duplicate_reactions
     - test_find_transport_reactions
     - test_find_constrained_transport_reactions

--- a/memote/suite/tests/test_thermodynamics.py
+++ b/memote/suite/tests/test_thermodynamics.py
@@ -27,71 +27,72 @@ if version_info[:2] < (3, 5):
     pytest.skip("Thermodynamic tests require at least Python version 3.5.",
                 allow_module_level=True)
 
-import memote.support.thermodynamics as thermo # noqa
-import memote.support.basic as basic # noqa
-from memote.utils import (annotate, get_ids, truncate) # noqa
+import memote.support.thermodynamics as thermo  # noqa
+import memote.support.basic as basic  # noqa
+from memote.utils import annotate, get_ids, wrapper  # noqa
 
 
 @annotate(title="Thermodynamic Reversibility of Purely Metabolic Reactions",
           format_type="percent")
-def test_find_incorrect_thermodynamic_reversibility(read_only_model):
+def test_find_candidate_irreversible_reactions(read_only_model):
     u"""
-    Expect reversibility of metabolic reactions to agree with thermodynamics.
+    Identify reversible reactions that could be irreversible.
 
     If a reaction is neither a transport reaction, a biomass reaction nor a
     boundary reaction, it is counted as a purely metabolic reaction.
     This test checks if the reversibility attribute of each reaction
-    in a list of cobrapy reactions agrees with a thermodynamics-based
+    agrees with a thermodynamics-based
     calculation of reversibility. To determine reversibility we calculate
-    the reversibility index ln_gamma of each reaction
-    using the eQuilibrator API. The default cutoff for ln_gamma of 3
-    "corresponds to allowing concentrations to span three orders of magnitude
-    around 100 μM (~3 μM—3 mM)" at "pH = 7, I = 0.1 M and T = 298 K". This
+    the reversibility index ln_gamma (natural logarithm of gamma) of each
+    reaction
+    using the eQuilibrator API. We use an ln_gamma of 10 as a threshold for
+    irreversibility. That value roughly corresponds to three times the
+    span of three orders of magnitude
+    around 100 μM (~3 μM—3 mM) at pH = 7, I = 0.1 M and T = 298 K. This
     means that a reaction is considered irreversible if the concentration of
     an individual metabolite would have to change more than three orders of
     magnitude i.e. from 3 µM to 3 mM to reverse the direction of flux. For
-    further information on the thermodynamic and implementational details
+    further information on the thermodynamic and implementation details
     please refer to
     https://doi.org/10.1093/bioinformatics/bts317 and
-    https://gitlab.com/elad.noor/equilibrator-api/tree/master.
+    https://pypi.org/project/equilibrator-api/.
 
     Please note that currently eQuilibrator can only determine the
     reversibility index for chemically and redox balanced reactions whose
-    metabolites can be mapped to KEGG compound IDs (e.g. C00001). In addition
+    metabolites can be mapped to KEGG compound identifiers (e.g. C00001). In
+    addition
     to not being mappable to KEGG or the reaction not being balanced,
     there is a possibility that the metabolite cannot be broken down into
     chemical groups which is essential for the calculation of Gibbs energy
-    using component contributions. This test collects each exceptional reaction
+    using group contributions. This test collects each erroneous reaction
     and returns them as a tuple containing each list in the following order:
-        1. Reactions with incorrect **rev**ersibility
-        2. Reactions with incomplete **mapping** to KEGG
-        3. Reactions with Metabolites that are problematic
-           during **calc**ulation
-        4. Chemically or redox un**bal**anced Reactions (after mapping to KEGG)
+        1. Reactions with reversibility index
+        2. Reactions with incomplete mapping to KEGG
+        3. Reactions with metabolites that are problematic during calculation
+        4. Chemically or redox unbalanced Reactions (after mapping to KEGG)
 
-    This test simply reports the number of metabolic reactions that disagree
-    with thermodynamic calculations i.e. are irreversible even though they
-    should not be (and vice versa), considering the above fluctuations of
-    metabolite concentrations. It does not have a mandatory 'pass' criterium.
+    This test simply reports the number of reversible reactions that, according
+    to the reversibility index, are likely to be irreversible.
 
     """
-    ann = test_find_incorrect_thermodynamic_reversibility.annotation
+    ann = test_find_candidate_irreversible_reactions.annotation
     met_rxns = basic.find_pure_metabolic_reactions(read_only_model)
-    rev, mapping, calc, bal = \
-        thermo.find_incorrect_thermodynamic_reversibility(met_rxns)
-    ann["data"] = (get_ids(rev), get_ids(mapping), get_ids(calc), get_ids(bal))
-    ann["message"] = "Out of {} purely metabolic reactions the reversibility "\
-                     "of {} does not agree with the calculated ln_gamma " \
-                     "cutoff ({:.2%}), and thus ought to be inverted. " \
-                     "{} reactions " \
-                     "could not be mapped to KEGG completely, " \
-                     "{} contained 'problematic' metabolites, and " \
-                     "{} are chemically or redox imbalanced: {}" \
-                     "".format(len(met_rxns), len(ann["data"][0]),
-                               ann["metric"], len(ann["data"][1]),
-                               len(ann["data"][2]), len(ann["data"][3]),
-                               truncate(ann["data"][0]))
-    ann["metric"] = (len(ann["data"][0]) +
-                     len(ann["data"][1]) +
-                     len(ann["data"][2]) +
-                     len(ann["data"][3])) / len(met_rxns)
+    rev_index, incomplete, problematic, unbalanced = \
+        thermo.find_thermodynamic_reversibility_index(met_rxns)
+    ann["data"] = (
+        [(r.id, i) for r, i in rev_index],
+        get_ids(incomplete),
+        get_ids(problematic),
+        get_ids(unbalanced)
+    )
+    num_irrev = sum(1 for r, i in rev_index if abs(i) >= 10)
+    ann["message"] = wrapper.fill(
+        """Out of {} purely metabolic reactions, {} have an absolute
+        reversibility index greater or equal to 10 and are therefore likely
+        candidates for being irreversible.
+        {} reactions could not be mapped to KEGG completely, {} contained
+        'problematic' metabolites, and {} are chemically or redox imbalanced.
+        """.format(len(met_rxns), num_irrev, len(incomplete), len(problematic),
+                   len(unbalanced))
+    )
+    ann["metric"] = num_irrev / len(rev_index)

--- a/memote/support/thermodynamics.py
+++ b/memote/support/thermodynamics.py
@@ -91,23 +91,25 @@ def map_metabolite2kegg(metabolite, threshold=0.85):
     logger.debug("Looking for KEGG compound identifier for %s.", metabolite.id)
     kegg_annotation = metabolite.annotation.get("kegg.compound")
     if kegg_annotation is None:
-        if metabolite.name:
-            # The compound matcher uses regular expression and chokes
-            # with a low level error on `[` in the name, for example.
-            df = compound_matcher.match(metabolite.name)
-            try:
-                return df.loc[df["score"] > threshold, "CID"].iat[0]
-            except (IndexError, AttributeError):
-                logger.warning(
-                    "Could not match the name %r to any kegg.compound "
-                    "annotation for metabolite %s.",
-                    metabolite.name, metabolite.id
-                )
-                return
-        else:
-            logger.warning("No kegg.compound annotation for metabolite %s.",
-                           metabolite.id)
-            return
+        # TODO (Moritz Beber): Currently name matching is very slow and
+        #  inaccurate. We disable it until there is a better solution.
+        # if metabolite.name:
+        #     # The compound matcher uses regular expression and chokes
+        #     # with a low level error on `[` in the name, for example.
+        #     df = compound_matcher.match(metabolite.name)
+        #     try:
+        #         return df.loc[df["score"] > threshold, "CID"].iat[0]
+        #     except (IndexError, AttributeError):
+        #         logger.warning(
+        #             "Could not match the name %r to any kegg.compound "
+        #             "annotation for metabolite %s.",
+        #             metabolite.name, metabolite.id
+        #         )
+        #         return
+        # else:
+        logger.warning("No kegg.compound annotation for metabolite %s.",
+                       metabolite.id)
+        return
     if isinstance(kegg_annotation, string_types) and \
             kegg_annotation.startswith("C"):
         return kegg_annotation

--- a/memote/support/thermodynamics.py
+++ b/memote/support/thermodynamics.py
@@ -227,6 +227,7 @@ def find_thermodynamic_reversibility_index(reactions):
             reversibility_indexes.append((rxn, ln_rev_index))
         else:
             unbalanced.append(rxn)
+    reversibility_indexes.sort(key=lambda p: abs(p[1]), reverse=True)
     return (
         reversibility_indexes, incomplete_mapping, problematic_calculation,
         unbalanced

--- a/memote/support/thermodynamics.py
+++ b/memote/support/thermodynamics.py
@@ -64,7 +64,7 @@ def get_smallest_compound_id(compounds_identifiers):
                key=lambda c: int(c[1:]))
 
 
-def map_metabolite2kegg(metabolite, threshold=0.85):
+def map_metabolite2kegg(metabolite):
     """
     Return a KEGG compound identifier for the metabolite if it exists.
 
@@ -79,13 +79,14 @@ def map_metabolite2kegg(metabolite, threshold=0.85):
     Parameters
     ----------
     metabolite : cobra.Metabolite
-    threshold : float, optional
-        Cut off for the name matching score. Can be between 0 and 1 with 1
-        being the stricter side.
+        The metabolite to be mapped to its KEGG compound identifier.
 
     Returns
     -------
+    None
+        If the metabolite could not be mapped.
     str
+        The smallest KEGG compound identifier that was found.
 
     """
     logger.debug("Looking for KEGG compound identifier for %s.", metabolite.id)
@@ -132,12 +133,16 @@ def translate_reaction(reaction, metabolite_mapping):
     Parameters
     ----------
     reaction : cobra.Reaction
+        The reaction whose metabolites are to be translated.
     metabolite_mapping : dict
+        An existing mapping from cobra.Metabolite to KEGG compound identifier
+        that may already contain the metabolites in question or will have to be
+        extended.
 
     Returns
     -------
     dict
-        The stoichiometry of a reaction given as a mapping from metabolite
+        The stoichiometry of the reaction given as a mapping from metabolite
         KEGG identifier to coefficient.
 
     """
@@ -150,54 +155,36 @@ def translate_reaction(reaction, metabolite_mapping):
         if kegg_id is None:
             continue
         stoichiometry[kegg_id] += coef
-    return stoichiometry
+    return dict(stoichiometry)
 
 
-def find_incorrect_thermodynamic_reversibility(reactions, ln_gamma=3):
+def find_thermodynamic_reversibility_index(reactions):
     u"""
-    Return reactions whose reversibilities do not agree with thermodynamics.
+    Return the reversibility index of the given reactions.
 
-    This function checks if the reversibility attribute of each reaction
-    in a list of cobrapy reactions agrees with a thermodynamics-based
-    calculation of the reversibility. To determine reversibility we calculate
+    To determine the reversibility index, we calculate
     the reversibility index ln_gamma (see [1]_ section 3.5) of each reaction
-    using the eQuilibrator API [2]_. The default cutoff for ln_gamma
-    "corresponds to allowing concentrations to span three orders of magnitude
-    around 100 μM (~3 μM—3 mM)" at "pH = 7, I = 0.1 M and T = 298 K" (see [1]_
-    supplement section 3). Here pH denotes the negative base 10 logarithm of
-    the activity of the hydrogen ion i.e. a measure of acidity/ basicity of an
-    aqueous solution, I denotes the molar ionic strength which is a measure of
-    the concentration of ions in a solution, lastly, T denotes the
-    thermodynamic temperature also called absolute temperature measured in
-    Kelvin.
+    using the eQuilibrator API [2]_.
 
     Parameters
     ----------
-        reactions: list of cobra.Reactions
-            A list of reactions to be checked for agreement with
-            thermodynamics-based calculations of reversibility.
-        ln_gamma: integer
-            Log-scale, symmetric range of metabolite concentrations around the
-            assumed average of 100 µM. A threshold of 3 means that a
-            reaction is considered irreversible if the concentration of an
-            individual metabolite would have to change more than three orders
-            of magnitude i.e. from 3 µM to 3 mM to reverse the direction of
-            flux.
+        reactions: list of cobra.Reaction
+            A list of reactions for which to calculate the reversibility index.
 
     Returns
     -------
-        incorrect_reversibility: list of cobra.Reactions
-            A list of reactions whose reversibility does not agree
-            with thermodynamic calculation.
-        incomplete_mapping: list of cobra.Reactions
+    tuple
+        list of cobra.Reaction, index pairs
+            A list of pairs of reactions and their reversibility indexes.
+        list of cobra.Reaction
             A list of reactions which contain at least one metabolite that
-            could not be mapped to KEGG on the basis of its annotation or name.
-        problematic_calculation: list of cobra.Reactions
+            could not be mapped to KEGG on the basis of its annotation.
+        list of cobra.Reaction
             A list of reactions for which it is not possible to calculate the
-            standard change in Gibbs potential. Reasons of failure include that
-            participating metabolites cannot be broken down with the group
-            contribution method.
-        unbalanced: list of cobra.Reactions
+            standard change in Gibbs free energy potential. Reasons of failure
+            include that participating metabolites cannot be broken down with
+            the group contribution method.
+        list of cobra.Reaction
             A list of reactions that are not chemically or redox balanced.
 
 
@@ -208,12 +195,12 @@ def find_incorrect_thermodynamic_reversibility(reactions, ln_gamma=3):
            reactions that combines accuracy and coverage, Bioinformatics,
            Volume 28, Issue 15, 1 August 2012, Pages 2037–2044,
            https://doi.org/10.1093/bioinformatics/bts317
-    .. [2] https://gitlab.com/elad.noor/equilibrator-api/tree/master
+    .. [2] https://pypi.org/project/equilibrator-api/
 
     """
     incomplete_mapping = []
     problematic_calculation = []
-    incorrect_reversibility = []
+    reversibility_indexes = []
     unbalanced = []
     metabolite_mapping = {}
 
@@ -233,18 +220,14 @@ def find_incorrect_thermodynamic_reversibility(reactions, ln_gamma=3):
         if eq_rxn.check_full_reaction_balancing():
             try:
                 ln_rev_index = eq_rxn.reversibility_index()
-            # TODO: Which exceptions can we expect here?
+            # TODO (Moritz Beber): Which exceptions can we expect here?
             except Exception:
                 problematic_calculation.append(rxn)
                 continue
-            if (ln_rev_index < ln_gamma) != rxn.reversibility:
-                incorrect_reversibility.append(rxn)
-            else:
-                continue
+            reversibility_indexes.append((rxn, ln_rev_index))
         else:
             unbalanced.append(rxn)
-
     return (
-        incorrect_reversibility, incomplete_mapping, problematic_calculation,
+        reversibility_indexes, incomplete_mapping, problematic_calculation,
         unbalanced
     )

--- a/tests/test_for_support/test_for_thermodynamics.py
+++ b/tests/test_for_support/test_for_thermodynamics.py
@@ -177,9 +177,14 @@ def test_get_smallest_compound_id(annotation, expected):
     ("h2o_c_list", "C00001"),
     ("o2_c_list", "C00007"),
     ("h2_c_list", "C00282"),
-    ("h2o_c_name", "C00001"),
-    ("o2_c_name", "C00007"),
-    ("h2_c_name", "C00282"),
+    # We currently do not match names because it takes too long.
+    # ("h2o_c_name", "C00001"),
+    # ("o2_c_name", "C00007"),
+    # ("h2_c_name", "C00282"),
+    # Names instead should return nothing.
+    ("h2o_c_name", None),
+    ("o2_c_name", None),
+    ("h2_c_name", None),
     ("whack_c", None),
     ("odd_c", None),
     ("unknown_c", None),
@@ -194,8 +199,11 @@ def test_map_metabolite2kegg(metabolite, kegg_id):
      {"C00668": -1, "C00001": -1, "C00267": 1, "C00009": 1}),
     ("list_annotation",
      {"C00282": -2, "C00007": -1, "C00001": 1}),
-    ("no_annotation_matching",
-     {"C00282": -2, "C00007": -1, "C00001": 1}),
+    # We currently do not match names because it takes too long.
+    # ("no_annotation_matching",
+    #  {"C00282": -2, "C00007": -1, "C00001": 1}),
+    # Names instead should return nothing.
+    ("no_annotation_matching", {}),
     ("no_annotation_not_matching", {})
 ], indirect=["reaction"])
 def test_translate_reaction(reaction, expected):
@@ -206,14 +214,17 @@ def test_translate_reaction(reaction, expected):
 
 @pytest.mark.parametrize("reaction, expected", [
     ("direct_annotation", (1, 0, 0, 0)),
-    ("direct_annotation_correct_rev", (0, 0, 0, 0)),
+    ("direct_annotation_correct_rev", (1, 0, 0, 0)),
     ("list_annotation", (0, 0, 0, 1)),
-    ("no_annotation_matching", (0, 0, 0, 1)),
+    # We currently do not match names because it takes too long.
+    # ("no_annotation_matching", (0, 0, 0, 1)),
+    # Names instead should return nothing.
+    ("no_annotation_matching", (0, 1, 0, 0)),
     ("no_annotation_not_matching", (0, 1, 0, 0)),
     ("problematic_metabolites", (0, 0, 1, 0))
 ], indirect=["reaction"])
 def test_find_incorrect_thermodynamic_reversibility(reaction, expected):
     """Expect the correct reversibility information."""
     result = tuple(map(
-        len, thermo.find_incorrect_thermodynamic_reversibility([reaction])))
+        len, thermo.find_thermodynamic_reversibility_index([reaction])))
     assert result == expected

--- a/tests/test_for_support/test_for_thermodynamics.py
+++ b/tests/test_for_support/test_for_thermodynamics.py
@@ -122,22 +122,29 @@ def problematic_metabolites():
     return r
 
 
-@pytest.mark.parametrize("input, expected", [
-    (["C00101", "C00099", "G12322"], ["C00099", "C00101"]),
-    (["G12322"], [])])
-def test_smallest_compound_ID(input, expected):
+@pytest.mark.parametrize("annotation, expected", [
+    (["C00101", "C00099", "G12322"], "C00099"),
+    pytest.param(["G12322"], None,
+                 marks=pytest.mark.raises(exception=ValueError))
+])
+def test_get_smallest_compound_id(annotation, expected):
     """Expect shortened and sorted list to be returned correctly."""
-    assert thermo.smallest_compound_id(input) == expected
+    assert thermo.get_smallest_compound_id(annotation) == expected
+
+
+def test_map_metabolite2kegg():
+    assert False
 
 
 @pytest.mark.parametrize("reaction, expected", [
     ("direct_annotation", "C00668 + C00001 -> C00267 + C00009"),
     ("list_annotation", "2 C00282 + C00007 -> C00001"),
     ("no_annotation_matching", "2 C00282 + C00007 -> C00001"),
-    ("no_annotation_not_matching", "odd_c + 2 unknown_c -> whack_c")],
-    indirect=["reaction"])
-def test_get_equilibrator_rxn_string(reaction, expected):
+    ("no_annotation_not_matching", "odd_c + 2 unknown_c -> whack_c")
+], indirect=["reaction"])
+def test_translate_reaction(reaction, expected):
     """Expect KEGG reaction string to match the expectation."""
+    assert False
     mapping_dict = thermo.get_metabolite_mapping([reaction])
     eq_rxn_string = thermo.get_equilibrator_reaction_string(reaction, mapping_dict)
     assert eq_rxn_string == expected
@@ -149,10 +156,11 @@ def test_get_equilibrator_rxn_string(reaction, expected):
     ("list_annotation", (0, 0, 0, 1)),
     ("no_annotation_matching", (0, 0, 0, 1)),
     ("no_annotation_not_matching", (0, 1, 0, 0)),
-    ("problematic_metabolites", (0, 0, 1, 0))],
-    indirect=["reaction"])
+    ("problematic_metabolites", (0, 0, 1, 0))
+], indirect=["reaction"])
 def test_find_incorrect_thermodynamic_reversibility(reaction, expected):
     """Expect KEGG reaction string to match the expectation."""
+    assert False
     reactions = [reaction]
     rev, map, calc, bal = \
         thermo.find_incorrect_thermodynamic_reversibility(reactions)


### PR DESCRIPTION
* [x] partially addresses #497 
* [x] This removes name to KEGG compound ID matching because it was very slow. It also changes the cut-off from 3 to 7 (natural logarithm instead of log10).
* [x] tests were adjusted
* [x] add an entry to the [next release](../HISTORY.rst)
