### PR TITLE
chore: register custom pytest markers to snuff error messages

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -3,6 +3,8 @@ History
 
 Next Release
 ------------
+* Explicitly register custom markers `biomass`, `essentiality` and `growth`
+  used for custom test parametrization in pytest.
 
 0.9.11 (2019-04-23)
 -------------------

--- a/src/memote/suite/collect.py
+++ b/src/memote/suite/collect.py
@@ -170,7 +170,7 @@ class ResultCollectionPlugin(object):
         return self._sbml_ver
 
     def pytest_configure(self, config):
-        """Register custom markers at runtime """
+        """Register custom markers at runtime."""
         config.addinivalue_line("markers",
                                 "biomass: ")
         config.addinivalue_line("markers",

--- a/src/memote/suite/collect.py
+++ b/src/memote/suite/collect.py
@@ -168,3 +168,12 @@ class ResultCollectionPlugin(object):
     def sbml_version(self):
         """Provide SBML level, version, and FBC use."""
         return self._sbml_ver
+
+    def pytest_configure(self, config):
+        """Register custom markers at runtime """
+        config.addinivalue_line("markers",
+                                "biomass: ")
+        config.addinivalue_line("markers",
+                                "essentiality: ")
+        config.addinivalue_line("markers",
+                                "growth: ")

--- a/src/memote/suite/collect.py
+++ b/src/memote/suite/collect.py
@@ -172,8 +172,8 @@ class ResultCollectionPlugin(object):
     def pytest_configure(self, config):
         """Register custom markers at runtime."""
         config.addinivalue_line("markers",
-                                "biomass: ")
+                                "biomass")
         config.addinivalue_line("markers",
-                                "essentiality: ")
+                                "essentiality")
         config.addinivalue_line("markers",
-                                "growth: ")
+                                "growth")


### PR DESCRIPTION
* [x] description of feature/fix
* [x] add an entry to the [next release](../HISTORY.rst)

This removes the warnings that appear with the most recent version of Pytest under Python 3.6.0 by registering the custom markers we use for parametrization (`biomass`, `essentiality` and `growth`). 

Running `memote report snapshot` on Google Colaboratory (Python 3.6.8) errors with something along these lines:
```'biomass' not found in `markers` configuration option```

This is [recommended by the authors of pytest](https://docs.pytest.org/en/latest/example/markers.html?highlight=register%20markers#registering-markers)
