### PR TITLE
feat: extend annotation tests with a check for inchi strings

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -17,6 +17,7 @@ Next Release
 * Unpin pytest (require >= 4.0) and adjust some internal mechanics accordingly.
 * Display an alternative message if some biomass components do not contain a 
   formula.
+* Extend the annotations tests by a check for full length InChI strings.
 
 0.8.11 (2019-01-07)
 -------------------

--- a/memote/support/annotation.py
+++ b/memote/support/annotation.py
@@ -37,6 +37,7 @@ LOGGER = logging.getLogger(__name__)
 # 'Kegg'        ['gen','rxn','met'] 'http://www.kegg.jp/'
 # 'SEED'        ['met']             'http://modelseed.org/'
 #
+# 'InChI'       ['met']     'https://www.ebi.ac.uk/chebi/'
 # 'InChIKey'    ['met']     'http://cactus.nci.nih.gov/chemical/structure'
 # 'ChEBI'       ['met']     'http://bioportal.bioontology.org/ontologies/CHEBI'
 # 'BRENDA'      ['rxn']     'http://www.brenda-enzymes.org/'
@@ -106,6 +107,9 @@ METABOLITE_ANNOTATIONS = OrderedDict([
     ('seed.compound', re.compile(r"^cpd\d+$")),
     ('inchikey', re.compile(
         r"^[A-Z]{14}\-[A-Z]{10}(\-[A-Z])?")),
+    ('inchi', re.compile(
+        r"^InChI\=1S?\/[A-Za-z0-9\.]+(\+[0-9]+)?"
+        r"(\/[cnpqbtmsih][A-Za-z0-9\-\+\(\)\,\/\?\;\.]+)*$")),
     ('chebi', re.compile(r"^CHEBI:\d+$")),
     ('hmdb', re.compile(r"^HMDB\d{5}$")),
     ('reactome', re.compile(

--- a/tests/test_for_support/test_for_annotation.py
+++ b/tests/test_for_support/test_for_annotation.py
@@ -130,6 +130,7 @@ def met_broken_id(base):
         'metanetx.chemical': "MNXR23",
         'kegg.compound': "K00022",
         'seed.compound': "cdp00020",
+        'inchi': "InBhI=1/C2H6O/z1-2-3/h3H,2Z2,1Y3",
         'inchikey': "LCT-ONWCANYUPML-UHFFFAOYSA-M",
         'chebi': ["CHEBI:487", "CHEBI:15361", "CHEBI:26462", "CHEBI:26466",
             "CHEBI:32816", "CEBI:O", "CHEBI:86354", "CHEBI:8685"],

--- a/tests/test_for_support/test_for_annotation.py
+++ b/tests/test_for_support/test_for_annotation.py
@@ -68,6 +68,7 @@ def met_each_present(base):
                       'kegg.compound': "C00022",
                       'seed.compound': "cpd00020",
                       'inchikey': "LCTONWCANYUPML-UHFFFAOYSA-M",
+                      'inchi': "InChI=1S/C3H4O3/c1-2(4)3(5)6/h1H3,(H,5,6)/p-1",
                       'chebi': ["CHEBI:14987", "CHEBI:15361",
                                 "CHEBI:26462", "CHEBI:26466",
                                 "CHEBI:32816", "CHEBI:45253",


### PR DESCRIPTION
* [x] fix #558 
* [x] tests added/passed
* [x] add an entry to the [next release](../HISTORY.rst)

I've left out SMILES for now because there seems to be no dedicated registry for it on `identifiers.org` and hence no MIRIAM-compliant identifier pattern.

@matthiaskoenig do you have any suggestions on how to still include SMILES or do you think InChI will suffice?