### PR TITLE
fix: invert logic of test_fast_growth_default

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -34,6 +34,8 @@ Next Release
 * Display an alternative message if some biomass components do not contain a 
   formula.
 * Extend the annotations tests by a check for full length InChI strings.
+* Fix a bug in ``Unrealistic Growth Rate In Default Medium`` which reported the
+  opposite of what was the case.
 
 0.8.11 (2019-01-07)
 -------------------

--- a/memote/suite/tests/test_biomass.py
+++ b/memote/suite/tests/test_biomass.py
@@ -248,15 +248,33 @@ def test_fast_growth_default(model, reaction_id):
     fastest growing organism. This is based on lowest doubling time reported
     here:
     http://www.pnnl.gov/science/highlights/highlight.asp?id=879
+
+    Implementation:
+    Calculate the solution of FBA with the biomass reaction set as objective
+    function and a model's default constraints. Then check if the objective
+    flux is above 10.3972.
+
     """
     ann = test_fast_growth_default.annotation
-    ann["data"][reaction_id] = helpers.run_fba(model, reaction_id) <= 10.3972
+    ann["data"][reaction_id] = helpers.run_fba(model, reaction_id) > 10.3972
     ann["metric"][reaction_id] = 1.0  # Placeholder value.
-    ann["message"][reaction_id] = wrapper.fill(
-        """Using the biomass reaction {} and when the model is simulated on
-        the provided default medium the growth rate amounts to {}""".format(
-            reaction_id, ann["data"][reaction_id]))
-    assert ann["data"][reaction_id] <= 10.3972, ann["message"][reaction_id]
+
+    if ann["data"][reaction_id]:
+        ann["message"][reaction_id] = wrapper.fill(
+            """Using the biomass reaction {} and when the model is simulated on
+            the provided default medium the growth rate is higher than that
+            of the fastest bacteria.
+            This could be due to inconsistencies in the network or missing
+            constraints.""".format(
+            reaction_id))
+    else:
+        ann["message"][reaction_id] = wrapper.fill(
+            """Using the biomass reaction {} and when the model is simulated on
+            the provided default medium the growth rate is lower than that
+            of the fastest bacteria. This is to be expected for
+            a majority of organisms.""".format(
+            reaction_id))
+    assert ann["data"][reaction_id] > 10.3972, ann["message"][reaction_id]
 
 
 @pytest.mark.biomass

--- a/memote/suite/tests/test_biomass.py
+++ b/memote/suite/tests/test_biomass.py
@@ -246,9 +246,9 @@ def test_fast_growth_default(model, reaction_id):
 
     The growth rate of a metabolic model should not be faster than that of the
     fastest growing organism. This is based on a doubling time of Vibrio
-    natriegens which was reported to be 14.8 minutes by: Henry H. Lee, Nili Ostrov,
-    Brandon G. Wong, Michaela A. Gold, Ahmad S. Khalil, George M. Church in
-    https://www.biorxiv.org/content/biorxiv/early/2016/06/12/058487.full.pdf
+    natriegens which was reported to be 14.8 minutes by: Henry H. Lee, Nili
+    Ostrov, Brandon G. Wong, Michaela A. Gold, Ahmad S. Khalil, George M. Church
+    in https://www.biorxiv.org/content/biorxiv/early/2016/06/12/058487.full.pdf
 
     The calculation ln(2)/(14.8/60) ~ 2.81 yields the corresponding growth
     rate.

--- a/memote/suite/tests/test_biomass.py
+++ b/memote/suite/tests/test_biomass.py
@@ -242,21 +242,25 @@ def test_gam_in_biomass(model, reaction_id):
           format_type="raw", data=dict(), message=dict(), metric=dict())
 def test_fast_growth_default(model, reaction_id):
     """
-    Expect the predicted growth rate for each BOF to be below 10.3972.
+    Expect the predicted growth rate for each BOF to be below 2.81.
 
     The growth rate of a metabolic model should not be faster than that of the
-    fastest growing organism. This is based on lowest doubling time reported
-    here:
-    http://www.pnnl.gov/science/highlights/highlight.asp?id=879
+    fastest growing organism. This is based on a doubling time of Vibrio
+    natriegens to be 14.8 minutes as reported by: Henry H. Lee, Nili Ostrov,
+    Brandon G. Wong, Michaela A. Gold, Ahmad S. Khalil, George M. Church in
+    https://www.biorxiv.org/content/biorxiv/early/2016/06/12/058487.full.pdf
+
+    The calculation ln(2)/(14.8/60) ~ 2.81 yields the corresponding growth
+    rate.
 
     Implementation:
     Calculate the solution of FBA with the biomass reaction set as objective
     function and a model's default constraints. Then check if the objective
-    flux is above 10.3972.
+    flux is higher than 2.81.
 
     """
     ann = test_fast_growth_default.annotation
-    ann["data"][reaction_id] = helpers.run_fba(model, reaction_id) > 10.3972
+    ann["data"][reaction_id] = helpers.run_fba(model, reaction_id) > 2.81
     ann["metric"][reaction_id] = 1.0  # Placeholder value.
 
     if ann["data"][reaction_id]:
@@ -272,7 +276,7 @@ def test_fast_growth_default(model, reaction_id):
             the provided default medium the growth rate is lower than that
             of the fastest bacteria. This is to be expected for
             a majority of organisms.""".format(reaction_id))
-    assert ann["data"][reaction_id] > 10.3972, ann["message"][reaction_id]
+    assert ann["data"][reaction_id] > 2.81, ann["message"][reaction_id]
 
 
 @pytest.mark.biomass

--- a/memote/suite/tests/test_biomass.py
+++ b/memote/suite/tests/test_biomass.py
@@ -246,7 +246,7 @@ def test_fast_growth_default(model, reaction_id):
 
     The growth rate of a metabolic model should not be faster than that of the
     fastest growing organism. This is based on a doubling time of Vibrio
-    natriegens to be 14.8 minutes as reported by: Henry H. Lee, Nili Ostrov,
+    natriegens which was reported to be 14.8 minutes by: Henry H. Lee, Nili Ostrov,
     Brandon G. Wong, Michaela A. Gold, Ahmad S. Khalil, George M. Church in
     https://www.biorxiv.org/content/biorxiv/early/2016/06/12/058487.full.pdf
 
@@ -256,7 +256,7 @@ def test_fast_growth_default(model, reaction_id):
     Implementation:
     Calculate the solution of FBA with the biomass reaction set as objective
     function and a model's default constraints. Then check if the objective
-    flux is higher than 2.81.
+    value is higher than 2.81.
 
     """
     ann = test_fast_growth_default.annotation
@@ -266,14 +266,14 @@ def test_fast_growth_default(model, reaction_id):
     if ann["data"][reaction_id]:
         ann["message"][reaction_id] = wrapper.fill(
             """Using the biomass reaction {} and when the model is simulated on
-            the provided default medium the growth rate is higher than that
+            the provided default medium the growth rate is *higher* than that
             of the fastest bacteria.
             This could be due to inconsistencies in the network or missing
             constraints.""".format(reaction_id))
     else:
         ann["message"][reaction_id] = wrapper.fill(
             """Using the biomass reaction {} and when the model is simulated on
-            the provided default medium the growth rate is lower than that
+            the provided default medium the growth rate is *lower* than that
             of the fastest bacteria. This is to be expected for
             a majority of organisms.""".format(reaction_id))
     assert ann["data"][reaction_id] > 2.81, ann["message"][reaction_id]

--- a/memote/suite/tests/test_biomass.py
+++ b/memote/suite/tests/test_biomass.py
@@ -265,15 +265,13 @@ def test_fast_growth_default(model, reaction_id):
             the provided default medium the growth rate is higher than that
             of the fastest bacteria.
             This could be due to inconsistencies in the network or missing
-            constraints.""".format(
-            reaction_id))
+            constraints.""".format(reaction_id))
     else:
         ann["message"][reaction_id] = wrapper.fill(
             """Using the biomass reaction {} and when the model is simulated on
             the provided default medium the growth rate is lower than that
             of the fastest bacteria. This is to be expected for
-            a majority of organisms.""".format(
-            reaction_id))
+            a majority of organisms.""".format(reaction_id))
     assert ann["data"][reaction_id] > 10.3972, ann["message"][reaction_id]
 
 


### PR DESCRIPTION
* [x] fix #516 
* [x] description of feature/fix
* [x] add an entry to the [next release](../HISTORY.rst)

The reason for the odd value was inverted logic in the test function.