### PR TITLE
added 's' to end of 'kegg.gene' to be compliant with identifiers.org namespace

### DIFF
--- a/memote/support/annotation.py
+++ b/memote/support/annotation.py
@@ -70,7 +70,7 @@ GENE_PRODUCT_ANNOTATIONS = OrderedDict([
         r"[0-9][A-Z, 0-9][A-Z, 0-9][A-Z, 0-9]"
         r"[0-9])(\.\d+)?$")),
     ('ecogene', re.compile(r"^EG\d+$")),
-    ('kegg.gene', re.compile(r"^\w+:[\w\d\.-]*$")),
+    ('kegg.genes', re.compile(r"^\w+:[\w\d\.-]*$")),
     ('ncbigi', re.compile(r"^(GI|gi)\:\d+$")),
     ('ncbigene', re.compile(r"^\d+$")),
     ('ncbiprotein', re.compile(r"^(\w+\d+(\.\d+)?)|(NP_\d+)$")),


### PR DESCRIPTION
Apologies for the small change, but the annotation search process was looking for the namespace "kegg.gene" rather than "kegg.genes". If users use "kegg.gene", the identifier.org URLs that are generated in SBML are incorrect.

See https://www.ebi.ac.uk/miriam/main/datatypes/MIR:00000070 for the definition and http://identifiers.org/kegg.genes/syn:ssr3451 for an example.