### PR TITLE
fix: add packages needed by sphinx autodoc to rtd build environment

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -25,6 +25,7 @@ import sphinx_bootstrap_theme
 # relative to the documentation root, use os.path.abspath to make it
 # absolute, like shown here.
 sys.path.insert(0, dirname(dirname(__file__)))
+autodoc_mock_imports = ["pylru", "equilibrator_api"]
 
 # Get the project root dir, which is the parent dir of this
 PROJECT_ROOT = dirname(dirname(__file__))

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -25,7 +25,7 @@ import sphinx_bootstrap_theme
 # relative to the documentation root, use os.path.abspath to make it
 # absolute, like shown here.
 sys.path.insert(0, dirname(dirname(__file__)))
-autodoc_mock_imports = ["pylru", "equilibrator_api"]
+autodoc_mock_imports = ["pylru", "equilibrator_api", "libsbml"]
 
 # Get the project root dir, which is the parent dir of this
 PROJECT_ROOT = dirname(dirname(__file__))

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -20,5 +20,3 @@ travispy
 travis-encrypt
 importlib_resources
 goodtables
-pylru
-equilibrator_api

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -20,3 +20,5 @@ travispy
 travis-encrypt
 importlib_resources
 goodtables
+pylru
+equilibrator_api


### PR DESCRIPTION
The AutoAPI part worked so now in our docs we have a [beautiful, automatically generated API documentation](https://memote.readthedocs.io/en/latest/autoapi/index.html) appended to the end of our ToC tree, but the autodoc part still didn't build. I investigated this in the RTD logs and saw that two packages could not be imported in their build process (`pylru` and `equilibrator_api`). I've added them to the `requirements.txt`.

Hopefully, RTD will be able to build the dedicated test section with sphinx_autodoc now.
