### PR TITLE
Fix topology tests

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -3,6 +3,9 @@ History
 
 Next Release
 ------------
+* Fix the discovery or orphan and dead-end metabolites.
+* Improve detection of metabolites that are not consumed or not produced by 
+  only opening exchange reactions not other boundary reactions.
 * Thematically reorganize the test cases in the config.
 * Instead of min/max bounds consider the median bounds for testing (un-)bounded 
   fluxes.

--- a/memote/suite/tests/test_basic.py
+++ b/memote/suite/tests/test_basic.py
@@ -223,7 +223,7 @@ def test_compartments_presence(model):
     # TODO: Fix the test in a later PR! Should expect 2 compartments instead!
     ann = test_compartments_presence.annotation
     assert hasattr(model, "compartments")
-    ann["data"] = list(model.get_metabolite_compartments())
+    ann["data"] = list(model.compartments)
     ann["message"] = wrapper.fill(
         """A total of {:d} compartments are defined in the model: {}""".format(
             len(ann["data"]), truncate(ann["data"])))

--- a/memote/suite/tests/test_consistency.py
+++ b/memote/suite/tests/test_consistency.py
@@ -62,7 +62,7 @@ def test_stoichiometric_consistency(model):
 
 @pytest.mark.parametrize("met", [x for x in consistency.ENERGY_COUPLES])
 @annotate(title="Erroneous Energy-generating Cycles", format_type="count",
-          data=dict(), message=dict())
+          data=dict(), message=dict(), metric=dict())
 def test_detect_energy_generating_cycles(model, met):
     u"""
     Expect that no energy metabolite can be produced out of nothing.

--- a/memote/support/consistency.py
+++ b/memote/support/consistency.py
@@ -441,32 +441,46 @@ def find_orphans(model):
     """
     Return metabolites that are only consumed in reactions.
 
+    Metabolites that are involved in an exchange reaction are never
+    considered to be orphaned.
+
     Parameters
     ----------
     model : cobra.Model
         The metabolic model under investigation.
 
     """
-    return [met for met in model.metabolites
-            if (len(met.reactions) > 0) and all(
-                (not rxn.reversibility) and (rxn.metabolites[met] < 0)
-                for rxn in met.reactions)]
+    exchange = frozenset(model.exchanges)
+    return [
+        met for met in model.metabolites
+        if (len(met.reactions) > 0) and all(
+            (not rxn.reversibility) and (rxn not in exchange) and
+            (rxn.metabolites[met] < 0) for rxn in met.reactions
+        )
+    ]
 
 
 def find_deadends(model):
     """
     Return metabolites that are only produced in reactions.
 
+    Metabolites that are involved in an exchange reaction are never
+    considered to be dead ends.
+
     Parameters
     ----------
     model : cobra.Model
         The metabolic model under investigation.
 
     """
-    return [met for met in model.metabolites
-            if (len(met.reactions) > 0) and all(
-                (not rxn.reversibility) and
-                (rxn.metabolites[met] > 0) for rxn in met.reactions)]
+    exchange = frozenset(model.exchanges)
+    return [
+        met for met in model.metabolites
+        if (len(met.reactions) > 0) and all(
+            (not rxn.reversibility) and (rxn not in exchange) and
+            (rxn.metabolites[met] > 0) for rxn in met.reactions
+        )
+    ]
 
 
 def find_disconnected(model):
@@ -484,26 +498,30 @@ def find_disconnected(model):
 
 def find_metabolites_not_produced_with_open_bounds(model):
     """
-    Return metabolites that cannot be produced with open boundary reactions.
+    Return metabolites that cannot be produced with open exchange reactions.
 
-    Inverse case from 'find_metabolites_produced_with_closed_bounds', just
-    like metabolites should not be produced from nothing, metabolites should
-    all be produced with open exchanges.
+    A perfect model should be able to produce each and every metabolite when
+    all medium components are available.
 
     Parameters
     ----------
     model : cobra.Model
         The metabolic model under investigation.
 
+    Returns
+    -------
+    list
+        Those metabolites that could not be produced.
+
     """
     mets_not_produced = list()
-    helpers.open_boundaries(model)
+    helpers.open_exchanges(model)
     for met in model.metabolites:
         with model:
             exch = model.add_boundary(
-                met, type="irrex", reaction_id="IRREX", lb=0, ub=1)
+                met, type="irrex", reaction_id="IRREX", lb=0, ub=1000)
             solution = helpers.run_fba(model, exch.id)
-            if solution is np.nan or solution < TOLERANCE_THRESHOLD:
+            if np.isnan(solution) or solution < TOLERANCE_THRESHOLD:
                 mets_not_produced.append(met)
     return mets_not_produced
 
@@ -512,24 +530,28 @@ def find_metabolites_not_consumed_with_open_bounds(model):
     """
     Return metabolites that cannot be consumed with open boundary reactions.
 
-    Reverse case from 'find_metabolites_not_produced_with_open_bounds', just
-    like metabolites should all be produced with open exchanges, they should
-    also all be consumed with open exchanges.
+    When all metabolites can be secreted, it should be possible for each and
+    every metabolite to be consumed in some form.
 
     Parameters
     ----------
     model : cobra.Model
         The metabolic model under investigation.
 
+    Returns
+    -------
+    list
+        Those metabolites that could not be consumed.
+
     """
     mets_not_consumed = list()
-    helpers.open_boundaries(model)
+    helpers.open_exchanges(model)
     for met in model.metabolites:
         with model:
             exch = model.add_boundary(
-                met, type="irrex", reaction_id="IRREX", lb=-1, ub=0)
+                met, type="irrex", reaction_id="IRREX", lb=-1000, ub=0)
             solution = helpers.run_fba(model, exch.id, direction="min")
-            if solution is np.nan or abs(solution) < TOLERANCE_THRESHOLD:
+            if np.isnan(solution) or abs(solution) < TOLERANCE_THRESHOLD:
                 mets_not_consumed.append(met)
     return mets_not_consumed
 

--- a/memote/support/helpers.py
+++ b/memote/support/helpers.py
@@ -541,19 +541,28 @@ def close_boundaries_sensibly(model):
         boundary.bounds = (0, 0)
 
 
-def open_boundaries(model):
+def open_exchanges(model):
     """
-    Return a copy of cobra model with all boundaries opened.
+    Open all exchange reactions.
 
     Parameters
     ----------
     model : cobra.Model
         The metabolic model under investigation.
 
-    Returns
+    """
+    for rxn in model.exchanges:
+        rxn.bounds = (-1000, 1000)
+
+
+def open_boundaries(model):
+    """
+    Open all boundary reactions.
+
+    Parameters
     ----------
-    cobra.Model
-        A cobra model with all boundary reactions opened.
+    model : cobra.Model
+        The metabolic model under investigation.
 
     """
     for boundary in model.boundary:

--- a/tests/test_for_support/test_for_basic.py
+++ b/tests/test_for_support/test_for_basic.py
@@ -633,7 +633,7 @@ def test_ngam_presence(model, num):
 ], indirect=["model"])
 def test_compartments_presence(model, boolean):
     """Expect amount of compartments to be identified correctly."""
-    assert (len(model.get_metabolite_compartments()) >= 3) == boolean
+    assert (len(model.compartments) >= 3) == boolean
 
 
 @pytest.mark.parametrize("model, num", [

--- a/tests/test_for_support/test_for_consistency.py
+++ b/tests/test_for_support/test_for_consistency.py
@@ -494,10 +494,10 @@ def consuming_toy_model(base):
 
 @register_with(MODEL_REGISTRY)
 def gap_model(base):
-    a_c = cobra.Metabolite("a_c")
-    a_e = cobra.Metabolite("a_e")
-    b_c = cobra.Metabolite("b_c")
-    c_c = cobra.Metabolite("c_c")
+    a_c = cobra.Metabolite("a_c", compartment="c")
+    a_e = cobra.Metabolite("a_e", compartment="e")
+    b_c = cobra.Metabolite("b_c", compartment="c")
+    c_c = cobra.Metabolite("c_c", compartment="c")
     base.add_metabolites([a_e])
     rxn1 = cobra.Reaction("R1")
     rxn1.add_metabolites({a_c: -1, b_c: 1})
@@ -509,24 +509,29 @@ def gap_model(base):
 
 @register_with(MODEL_REGISTRY)
 def gap_model_2(base):
-    base.add_metabolites([cobra.Metabolite(i) for i in "abcd"])
+    a_c = cobra.Metabolite("a_c", compartment="c")
+    b_c = cobra.Metabolite("b_c", compartment="c")
+    c_c = cobra.Metabolite("c_c", compartment="c")
+    d_c = cobra.Metabolite("d_c", compartment="c")
     base.add_reactions([cobra.Reaction(i)
                         for i in ["EX_A", "A2B", "C2D", "EX_D"]])
-    base.reactions.EX_A.add_metabolites({"a": 1})
-    base.reactions.EX_D.add_metabolites({"d": -1})
-    base.reactions.A2B.add_metabolites({"a": -1, "b": 1})
-    base.reactions.C2D.add_metabolites({"c": -1, "d": 1})
+    base.reactions.EX_A.add_metabolites({a_c: -1})
+    base.reactions.EX_D.add_metabolites({d_c: -1})
+    base.reactions.A2B.add_metabolites({a_c: -1, b_c: 1})
+    base.reactions.C2D.add_metabolites({c_c: -1, d_c: 1})
+    base.reactions.EX_A.bounds = -1000, 1000
     base.reactions.A2B.bounds = 0, 1000
     base.reactions.C2D.bounds = 0, 1000
+    base.reactions.EX_D.bounds = -1000, 1000
     return base
 
 
 @register_with(MODEL_REGISTRY)
 def gapfilled_model(base):
-    a_c = cobra.Metabolite("a_c")
-    a_e = cobra.Metabolite("a_e")
-    b_c = cobra.Metabolite("b_c")
-    c_c = cobra.Metabolite("c_c")
+    a_c = cobra.Metabolite("a_c", compartment="c")
+    a_e = cobra.Metabolite("a_e", compartment="e")
+    b_c = cobra.Metabolite("b_c", compartment="c")
+    c_c = cobra.Metabolite("c_c", compartment="c")
     rxn1 = cobra.Reaction("R1")
     rxn1.add_metabolites({a_c: -1, b_c: 1})
     rxn2 = cobra.Reaction("R2")
@@ -545,9 +550,9 @@ def gapfilled_model(base):
 
 @register_with(MODEL_REGISTRY)
 def reversible_gap(base):
-    a_c = cobra.Metabolite("a_c")
-    b_c = cobra.Metabolite("b_c")
-    c_c = cobra.Metabolite("c_c")
+    a_c = cobra.Metabolite("a_c", compartment="c")
+    b_c = cobra.Metabolite("b_c", compartment="c")
+    c_c = cobra.Metabolite("c_c", compartment="c")
     rxn1 = cobra.Reaction("R1", lower_bound=-1000)
     rxn1.add_metabolites({a_c: -1, b_c: 1})
     rxn2 = cobra.Reaction("R2")

--- a/tests/test_for_support/test_for_helpers.py
+++ b/tests/test_for_support/test_for_helpers.py
@@ -318,7 +318,7 @@ def one_exchange(base):
                           compartment='e'): -1}
     )
     rxn.bounds = -1, 5
-    base.add_reaction(rxn)
+    base.add_reactions([rxn])
     return base
 
 


### PR DESCRIPTION
* [x] fix #519
* [x] description of feature/fix
* [x] tests added/passed
* [x] add an entry to the [next release](../HISTORY.rst)

Metabolites with irreversible exchange reactions were falsely identified as orphans. Not consumed and not produced metabolites were detected opening all boundary reactions. This has changed to only opening exchanges.

* Orphans are now a complete subset of not produced compounds.
* Dead-ends are now a complete subset of not consumed compounds.