### PR TITLE
fix: detect minimal uncoservable sets

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -5,6 +5,7 @@ Next Release
 ------------
 * Fix an issue where experimental growth was incorrectly not reported.
 * Allow the user to set a threshold value for growth in experimental data.
+* Fix and enable the consistency test for minimal unconservable sets.
 
 0.10.2 (2020-03-24)
 -------------------

--- a/src/memote/suite/tests/test_consistency.py
+++ b/src/memote/suite/tests/test_consistency.py
@@ -58,7 +58,7 @@ def test_stoichiometric_consistency(model):
     ann["data"] = {
         "unconserved_metabolites":  [] if is_consistent else get_ids(
             consistency.find_unconserved_metabolites(model)),
-        "minimal_uncoservable_sets": [] if is_consistent else get_ids(
+        "minimal_unconservable_sets": [] if is_consistent else get_ids(
             consistency.find_inconsistent_min_stoichiometry(model)),
     }
     ann["metric"] = len(ann["data"]["unconserved_metabolites"]) / len(
@@ -67,12 +67,13 @@ def test_stoichiometric_consistency(model):
     ann["message"] = wrapper.fill(
         """This model contains {} ({:.2%}) unconserved
         metabolites: {}; and {} minimal uncoservable sets""".format(
-            len(ann["data"]["uncoserved_metabolites"]),
+            len(ann["data"]["unconserved_metabolites"]),
             ann["metric"],
-            truncate(ann["data"]["uncoserved_metabolites"]),
-            truncate(ann["data"]["minimal_uncoservable_sets"]),
+            truncate(ann["data"]["unconserved_metabolites"]),
+            truncate(ann["data"]["minimal_unconservable_sets"]),
         )
     )
+    print(f"ANN OBJ -> {ann}")
     assert is_consistent, ann["message"]
 
 

--- a/src/memote/suite/tests/test_consistency.py
+++ b/src/memote/suite/tests/test_consistency.py
@@ -66,14 +66,14 @@ def test_stoichiometric_consistency(model):
     )
     ann["message"] = wrapper.fill(
         """This model contains {} ({:.2%}) unconserved
-        metabolites: {}; and {} minimal uncoservable sets""".format(
+        metabolites: {}; and {} minimal unconservable sets: {}""".format(
             len(ann["data"]["unconserved_metabolites"]),
             ann["metric"],
             truncate(ann["data"]["unconserved_metabolites"]),
+            len(ann["data"]["minimal_unconservable_sets"]),
             truncate(ann["data"]["minimal_unconservable_sets"]),
         )
     )
-    print(f"ANN OBJ -> {ann}")
     assert is_consistent, ann["message"]
 
 

--- a/src/memote/suite/tests/test_consistency.py
+++ b/src/memote/suite/tests/test_consistency.py
@@ -58,8 +58,10 @@ def test_stoichiometric_consistency(model):
     ann["data"] = {
         "unconserved_metabolites":  [] if is_consistent else get_ids(
             consistency.find_unconserved_metabolites(model)),
-        "minimal_unconservable_sets": [] if is_consistent else get_ids(
-            consistency.find_inconsistent_min_stoichiometry(model)),
+        "minimal_unconservable_sets": [] if is_consistent else [
+            get_ids(mets)
+            for mets in
+            consistency.find_inconsistent_min_stoichiometry(model)],
     }
     ann["metric"] = len(ann["data"]["unconserved_metabolites"]) / len(
         model.metabolites

--- a/src/memote/support/consistency.py
+++ b/src/memote/support/consistency.py
@@ -223,18 +223,22 @@ def find_inconsistent_min_stoichiometry(model, atol=None):
             "nullspace has dimension %d", left_ns.shape[1]
             if len(left_ns.shape) > 1 else 0)
     inc_minimal = set()
-    (problem, indicators) = con_helpers.create_milp_problem(
-        left_ns, metabolites, Model, Variable, Constraint, Objective)
-    # We clone the existing configuration in order to apply non-default
-    # settings, for example, for solver verbosity or timeout.
-    problem.configuration = model.problem.Configuration.clone(
-        config=model.solver.configuration,
-        problem=problem
-    )
-    LOGGER.debug(str(problem))
+    if left_ns.size != 0:
+        (problem, indicators) = con_helpers.create_milp_problem(
+            left_ns, metabolites, Model, Variable, Constraint, Objective)
+        # We clone the existing configuration in order to apply non-default
+        # settings, for example, for solver verbosity or timeout.
+        problem.configuration = model.problem.Configuration.clone(
+            config=model.solver.configuration,
+            problem=problem
+        )
+        LOGGER.debug(str(problem))
+    else:
+        LOGGER.info("Left nullspace is empty!")
     cuts = list()
     for met in unconserved_mets:
-        row = met_index[met]
+        # always add the met as an uncoserved set if there is no left nullspace
+        row = met_index[met] if left_ns.size != 0 else None
         if (left_ns[row] == 0.0).all():
             LOGGER.debug("%s: singleton minimal unconservable set", met.id)
             # singleton set!

--- a/src/memote/support/consistency.py
+++ b/src/memote/support/consistency.py
@@ -218,11 +218,6 @@ def find_inconsistent_min_stoichiometry(model, atol=1e-13):
     stoich, met_index, rxn_index = con_helpers.stoichiometry_matrix(
         metabolites, reactions)
     left_ns = con_helpers.nullspace(stoich.T, atol)
-    if len(left_ns.shape) > 1:
-        LOGGER.info(
-            "nullspace has dimension %d", left_ns.shape[1]
-            if len(left_ns.shape) > 1 else 0)
-    inc_minimal = set()
     if left_ns.size != 0:
         (problem, indicators) = con_helpers.create_milp_problem(
             left_ns, metabolites, Model, Variable, Constraint, Objective)
@@ -232,9 +227,14 @@ def find_inconsistent_min_stoichiometry(model, atol=1e-13):
             config=model.solver.configuration,
             problem=problem
         )
+        LOGGER.info(
+            "nullspace has dimension %d", left_ns.shape[1]
+            if len(left_ns.shape) > 1 else 0)
         LOGGER.debug(str(problem))
     else:
         LOGGER.info("Left nullspace is empty!")
+        return {(met,) for met in unconserved_mets}
+    inc_minimal = set()
     cuts = list()
     for met in unconserved_mets:
         # always add the met as an uncoserved set if there is no left nullspace

--- a/src/memote/support/consistency.py
+++ b/src/memote/support/consistency.py
@@ -180,7 +180,7 @@ def find_unconserved_metabolites(model):
             " Solver status is '{}' (only optimal expected).".format(status))
 
 
-def find_inconsistent_min_stoichiometry(model, atol=None):
+def find_inconsistent_min_stoichiometry(model, atol=1e-13):
     """
     Detect inconsistent minimal net stoichiometries.
 

--- a/src/memote/support/consistency.py
+++ b/src/memote/support/consistency.py
@@ -217,10 +217,11 @@ def find_inconsistent_min_stoichiometry(model, atol=None):
     metabolites = sorted(internal_mets, key=get_id)
     stoich, met_index, rxn_index = con_helpers.stoichiometry_matrix(
         metabolites, reactions)
-    left_ns = con_helpers.nullspace(stoich.T)
-    # deal with numerical instabilities
-    left_ns[np.abs(left_ns) < atol] = 0.0
-    LOGGER.info("nullspace has dimension %d", left_ns.shape[1])
+    left_ns = con_helpers.nullspace(stoich.T, atol)
+    if len(left_ns.shape) > 1:
+        LOGGER.info(
+            "nullspace has dimension %d", left_ns.shape[1]
+            if len(left_ns.shape) > 1 else 0)
     inc_minimal = set()
     (problem, indicators) = con_helpers.create_milp_problem(
         left_ns, metabolites, Model, Variable, Constraint, Objective)

--- a/src/memote/support/consistency.py
+++ b/src/memote/support/consistency.py
@@ -180,9 +180,7 @@ def find_unconserved_metabolites(model):
             " Solver status is '{}' (only optimal expected).".format(status))
 
 
-# FIXME: The results of this function are currently inconsistent with
-# published results.
-def find_inconsistent_min_stoichiometry(model, atol=1e-13):
+def find_inconsistent_min_stoichiometry(model, atol=None):
     """
     Detect inconsistent minimal net stoichiometries.
 

--- a/src/memote/support/consistency_helpers.py
+++ b/src/memote/support/consistency_helpers.py
@@ -227,9 +227,11 @@ def create_milp_problem(kernel, metabolites, Model, Variable, Constraint,
         k_var = Variable("k_{}".format(met.id), type="binary")
         k_vars.append(k_var)
         ns_problem.add([y_var, k_var])
-        # This constraint is equivalent to 0 <= y[i] <= k[i].
+        # These following constraints are equivalent to 0 <= y[i] <= k[i].
         ns_problem.add(Constraint(
             y_var - k_var, ub=0, name="switch_{}".format(met.id)))
+        ns_problem.add(Constraint(
+            y_var, lb=0, name="switch2_{}".format(met.id)))
     ns_problem.update()
     # add nullspace constraints
     for (j, column) in enumerate(kernel.T):

--- a/src/memote/support/consistency_helpers.py
+++ b/src/memote/support/consistency_helpers.py
@@ -24,6 +24,8 @@ from collections import defaultdict
 
 import numpy as np
 import sympy
+
+from numpy.linalg import svd
 from six import iteritems, itervalues
 from builtins import zip, dict
 from pylru import lrudecorator
@@ -96,31 +98,12 @@ def stoichiometry_matrix(metabolites, reactions):
     return matrix, met_index, rxn_index
 
 
-def _build_is_zero(atol):
-    return sympy.matrices._iszero if atol is None else lambda x: x < atol
-
-
-def rank(matrix, atol=None):
+def rank(matrix, atol=1e-13, rtol=0):
     """
     Estimate the rank, i.e., the dimension of the column space, of a matrix.
 
-    Parameters
-    ----------
-    matrix : ndarray
-        The matrix should be at most 2-D.  A 1-D array with length k
-        will be treated as a 2-D with shape (1, k)
-    atol : float
-        The absolute tolerance for a zero singular value.  Singular values
-        smaller than ``atol`` are considered to be zero. Default: rely on sympy
-        definition of 0 (`sympy.matrices._iszero`).
-
-    """
-    return sympy.Matrix(np.atleast_2d(matrix)).rank(_build_is_zero(atol=atol))
-
-
-def nullspace(matrix, atol=None):  # noqa: D402
-    """
-    Compute normalized basis for the null space (kernel) of a matrix.
+    The algorithm used by this function is based on the singular value
+    decomposition of `stoichiometry_matrix`.
 
     Parameters
     ----------
@@ -129,8 +112,63 @@ def nullspace(matrix, atol=None):  # noqa: D402
         will be treated as a 2-D with shape (1, k)
     atol : float
         The absolute tolerance for a zero singular value.  Singular values
-        smaller than ``atol`` are considered to be zero. Default: rely on sympy
-        definition of 0 (`sympy.matrices._iszero`).
+        smaller than ``atol`` are considered to be zero.
+    rtol : float
+        The relative tolerance for a zero singular value.  Singular values less
+        than the relative tolerance times the largest singular value are
+        considered to be zero
+
+    Notes
+    -----
+    If both `atol` and `rtol` are positive, the combined tolerance is the
+    maximum of the two; that is::
+        tol = max(atol, rtol * smax)
+    Singular values smaller than ``tol`` are considered to be zero.
+
+    Returns
+    -------
+    int
+        The estimated rank of the matrix.
+
+    See Also
+    --------
+    numpy.linalg.matrix_rank
+        matrix_rank is basically the same as this function, but it does not
+        provide the option of the absolute tolerance.
+
+    """
+    matrix = np.atleast_2d(matrix)
+    sigma = svd(matrix, compute_uv=False)
+    tol = max(atol, rtol * sigma[0])
+    return int((sigma >= tol).sum())
+
+
+def nullspace(matrix, atol=1e-13, rtol=0.0):  # noqa: D402
+    """
+    Compute an approximate basis for the null space (kernel) of a matrix.
+
+    The algorithm used by this function is based on the singular value
+    decomposition of the given matrix.
+
+    Parameters
+    ----------
+    matrix : ndarray
+        The matrix should be at most 2-D.  A 1-D array with length k
+        will be treated as a 2-D with shape (1, k)
+    atol : float
+        The absolute tolerance for a zero singular value.  Singular values
+        smaller than ``atol`` are considered to be zero.
+    rtol : float
+        The relative tolerance for a zero singular value.  Singular values less
+        than the relative tolerance times the largest singular value are
+        considered to be zero.
+
+    Notes
+    -----
+    If both `atol` and `rtol` are positive, the combined tolerance is the
+    maximum of the two; that is::
+        tol = max(atol, rtol * smax)
+    Singular values smaller than ``tol`` are considered to be zero.
 
     Returns
     -------
@@ -139,11 +177,17 @@ def nullspace(matrix, atol=None):  # noqa: D402
         nullspace will be an array with shape ``(k, n)``, where n is the
         estimated dimension of the nullspace.
 
+    References
+    ----------
+    Adapted from:
+    https://scipy.github.io/old-wiki/pages/Cookbook/RankNullspace.html
+
     """
-    return np.array(
-        sympy.Matrix(np.atleast_2d(matrix))
-        .nullspace(iszerofunc=_build_is_zero(atol=atol))
-    ).T.astype(float)
+    matrix = np.atleast_2d(matrix)
+    _, sigma, vh = svd(matrix)
+    tol = max(atol, rtol * sigma[0])
+    num_nonzero = (sigma >= tol).sum()
+    return vh[num_nonzero:].conj().T
 
 
 @lrudecorator(size=2)

--- a/src/memote/support/matrix.py
+++ b/src/memote/support/matrix.py
@@ -58,8 +58,8 @@ def number_independent_conservation_relations(model):
     s_matrix, _, _ = con_helpers.stoichiometry_matrix(
         model.metabolites, model.reactions
     )
-    ln_matrix = con_helpers.nullspace(s_matrix.T)
-    return ln_matrix.shape[1]
+    left_ns = con_helpers.nullspace(s_matrix.T)
+    return left_ns.shape[1] if len(left_ns) > 1 else 0
 
 
 def matrix_rank(model):

--- a/tests/test_for_support/test_for_consistency.py
+++ b/tests/test_for_support/test_for_consistency.py
@@ -582,7 +582,6 @@ def test_find_unconserved_metabolites(model, inconsistent):
     assert set([met.id for met in unconserved_mets]) == set(inconsistent)
 
 
-@pytest.mark.xfail(reason="Bug in current implementation.")
 @pytest.mark.parametrize("model, inconsistent", [
     ("textbook", []),
     ("figure_1", [("A'",), ("B'",), ("C'",)]),

--- a/tests/test_for_support/test_for_consistency.py
+++ b/tests/test_for_support/test_for_consistency.py
@@ -584,7 +584,7 @@ def test_find_unconserved_metabolites(model, inconsistent):
 
 @pytest.mark.parametrize("model, inconsistent", [
     ("textbook", []),
-    ("figure_1", [("A'",), ("B'",), ("C'",)]),
+    ("figure_1", [("A'", "B'", "C'",)]),
     ("equation_8", [("A",), ("B",), ("C",)]),
     ("figure_2", [("X",)]),
 ], indirect=["model"])


### PR DESCRIPTION
* [x] fix #378 (issue number)
The detection of minimal uncoservable sets was not complying with experimental results.
* [x] description of feature/fix
**There was a constraint lacking in the MILP problem (y>=0)**. Moreover, the nullspace computation was verified with the sympy interface, which, by default, normalizes the nullspace yielding the same results as in the toy examples in [Gevorgyan et al., 2008](https://academic.oup.com/bioinformatics/article/24/19/2245/248822). This behavior is due to the definition of "zero". It yields the same minimal unconservable sets as the numpy implementation so it was left as it was.
* [x] tests added/passed
* [x] add an entry to the [next release](../HISTORY.rst)
