### PR TITLE
fix: set threshold to model tolerance when solution is infeasible

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -3,6 +3,7 @@ History
 
 Next Release
 ------------
+* Fix an issue where experimental growth was incorrectly not reported.
 
 0.10.2 (2020-03-24)
 -------------------
@@ -184,14 +185,14 @@ Next Release
 
 0.8.9 (2018-12-11)
 ------------------
-* Compress JSON and SQLite storage of results using gzip by default. JSON 
-  continues to work either compressed or uncompressed. At the moment we 
-  offer no database migration, please contact us if you need help in 
+* Compress JSON and SQLite storage of results using gzip by default. JSON
+  continues to work either compressed or uncompressed. At the moment we
+  offer no database migration, please contact us if you need help in
   migrating a large existing SQLite database rather than just re-computing it.
 
 0.8.8 (2018-12-10)
 ------------------
-* Adjust the reversibility index test to not use name matching and increase 
+* Adjust the reversibility index test to not use name matching and increase
   the threshold slightly. Also adjust the description of the test.
 * Adjust tests to the change in the ``add_boundary`` interface.
 * Identify blocked reactions using the cobrapy built-in function.
@@ -202,16 +203,16 @@ Next Release
 * Add a test that checks if reactions are annotated with reactome identifiers.
 * Add a feature that allows identifying specific metabolites by matching
   annotation information against the metabolite shortlist for a given MNX ID.
-* Change every usage of SBO key to lower case to conform to the identifiers.org 
+* Change every usage of SBO key to lower case to conform to the identifiers.org
   namespace for the Systems Biology Ontology.
-* Remove that metabolite SBO terms are used when identifying transport 
+* Remove that metabolite SBO terms are used when identifying transport
   reactions as this may lead to false positives.
-* Return metabolite IDs when finding duplicate metabolites to avoid 
+* Return metabolite IDs when finding duplicate metabolites to avoid
   serialization errors.
 * Identify transport reactions first by formula then by annotation.
 * For the diff report, run pytest in different processes to avoid accidentally
   overwriting the results of the former with the results of the later runs.
-* In the diff report, fix a typo that allowed the diff button to depart the 
+* In the diff report, fix a typo that allowed the diff button to depart the
   defined colour scheme (blue -> red) to cyan.
 * Fix the snapshot report not showing environment information.
 * Allow ``memote run`` to skip commits where the model was not
@@ -253,7 +254,7 @@ Next Release
   category are grouped logically.
 * Updated the documentation to include a newer flowchart, up-to-date getting
   started and custom test sections.
-* Update code to account for breaking changes in the most recent version of 
+* Update code to account for breaking changes in the most recent version of
   cobrapy (0.13.0) and subsequently unpin cobrapy dependency (set to >=0.13.0).
 
 0.8.1 (2018-06-27)

--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -4,6 +4,7 @@ History
 Next Release
 ------------
 * Fix an issue where experimental growth was incorrectly not reported.
+* Allow the user to set a threshold value for growth in experimental data.
 
 0.10.2 (2020-03-24)
 -------------------

--- a/docs/experimental_data.rst
+++ b/docs/experimental_data.rst
@@ -49,11 +49,11 @@ The file simply states that files relating to media, essentiality, and growth
 experiments can be found at directories stated under ``path:`` relative to the
 location of the file.
 
-Minimum growth threshold
-------------------------
+Minimal growth rate
+-------------------
 Both growth and essentiality experiments require a threshold for the biomass
 function to determine if the model is growing. This value can be set via the
-``min_growth`` option in the ``experiments.yml`` file.
+``minimal_growth_rate`` option in the ``experiments.yml`` file.
 For instance:
 
 .. code-block:: yaml
@@ -65,9 +65,9 @@ For instance:
       path: "essentiality/"
     growth:
       path: "growth/"
-    min_growth: 0.05
+    minimal_growth_rate: 0.05
 
-By default, ``min_growth`` is set to 10% of the biomass function value
+By default, ``minimal_growth_rate`` is set to 10% of the biomass function value
 under the default constraints in the model.
 
 Media

--- a/docs/experimental_data.rst
+++ b/docs/experimental_data.rst
@@ -49,6 +49,27 @@ The file simply states that files relating to media, essentiality, and growth
 experiments can be found at directories stated under ``path:`` relative to the
 location of the file.
 
+Minimum growth threshold
+------------------------
+Both growth and essentiality experiments require a threshold for the biomass
+function to determine if the model is growing. This value can be set via the
+``min_growth`` option in the ``experiments.yml`` file.
+For instance:
+
+.. code-block:: yaml
+
+    version: "0.1"
+    medium:
+      path: "media/"
+    essentiality:
+      path: "essentiality/"
+    growth:
+      path: "growth/"
+    min_growth: 0.05
+
+By default, ``min_growth`` is set to 10% of the biomass function value
+under the default constraints in the model.
+
 Media
 =====
 

--- a/docs/experimental_data.rst
+++ b/docs/experimental_data.rst
@@ -51,9 +51,9 @@ location of the file.
 
 Minimal growth rate
 -------------------
-Both growth and essentiality experiments require a threshold for the biomass
-function to determine if the model is growing. This value can be set via the
-``minimal_growth_rate`` option in the ``experiments.yml`` file.
+Both growth and essentiality experiments require a minimal biomass function
+value to determine if the model predicts viability. This value can be set via
+the ``minimal_growth_rate`` option in the ``experiments.yml`` file.
 For instance:
 
 .. code-block:: yaml

--- a/src/memote/experimental/config.py
+++ b/src/memote/experimental/config.py
@@ -193,10 +193,10 @@ class ExperimentConfiguration(object):
         Parameters
         ----------
         model : cobra.Model
-        threshold : float
+        threshold : float, optional
             If no input is provided by the user the default value is set to a
-            coefficient `threshold` times the growth under default constraints.
-            Default: 0.1.
+            coefficient `threshold` times the growth under default constraints
+            (default: 0.1).
 
         """
         minimal_growth_rate = self.config.get("minimal_growth_rate")

--- a/src/memote/experimental/config.py
+++ b/src/memote/experimental/config.py
@@ -121,7 +121,7 @@ class ExperimentConfiguration(object):
             return
         path = self.get_path(data,
                              join("data", "experimental", "essentiality"))
-        min_growth = self.get_min_growth(model)
+        min_growth = self.get_minimal_growth_rate(model)
         for exp_id, exp in iteritems(experiments):
             if exp is None:
                 exp = dict()
@@ -153,7 +153,7 @@ class ExperimentConfiguration(object):
             return
         path = self.get_path(data,
                              join("data", "experimental", "growth"))
-        min_growth = self.get_min_growth(model)
+        minimal_growth_rate = self.get_minimal_growth_rate(model)
         for exp_id, exp in iteritems(experiments):
             if exp is None:
                 exp = dict()
@@ -164,7 +164,7 @@ class ExperimentConfiguration(object):
                 filename = join(path, filename)
             growth = GrowthExperiment(
                 identifier=exp_id, obj=exp,
-                filename=filename, min_growth=min_growth
+                filename=filename, minimal_growth_rate=minimal_growth_rate
             )
             if growth.medium is not None:
                 assert growth.medium in self.media, \
@@ -184,7 +184,7 @@ class ExperimentConfiguration(object):
             path = join(self._base, path)
         return path
 
-    def get_min_growth(self, model, threshold=0.1):
+    def get_minimal_growth_rate(self, model, threshold=0.1):
         """Calculate min growth default value or return input value.
 
         This value is used to determine if a model is capable of growth under
@@ -199,14 +199,14 @@ class ExperimentConfiguration(object):
             Default: 0.1.
 
         """
-        min_growth = self.config.get("min_growth")
-        if min_growth is None:
-            min_growth = model.slim_optimize() * threshold
-            if isnan(min_growth):
+        minimal_growth_rate = self.config.get("minimal_growth_rate")
+        if minimal_growth_rate is None:
+            minimal_growth_rate = model.slim_optimize() * threshold
+            if isnan(minimal_growth_rate):
                 LOGGER.debug(
                     "Threshold set to {} due to infeasible "
                     "solution (NaN produced) with default "
                     "constraints.".format(model.tolerance)
                 )
-                min_growth = model.tolerance
-        return min_growth
+                minimal_growth_rate = model.tolerance
+        return minimal_growth_rate

--- a/src/memote/experimental/config.py
+++ b/src/memote/experimental/config.py
@@ -121,7 +121,7 @@ class ExperimentConfiguration(object):
             return
         path = self.get_path(data,
                              join("data", "experimental", "essentiality"))
-        min_growth = self.get_minimal_growth_rate(model)
+        minimal_growth_rate = self.get_minimal_growth_rate(model)
         for exp_id, exp in iteritems(experiments):
             if exp is None:
                 exp = dict()
@@ -132,7 +132,7 @@ class ExperimentConfiguration(object):
                 filename = join(path, filename)
             experiment = EssentialityExperiment(
                 identifier=exp_id, obj=exp,
-                filename=filename, min_growth=min_growth
+                filename=filename, minimal_growth_rate=minimal_growth_rate
             )
             if experiment.medium is not None:
                 assert experiment.medium in self.media, \
@@ -203,7 +203,7 @@ class ExperimentConfiguration(object):
         if minimal_growth_rate is None:
             minimal_growth_rate = model.slim_optimize() * threshold
             if isnan(minimal_growth_rate):
-                LOGGER.debug(
+                LOGGER.error(
                     "Threshold set to {} due to infeasible "
                     "solution (NaN produced) with default "
                     "constraints.".format(model.tolerance)

--- a/src/memote/experimental/essentiality.py
+++ b/src/memote/experimental/essentiality.py
@@ -91,6 +91,6 @@ class EssentialityExperiment(Experiment):
             essen = single_gene_deletion(
                 model, gene_list=self.data["gene"], processes=1)
         essen["gene"] = [list(g)[0] for g in essen.index]
-        essen["essential"] = (essen["growth"] < (max_val * 0.1)) \
+        essen["essential"] = (essen["growth"] < self.min_growth) \
             | essen["growth"].isna()
         return essen

--- a/src/memote/experimental/essentiality.py
+++ b/src/memote/experimental/essentiality.py
@@ -90,6 +90,6 @@ class EssentialityExperiment(Experiment):
             essen = single_gene_deletion(
                 model, gene_list=self.data["gene"], processes=1)
         essen["gene"] = [list(g)[0] for g in essen.index]
-        essen["essential"] = (essen["growth"] < self.min_growth) \
+        essen["essential"] = (essen["growth"] < self.minimal_growth_rate) \
             | essen["growth"].isna()
         return essen

--- a/src/memote/experimental/essentiality.py
+++ b/src/memote/experimental/essentiality.py
@@ -87,7 +87,6 @@ class EssentialityExperiment(Experiment):
             if self.objective is not None:
                 model.objective = self.objective
             model.add_cons_vars(self.constraints)
-            max_val = model.slim_optimize()
             essen = single_gene_deletion(
                 model, gene_list=self.data["gene"], processes=1)
         essen["gene"] = [list(g)[0] for g in essen.index]

--- a/src/memote/experimental/experiment.py
+++ b/src/memote/experimental/experiment.py
@@ -31,13 +31,16 @@ LOGGER = logging.getLogger(__name__)
 class Experiment(ExperimentalBase):
     """Base class for experimental data."""
 
-    def __init__(self, obj, **kwargs):
+    def __init__(self, obj, minimal_growth_rate, **kwargs):
         """
         Initialize an experiment.
 
         Parameters
         ----------
         obj : dict
+        minimal_growth_rate : float
+            minimum value of biomass function for the model to be considered as
+            growing. Not used by Medium. Default: None
         kwargs
 
         """
@@ -51,6 +54,7 @@ class Experiment(ExperimentalBase):
             raise NotImplementedError(
                 "This feature is not implemented yet. Please let us know that "
                 "you want it at https://github.com/opencobra/memote/issues.")
+        self.minimal_growth_rate = minimal_growth_rate
 
     def evaluate(self, model):
         """Abstract base method for evaluating experimental data."""

--- a/src/memote/experimental/experimental_base.py
+++ b/src/memote/experimental/experimental_base.py
@@ -50,7 +50,9 @@ class ExperimentalBase(object):
         "YES"
     }
 
-    def __init__(self, identifier, obj, filename, min_growth=None, **kwargs):
+    def __init__(
+        self, identifier, obj, filename, minimal_growth_rate=None, **kwargs
+    ):
         """
         Initialize a medium.
 
@@ -60,7 +62,7 @@ class ExperimentalBase(object):
         obj : dict
         filename : str or pathlib.Path
             The full file path. May be a compressed file.
-        min_growth : float
+        minimal_growth_rate : float
             minimum value of biomass function for the model to be considered as
             growing. Not used by Medium. Default: None
         kwargs
@@ -74,7 +76,7 @@ class ExperimentalBase(object):
         self.filename = filename
         self.data = None
         self.schema = None
-        self.min_growth = min_growth
+        self.minimal_growth_rate = minimal_growth_rate
 
     def load(self, dtype_conversion=None):
         """

--- a/src/memote/experimental/experimental_base.py
+++ b/src/memote/experimental/experimental_base.py
@@ -50,7 +50,7 @@ class ExperimentalBase(object):
         "YES"
     }
 
-    def __init__(self, identifier, obj, filename, **kwargs):
+    def __init__(self, identifier, obj, filename, min_growth=None, **kwargs):
         """
         Initialize a medium.
 
@@ -60,6 +60,9 @@ class ExperimentalBase(object):
         obj : dict
         filename : str or pathlib.Path
             The full file path. May be a compressed file.
+        min_growth : float
+            minimum value of biomass function for the model to be considered as
+            growing. Not used by Medium. Default: None
         kwargs
 
         """
@@ -71,6 +74,7 @@ class ExperimentalBase(object):
         self.filename = filename
         self.data = None
         self.schema = None
+        self.min_growth = min_growth
 
     def load(self, dtype_conversion=None):
         """

--- a/src/memote/experimental/experimental_base.py
+++ b/src/memote/experimental/experimental_base.py
@@ -51,7 +51,7 @@ class ExperimentalBase(object):
     }
 
     def __init__(
-        self, identifier, obj, filename, minimal_growth_rate=None, **kwargs
+        self, identifier, obj, filename, **kwargs
     ):
         """
         Initialize a medium.
@@ -62,9 +62,6 @@ class ExperimentalBase(object):
         obj : dict
         filename : str or pathlib.Path
             The full file path. May be a compressed file.
-        minimal_growth_rate : float
-            minimum value of biomass function for the model to be considered as
-            growing. Not used by Medium. Default: None
         kwargs
 
         """
@@ -76,7 +73,6 @@ class ExperimentalBase(object):
         self.filename = filename
         self.data = None
         self.schema = None
-        self.minimal_growth_rate = minimal_growth_rate
 
     def load(self, dtype_conversion=None):
         """

--- a/src/memote/experimental/growth.py
+++ b/src/memote/experimental/growth.py
@@ -21,8 +21,6 @@ from __future__ import absolute_import
 
 import logging
 
-from math import isnan
-
 from pandas import DataFrame
 
 from memote.experimental.experiment import Experiment

--- a/src/memote/experimental/growth.py
+++ b/src/memote/experimental/growth.py
@@ -21,6 +21,8 @@ from __future__ import absolute_import
 
 import logging
 
+from math import isnan
+
 from pandas import DataFrame
 
 from memote.experimental.experiment import Experiment
@@ -73,6 +75,12 @@ class GrowthExperiment(Experiment):
                 model.objective = self.objective
             model.add_cons_vars(self.constraints)
             threshold *= model.slim_optimize()
+            if isnan(threshold):
+                LOGGER.debug(
+                    f"Threshold set to {model.tolerance} "
+                    f"due to infeasible solution (NaN produced)."
+                )
+                threshold = model.tolerance
             growth = list()
             for row in self.data.itertuples(index=False):
                 with model:

--- a/src/memote/experimental/growth.py
+++ b/src/memote/experimental/growth.py
@@ -80,7 +80,9 @@ class GrowthExperiment(Experiment):
                         exchange.lower_bound = -row.uptake
                     else:
                         exchange.upper_bound = row.uptake
-                    growth.append(model.slim_optimize() >= self.min_growth)
+                    growth.append(
+                        model.slim_optimize() >= self.minimal_growth_rate
+                    )
         return DataFrame({
             "exchange": self.data["exchange"],
             "growth": growth

--- a/src/memote/experimental/growth.py
+++ b/src/memote/experimental/growth.py
@@ -77,8 +77,8 @@ class GrowthExperiment(Experiment):
             threshold *= model.slim_optimize()
             if isnan(threshold):
                 LOGGER.debug(
-                    f"Threshold set to {model.tolerance} "
-                    f"due to infeasible solution (NaN produced)."
+                    "Threshold set to {} due to infeasible "
+                    "solution (NaN produced).".format(model.tolerance)
                 )
                 threshold = model.tolerance
             growth = list()

--- a/src/memote/experimental/growth.py
+++ b/src/memote/experimental/growth.py
@@ -80,7 +80,7 @@ class GrowthExperiment(Experiment):
                         exchange.lower_bound = -row.uptake
                     else:
                         exchange.upper_bound = row.uptake
-                    growth.append(model.slim_optimize() >= 0.002)
+                    growth.append(model.slim_optimize() >= self.min_growth)
         return DataFrame({
             "exchange": self.data["exchange"],
             "growth": growth

--- a/src/memote/experimental/schemata/configuration.json
+++ b/src/memote/experimental/schemata/configuration.json
@@ -119,7 +119,7 @@
     "growth": {
       "$ref": "#/definitions/experiments"
     },
-    "min_growth": {
+    "minimal_growth_rate": {
       "type": [
         "number",
         "null"

--- a/src/memote/experimental/schemata/configuration.json
+++ b/src/memote/experimental/schemata/configuration.json
@@ -118,6 +118,12 @@
     },
     "growth": {
       "$ref": "#/definitions/experiments"
+    },
+    "min_growth": {
+      "type": [
+        "number",
+        "null"
+      ]
     }
   },
   "required": [

--- a/tests/test_for_experimental/data/growth.yml
+++ b/tests/test_for_experimental/data/growth.yml
@@ -3,6 +3,7 @@ medium:
   path: "media/"
   definitions:
     m9_minimal:
+min_growth: 0.002
 growth:
   path: "growth"
   experiments:

--- a/tests/test_for_experimental/data/growth.yml
+++ b/tests/test_for_experimental/data/growth.yml
@@ -3,7 +3,7 @@ medium:
   path: "media/"
   definitions:
     m9_minimal:
-min_growth: 0.002
+minimal_growth_rate: 0.002
 growth:
   path: "growth"
   experiments:

--- a/tests/test_for_experimental/test_for_experimental_base.py
+++ b/tests/test_for_experimental/test_for_experimental_base.py
@@ -49,7 +49,16 @@ def klass(request):
     {"label": "bird"}
 ])
 def test_init(klass, obj):
-    exp = klass(identifier="that", obj=obj, filename=join(DATA_PATH, "."))
+    kwargs = {
+        "identifier": "that",
+        "obj": obj,
+        "filename": join(DATA_PATH, "."),
+    }
+    if issubclass(klass, Experiment):
+        # minimal_growth_rate is required and only used by classes derived
+        # from Experiment (GrowthExperiment and EssentialityExperiment)
+        kwargs["minimal_growth_rate"] = 0.002
+    exp = klass(**kwargs)
     for key, value in iteritems(obj):
         assert getattr(exp, key) == value
 


### PR DESCRIPTION
* [x] description of bug
The growth tests with experimental data do not work when, after applying the medium, the solver returns infeasible, propagating a `NaN` to the growth comparison that hampers the tests (reports 0 for all metabolites).
* [x] description of feature/fix
Now the user can provide an absolute value in the `experiments.yml` configuration as minimum growth that acts both on essentiality and growth experiments. If no value is provided, it defaults to a coefficient (set as 10% for now) of the growth under default constraints.
* [ ] tests added/passed
* [x] document min_growth
* [x] add an entry to the [next release](../HISTORY.rst)
