### PR TITLE
Have memote.utils.is_modified() return False if file was deleted.

### DIFF
--- a/src/memote/suite/cli/runner.py
+++ b/src/memote/suite/cli/runner.py
@@ -29,7 +29,6 @@ from getpass import getpass
 from time import sleep
 from tempfile import mkdtemp
 from shutil import copy2, move
-from subprocess import check_call
 
 import click
 import click_log
@@ -212,9 +211,9 @@ def run(model, collect, filename, location, ignore_git, pytest_args, exclusive,
                 "Committing result and changing back to working branch.")
             manager.store(result, commit=previous_cmt.hexsha)
             repo.git.add(".")
-            check_call(
-                ['git', 'commit',
-                 '-m', "chore: add result for {}".format(previous_cmt.hexsha)]
+            repo.git.commit(
+                "--message",
+                "chore: add result for {}".format(previous_cmt.hexsha)
             )
             if is_branch:
                 previous.checkout()
@@ -422,7 +421,7 @@ def history(model, message, rewrite, solver, location, pytest_args, deployment,
     else:
         move(new_location, os.getcwd())
     repo.git.add(".")
-    check_call(['git', 'commit', '-m', message])
+    repo.git.commit("--message", message)
     LOGGER.info("Success!")
     # Checkout the original branch.
     previous.checkout()
@@ -772,12 +771,8 @@ def online(note, github_repository, github_username):
     te.dump_travis_configuration(config, ".travis.yml")
     LOGGER.info("Add, commit and push changes to '.travis.yml' to GitHub.")
     repo.index.add([".travis.yml"])
-    check_call(
-      ['git', 'commit', '-m', "chore: add encrypted GitHub access token"]
-    )
-    check_call(
-      ['git', 'push', '--set-upstream', 'origin', repo.active_branch.name]
-    )
+    repo.git.commit("--message", "chore: add encrypted GitHub access token")
+    repo.git.push("--set-upstream", "origin", repo.active_branch.name)
 
 
 cli.add_command(report)

--- a/src/memote/utils.py
+++ b/src/memote/utils.py
@@ -268,7 +268,7 @@ def flatten(list_of_lists):
 
 def is_modified(path, commit):
     """
-    Test whether a given file was modified in a specific commit.
+    Test whether a given file was present and modified in a specific commit.
 
     Parameters
     ----------
@@ -280,10 +280,19 @@ def is_modified(path, commit):
     Returns
     -------
     bool
-        Whether or not the given path is among the modified files.
+        Whether or not the given path is among the modified files
+        and was not deleted in this commit.
 
     """
-    return path in commit.stats.files
+    try:
+        d = commit.stats.files["path"]
+        if (d["insertions"] == 0) and (d["deletions"] == d["lines"]):
+            # File was deleted in commit, so cannot be tested
+            return False
+        else:
+            return True
+    except KeyError:
+        return False
 
 
 def stdout_notifications(notifications):

--- a/src/memote/utils.py
+++ b/src/memote/utils.py
@@ -285,7 +285,7 @@ def is_modified(path, commit):
 
     """
     try:
-        d = commit.stats.files["path"]
+        d = commit.stats.files[path]
         if (d["insertions"] == 0) and (d["deletions"] == d["lines"]):
             # File was deleted in commit, so cannot be tested
             return False

--- a/tests/test_for_suite/test_for_cli/test_for_runner.py
+++ b/tests/test_for_suite/test_for_cli/test_for_runner.py
@@ -22,9 +22,6 @@ from __future__ import absolute_import
 import os
 from builtins import str
 from os.path import exists, join, dirname, pardir
-from subprocess import check_output, call
-
-import pytest
 
 
 from memote.suite.cli.runner import cli
@@ -176,29 +173,25 @@ def test_online(runner, mock_repo, monkeypatch):
 
     # Use the Repository from the mock_repo fixture as the origin to clone from
     path2origin = mock_repo[0]
-    originrepo = mock_repo[1]
+    origin_repo = mock_repo[1]
 
     # We have to allow pushing into the 'origin' repo.
     os.chdir(path2origin)
-    check_output(['git', 'config', 'receive.denyCurrentBranch', 'ignore'])
+    with origin_repo.config_writer() as writer:
+        writer.set_value("receive", "denyCurrentBranch", "ignore").release()
 
     # Create a directory at a temporary path to clone the mock_repo into.
     # Cloning configures the mock_repo as the origin of the "local" repo which
     # allows us to push from one local directory to another.
     path2local = join(path2origin, pardir, 'cloned_repo')
     os.mkdir(path2local)
-    localrepo = originrepo.clone(path2local)
+    local_repo = origin_repo.clone(path2local)
     os.chdir(path2local)
 
     # Setting the config for the local repo.
-    call(
-        ['git', 'config',
-         'user.email', 'memote@opencobra.com']
-    )
-    call(
-        ['git', 'config',
-         'user.name', 'memote-bot']
-    )
+    with local_repo.config_writer() as writer:
+        writer.set_value("user", "name", "memote-bot").release()
+        writer.set_value("user", "email", "bot@memote.io").release()
 
     # Build context_settings
     context_settings = ConfigFileProcessor.read_config()
@@ -212,8 +205,8 @@ def test_online(runner, mock_repo, monkeypatch):
     assert result.exit_code == 0
 
     # Teardown
-    localrepo.git.reset("--hard", 'HEAD~')
-    localrepo.git.push('--force', 'origin', 'master')
+    local_repo.git.reset("--hard", 'HEAD~')
+    local_repo.git.push('--force', 'origin', 'master')
     os.chdir(previous_wd)
 
 

--- a/tests/test_for_utils.py
+++ b/tests/test_for_utils.py
@@ -135,8 +135,10 @@ def mock_repo(tmpdir_factory):
         repo.index.add([relname])
         repo.index.commit(message)
 
-    repo.index.add([relname])
-    repo.index.commit("Empty commit.")
+    with open(os.path.join(path, "unrelated_file.txt"), "w") as f:
+        f.write("Unrelated file.")
+    repo.index.add(["unrelated_file.txt"])
+    repo.index.commit("A commit that does not touch {}".format(relname))
 
     repo.index.remove([relname], working_tree=True)
     repo.index.commit("Delete file.")

--- a/tests/test_for_utils.py
+++ b/tests/test_for_utils.py
@@ -124,7 +124,7 @@ def test_show_versions(capsys):
 @pytest.fixture(scope="function")
 def mock_repo(tmpdir_factory):
     """Mock repo with history: add, modify, do nothing, delete file."""
-    path = tmpdir_factory.mktemp("memote-mock-repo")
+    path = str(tmpdir_factory.mktemp("memote-mock-repo"))
     repo = git.Repo.init(path)
     relname = "test_file.txt"
     absname = os.path.join(path, relname)

--- a/tests/test_for_utils.py
+++ b/tests/test_for_utils.py
@@ -15,7 +15,10 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import os
+
 import pytest
+import git
 
 import memote.utils as utils
 
@@ -116,3 +119,40 @@ def test_show_versions(capsys):
     assert lines[7].startswith("Package Versions")
     assert lines[8].startswith("================")
     assert any(l.startswith("memote") for l in lines[9:])
+
+
+@pytest.fixture(scope="function")
+def mock_repo(tmpdir_factory):
+    """Mock repo with history: add, modify, do nothing, delete file."""
+    path = tmpdir_factory.mktemp("memote-mock-repo")
+    repo = git.Repo.init(path)
+    relname = "test_file.txt"
+    absname = os.path.join(path, relname)
+
+    for message in "Add file.", "Modify file.":
+        with open(absname, "w") as f:
+            f.write(message)
+        repo.index.add([relname])
+        repo.index.commit(message)
+
+    repo.index.add([relname])
+    repo.index.commit("Empty commit.")
+
+    repo.index.remove([relname], working_tree=True)
+    repo.index.commit("Delete file.")
+
+    return relname, repo
+
+
+def test_is_modified_deleted(mock_repo):
+    """Don't report file deletion as modification."""
+    relname, repo = mock_repo
+    # File history (newest first): deleted, unchanged, modified, created
+    # Don't report file deletion as "modification"
+    # for purposes of running memote tests on the file.
+    want = False, False, True, True
+    # Convert to tuple so we can compare want == got,
+    # which pytest will introspect helpfully if the assertion fails.
+    got = tuple(utils.is_modified(relname, commit)
+                for commit in repo.iter_commits())
+    assert want == got

--- a/tests/test_for_utils.py
+++ b/tests/test_for_utils.py
@@ -126,6 +126,9 @@ def mock_repo(tmpdir_factory):
     """Mock repo with history: add, modify, do nothing, delete file."""
     path = str(tmpdir_factory.mktemp("memote-mock-repo"))
     repo = git.Repo.init(path)
+    with repo.config_writer() as writer:
+        writer.set_value("user", "name", "memote-bot").release()
+        writer.set_value("user", "email", "bot@memote.io").release()
     relname = "test_file.txt"
     absname = os.path.join(path, relname)
 
@@ -133,15 +136,18 @@ def mock_repo(tmpdir_factory):
         with open(absname, "w") as f:
             f.write(message)
         repo.index.add([relname])
-        repo.index.commit(message)
+        repo.git.commit("--message", message)
 
     with open(os.path.join(path, "unrelated_file.txt"), "w") as f:
         f.write("Unrelated file.")
     repo.index.add(["unrelated_file.txt"])
-    repo.index.commit("A commit that does not touch {}".format(relname))
+    repo.git.commit(
+        "--message",
+        "A commit that does not touch {}".format(relname)
+    )
 
     repo.index.remove([relname], working_tree=True)
-    repo.index.commit("Delete file.")
+    repo.git.commit("--message", "Delete file.")
 
     return relname, repo
 


### PR DESCRIPTION
`memote history` will fail on a commit that deleted the model file.

```
Running the test suite for commit '8daf...'.
Traceback (most recent call last):
...
  File "C:\NMBU\Miniconda3\envs\cbm\lib\site-packages\click\core.py", line 535, in invoke
    return callback(*args, **kwargs)
  File "c:\git\digisal\memote\memote\suite\cli\runner.py", line 393, in history
    blob = cmt.tree[model]
  File "C:\NMBU\Miniconda3\envs\cbm\lib\site-packages\git\objects\tree.py", line 298, in __getitem__
    return self.join(item)
  File "C:\NMBU\Miniconda3\envs\cbm\lib\site-packages\git\objects\tree.py", line 225, in join
    item = tree[token]
  File "C:\NMBU\Miniconda3\envs\cbm\lib\site-packages\git\objects\tree.py", line 298, in __getitem__
    return self.join(item)
  File "C:\NMBU\Miniconda3\envs\cbm\lib\site-packages\git\objects\tree.py", line 244, in join
    raise KeyError(msg % file)
KeyError: "Blob or Tree named 'export' not found"
```

(where `export` referred to my model file `export/model.xml`)

This is because [memote.utils.is_modified](https://github.com/opencobra/memote/blob/276630fcd4449fb7b914186edfd38c239e7052df/memote/utils.py#L269) just tests for `path in commit.stats.files`, whereas a deletion shows up as `{'insertions': 0, 'deletions': N, 'lines': N}` where `N` is the number of lines in the file.

[This example](https://github.com/jonovik/memote/blob/37fdb6a4b58952d57a9c78c0a31cba1a4757c321/tests/test_for_utils.py#L125) shows a file being created, modified, untouched, deleted (in reverse chronological order):

```python
>>> [commit.stats.files for commit in repo.iter_commits()]
[{'test_file.txt': {'insertions': 0, 'deletions': 1, 'lines': 1}},
 {},
 {'test_file.txt': {'insertions': 1, 'deletions': 1, 'lines': 2}},
 {'test_file.txt': {'insertions': 1, 'deletions': 0, 'lines': 1}}]
```

Since we cannot run tests on a nonexistent model file, it is more robust to skip those commits.
I have modified [memote.utils.is_modified](https://github.com/jonovik/memote/blob/37fdb6a4b58952d57a9c78c0a31cba1a4757c321/memote/utils.py#L269) and added a [test](https://github.com/jonovik/memote/blob/37fdb6a4b58952d57a9c78c0a31cba1a4757c321/tests/test_for_utils.py#L147) which fails in 276630f but passes in my pull request.