### PR TITLE
fix: change logic of test production and consumption metabolites to speed up the process

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -6,6 +6,12 @@ Next Release
 * Improve the biomass reaction finding logic.
 * Explicitly register custom markers `biomass`, `essentiality` and `growth`
   used for custom test parametrization in pytest.
+  
+0.9.12 (2019-11-27)
+-------------------
+* New logic for `consistency` tests of production and consumption of metabolites
+  with open bounds. It allows multiprocessing, currently relying on 
+  `cobra.Configuration` to select the number of processors).
 
 0.9.11 (2019-04-23)
 -------------------

--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -11,7 +11,7 @@ Next Release
 -------------------
 * New logic for `consistency` tests of production and consumption of metabolites
   with open bounds. It allows multiprocessing, currently relying on 
-  `cobra.Configuration` to select the number of processors).
+  `cobra.Configuration` to select the number of processors.
 
 0.9.11 (2019-04-23)
 -------------------

--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -6,11 +6,8 @@ Next Release
 * Improve the biomass reaction finding logic.
 * Explicitly register custom markers `biomass`, `essentiality` and `growth`
   used for custom test parametrization in pytest.
-  
-0.9.12 (2019-11-27)
--------------------
-* New logic for `consistency` tests of production and consumption of metabolites
-  with open bounds. It allows multiprocessing, currently relying on 
+* Fix logic for `consistency` tests of production and consumption of 
+  metabolites with open bounds. It allows multiprocessing, currently relying on 
   `cobra.Configuration` to select the number of processors.
 
 0.9.11 (2019-04-23)

--- a/src/memote/support/consistency.py
+++ b/src/memote/support/consistency.py
@@ -623,7 +623,7 @@ def find_metabolites_not_consumed_with_open_bounds(model, processes=None):
         Those metabolites that could not be consumed.
 
     """
-    find_metabolites_not_produced_with_open_bounds(
+    return find_metabolites_not_produced_with_open_bounds(
         model, processes=processes, prod=False
     )
 

--- a/src/memote/support/consistency.py
+++ b/src/memote/support/consistency.py
@@ -535,9 +535,6 @@ def _solve_metabolite_production(metabolite):
         metabolite passed as argument (to use map as a filter)
 
     """
-    global _model
-    global _irr
-    global _val
     constraint = _model.metabolites.get_by_id(metabolite.id).constraint
     constraint.set_linear_coefficients({_irr: _val})
     solution = _model.slim_optimize()

--- a/src/memote/support/consistency.py
+++ b/src/memote/support/consistency.py
@@ -518,8 +518,8 @@ def _init_worker(model, irr, val):
 
 def _solve_metabolite_production(metabolite):
     """
-    Add reaction to a `metabolite`'s contraints. 
-    
+    Add reaction to a `metabolite`'s contraints.
+
     The reaction and the model are passed as globals.
 
     Parameters

--- a/src/memote/support/consistency.py
+++ b/src/memote/support/consistency.py
@@ -493,7 +493,8 @@ def find_disconnected(model):
 
 
 def _init_worker(model, irr, val):
-    """Initialize a global model object for multiprocessing.
+    """
+    Initialize a global model object for multiprocessing.
 
     Parameters
     ----------
@@ -504,6 +505,7 @@ def _init_worker(model, irr, val):
         variables of the model.
     val: int
         value of the coefficient: -1 for production and 1 for consumption
+
     """
     global _model
     global _irr
@@ -516,8 +518,9 @@ def _init_worker(model, irr, val):
 
 def _solve_metabolite_production(metabolite):
     """
-    Solves the model when some reaction has been added to a `metabolite`'s
-    contraints. The reaction and the model are passed as globals.
+    Add reaction to a `metabolite`'s contraints. 
+    
+    The reaction and the model are passed as globals.
 
     Parameters
     ----------
@@ -530,6 +533,7 @@ def _solve_metabolite_production(metabolite):
         the value of the solution of the LP problem, *NaN* if infeasible.
     metabolite: cobra.Metabolite
         metabolite passed as argument (to use map as a filter)
+
     """
     global _model
     global _irr

--- a/src/memote/support/consistency.py
+++ b/src/memote/support/consistency.py
@@ -541,7 +541,9 @@ def _solve_metabolite_production(metabolite):
     return solution, metabolite
 
 
-def find_metabolites_not_produced_with_open_bounds(model, processes=None, prod=True):
+def find_metabolites_not_produced_with_open_bounds(
+    model, processes=None, prod=True
+):
     """
     Return metabolites that cannot be produced with open exchange reactions.
 
@@ -572,9 +574,9 @@ def find_metabolites_not_produced_with_open_bounds(model, processes=None, prod=T
     n_mets = len(model.metabolites)
     processes = min(processes, n_mets)
     # manage the value of the linear coefficient to be added to each metabolite
-    val = -1 # production
+    val = -1  # production
     if not prod:
-        val = 1 # consumption
+        val = 1  # consumption
 
     helpers.open_exchanges(model)
     irr = model.problem.Variable("irr", lb=0, ub=1000)
@@ -621,7 +623,9 @@ def find_metabolites_not_consumed_with_open_bounds(model, processes=None):
         Those metabolites that could not be consumed.
 
     """
-    find_metabolites_not_produced_with_open_bounds(model, processes=processes, prod=False)
+    find_metabolites_not_produced_with_open_bounds(
+        model, processes=processes, prod=False
+    )
 
 
 def find_reactions_with_unbounded_flux_default_condition(model):


### PR DESCRIPTION
In order to speed up the consistency tests of checking metabolite production and consumption with open bounds, the logic of the test has been changed. Instead of adding a boundary to the model each time, the test now works by sequentially changing the linear coefficients of the metabolites, which should be faster.

* Add a variable **just once** (bounds in 0,1000);
* Set the variable as the objective of the model;
* for each metabolite:  
        ▪ get the linear coefficients of the constraint of each metabolite;  
        ▪ add a coefficient to the variable in the constraint (-1 for production and 1 for consumption)
        ▪ solve;  
        ▪ restore constraint;  
        ▪ If not solution, add the metabolite to the returned output.

**Multiprocessing** was also added to decrease the running time.