### PR TITLE
fix: remove preliminary inversion of metrics

### DIFF
--- a/memote/suite/tests/test_basic.py
+++ b/memote/suite/tests/test_basic.py
@@ -43,7 +43,7 @@ def test_model_id_presence(model):
     ann = test_model_id_presence.annotation
     assert hasattr(model, "id")
     ann["data"] = model.id
-    ann["metric"] = 1.0 - float(bool(ann["data"]))
+    ann["metric"] = float(bool(ann["data"]))
     ann["message"] = "The model ID is {}".format(ann["data"])
     assert bool(model.id)
 
@@ -234,7 +234,7 @@ def test_ngam_presence(model):
     """
     ann = test_ngam_presence.annotation
     ann["data"] = get_ids(basic.find_ngam(model))
-    ann["metric"] = 1.0 - float(len(ann["data"]) == 1)
+    ann["metric"] = float(len(ann["data"]) == 1)
     ann["message"] = wrapper.fill(
         """A total of {} NGAM reactions could be identified:
         {}""".format(len(ann["data"]), truncate(ann["data"])))
@@ -290,7 +290,7 @@ def test_compartments_presence(model):
     ann = test_compartments_presence.annotation
     assert hasattr(model, "compartments")
     ann["data"] = list(model.compartments)
-    ann["metric"] = 1.0 - float(len(ann["data"]) >= 2)
+    ann["metric"] = float(len(ann["data"]) >= 2)
     ann["message"] = wrapper.fill(
         """A total of {:d} compartments are defined in the model: {}""".format(
             len(ann["data"]), truncate(ann["data"])))

--- a/memote/suite/tests/test_biomass.py
+++ b/memote/suite/tests/test_biomass.py
@@ -69,7 +69,7 @@ def test_biomass_presence(model):
     ann["data"] = [
         rxn.id for rxn in helpers.find_biomass_reaction(model)]
     outcome = len(ann["data"]) > 0
-    ann["metric"] = 1.0 - float(outcome)
+    ann["metric"] = float(outcome)
     ann["message"] = wrapper.fill(
         """In this model {} the following biomass reactions were
         identified: {}""".format(
@@ -115,7 +115,7 @@ def test_biomass_consistency(model, reaction_id):
             """.format(reaction_id, ann["data"][reaction_id])
         )
     outcome = (1 - 1e-03) < ann["data"][reaction_id] < (1 + 1e-06)
-    ann["metric"][reaction_id] = 1.0 - float(outcome)
+    ann["metric"][reaction_id] = float(outcome)
     # To account for numerical inaccuracies, a range from 1-1e0-3 to 1+1e-06
     # is implemented in the assertion check
     assert outcome, ann["message"][reaction_id]
@@ -140,7 +140,7 @@ def test_biomass_default_production(model, reaction_id):
     ann = test_biomass_default_production.annotation
     ann["data"][reaction_id] = helpers.run_fba(model, reaction_id)
     outcome = ann["data"][reaction_id] > 1E-07
-    ann["metric"][reaction_id] = 1.0 - float(outcome)
+    ann["metric"][reaction_id] = float(outcome)
     ann["message"][reaction_id] = wrapper.fill(
         """Using the biomass reaction {} this is the growth rate (1/h) that
         can be achieved when the model is simulated on the provided
@@ -169,7 +169,7 @@ def test_biomass_open_production(model, reaction_id):
     helpers.open_boundaries(model)
     ann["data"][reaction_id] = helpers.run_fba(model, reaction_id)
     outcome = ann["data"][reaction_id] > 1E-07
-    ann["metric"][reaction_id] = 1.0 - float(outcome)
+    ann["metric"][reaction_id] = float(outcome)
     ann["message"][reaction_id] = wrapper.fill(
         """Using the biomass reaction {} this is the growth rate that can be
         achieved when the model is simulated on a complete medium i.e.
@@ -315,7 +315,7 @@ def test_gam_in_biomass(model, reaction_id):
     reaction = model.reactions.get_by_id(reaction_id)
     outcome = biomass.gam_in_biomass(model, reaction)
     ann["data"][reaction_id] = outcome
-    ann["metric"][reaction_id] = 1.0 - float(outcome)
+    ann["metric"][reaction_id] = float(outcome)
     if outcome:
         ann["message"][reaction_id] = wrapper.fill(
             """Yes, {} contains a term for growth-associated maintenance.
@@ -353,7 +353,7 @@ def test_fast_growth_default(model, reaction_id):
     ann = test_fast_growth_default.annotation
     outcome = helpers.run_fba(model, reaction_id) > 2.81
     ann["data"][reaction_id] = outcome
-    ann["metric"][reaction_id] = 1.0 - float(outcome)
+    ann["metric"][reaction_id] = float(outcome)
     if ann["data"][reaction_id]:
         ann["message"][reaction_id] = wrapper.fill(
             """Using the biomass reaction {} and when the model is simulated on

--- a/memote/suite/tests/test_matrix.py
+++ b/memote/suite/tests/test_matrix.py
@@ -48,7 +48,7 @@ def test_absolute_extreme_coefficient_ratio(model, threshold=1e9):
     high, low = matrix.absolute_extreme_coefficient_ratio(model)
     ann["data"] = high / low
     # Inverse the Boolean: 0.0 = good; 1.0 = bad.
-    ann["metric"] = 1.0 - float(ann["data"] < threshold)
+    ann["metric"] = float(ann["data"] < threshold)
     ann["message"] = wrapper.fill(
         """The ratio of the absolute values of the largest coefficient {} and
         the lowest, non-zero coefficient {} is: {:.3G}.""".format(

--- a/memote/suite/tests/test_sbml.py
+++ b/memote/suite/tests/test_sbml.py
@@ -40,7 +40,7 @@ def test_sbml_level(sbml_version):
     ann = test_sbml_level.annotation
     ann["data"] = version_tag
     outcome = sbml_version[:2] >= (3, 1)
-    ann["metric"] = 1.0 - float(outcome)
+    ann["metric"] = float(outcome)
     ann["message"] = wrapper.fill(
         """The SBML file uses: {}""".format(ann["data"]))
     assert sbml_version[:2] >= (3, 1), ann["message"]
@@ -66,7 +66,7 @@ def test_fbc_presence(sbml_version):
     fbc_present = sbml_version[2] is not None
     ann = test_fbc_presence.annotation
     ann["data"] = fbc_present
-    ann["metric"] = 1.0 - float(fbc_present)
+    ann["metric"] = float(fbc_present)
     if fbc_present:
         ann["message"] = wrapper.fill("The FBC package *is* used.")
     else:


### PR DESCRIPTION
I think it is much less confusing if the metrics of unscored tests reflect the title/ test description in their meaning e.g. `SBML Level and Version` checks that the lvl and ver fulfill a certain condition `    outcome = sbml_version[:2] >= (3, 1)`. The metric of that test `float(outcome)` shouldn't be the inverse of this.

Removing the inversion makes labeling consistent for all unscored tests.