### PR TITLE
fix: point to ids column instead of index

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -3,6 +3,7 @@ History
 
 Next Release
 ------------
+* Fix bug caused from upstream changes -> cobrapy -> pandas.
 
 0.11.1 (2020-08-10)
 -------------------

--- a/src/memote/experimental/config.py
+++ b/src/memote/experimental/config.py
@@ -173,9 +173,10 @@ class ExperimentConfiguration(object):
                 minimal_growth_rate=minimal_growth_rate,
             )
             if growth.medium is not None:
-                assert growth.medium in self.media, (
-                    "Growth-experiment '{}' has an undefined medium '{}'."
-                    "".format(exp_id, growth.medium)
+                assert (
+                    growth.medium in self.media
+                ), "Growth-experiment '{}' has an undefined medium '{}'." "".format(
+                    exp_id, growth.medium
                 )
                 growth.medium = self.media[growth.medium]
             growth.load()

--- a/src/memote/experimental/config.py
+++ b/src/memote/experimental/config.py
@@ -175,7 +175,7 @@ class ExperimentConfiguration(object):
             if growth.medium is not None:
                 assert (
                     growth.medium in self.media
-                ), "Growth-experiment '{}' has an undefined medium '{}'." "".format(
+                ), "Growth-experiment '{}' has an undefined medium '{}'.".format(
                     exp_id, growth.medium
                 )
                 growth.medium = self.media[growth.medium]

--- a/src/memote/experimental/essentiality.py
+++ b/src/memote/experimental/essentiality.py
@@ -20,7 +20,6 @@
 from __future__ import absolute_import
 
 import logging
-from collections import Iterable
 
 from cobra.flux_analysis import single_gene_deletion
 

--- a/src/memote/experimental/essentiality.py
+++ b/src/memote/experimental/essentiality.py
@@ -18,9 +18,9 @@
 """Provide an interface for essentiality experiments."""
 
 from __future__ import absolute_import
-from collections import Iterable
 
 import logging
+from collections import Iterable
 
 from cobra.flux_analysis import single_gene_deletion
 

--- a/src/memote/experimental/essentiality.py
+++ b/src/memote/experimental/essentiality.py
@@ -18,6 +18,7 @@
 """Provide an interface for essentiality experiments."""
 
 from __future__ import absolute_import
+from collections import Iterable
 
 import logging
 
@@ -92,7 +93,9 @@ class EssentialityExperiment(Experiment):
             essen = single_gene_deletion(
                 model, gene_list=self.data["gene"], processes=1
             )
-        essen["gene"] = [list(g)[0] for g in essen.index]
+        essen["gene"] = [
+            list(g)[0] if isinstance(g, Iterable) else g for g in essen["ids"]
+        ]
         essen["essential"] = (essen["growth"] < self.minimal_growth_rate) | essen[
             "growth"
         ].isna()

--- a/src/memote/experimental/essentiality.py
+++ b/src/memote/experimental/essentiality.py
@@ -93,9 +93,7 @@ class EssentialityExperiment(Experiment):
             essen = single_gene_deletion(
                 model, gene_list=self.data["gene"], processes=1
             )
-        essen["gene"] = [
-            list(g)[0] if isinstance(g, Iterable) else g for g in essen["ids"]
-        ]
+        essen["gene"] = [list(g)[0] for g in essen["ids"]]
         essen["essential"] = (essen["growth"] < self.minimal_growth_rate) | essen[
             "growth"
         ].isna()

--- a/tests/test_for_suite/test_for_api.py
+++ b/tests/test_for_suite/test_for_api.py
@@ -51,12 +51,24 @@ def complete_failure(base):
     return base
 
 
-@pytest.mark.parametrize("model, code", [("complete_failure", 1),], indirect=["model"])
+@pytest.mark.parametrize(
+    "model, code",
+    [
+        ("complete_failure", 1),
+    ],
+    indirect=["model"],
+)
 def test_test_model_code(model, code):
     assert api.test_model(model) == code
 
 
-@pytest.mark.parametrize("model", ["complete_failure",], indirect=["model"])
+@pytest.mark.parametrize(
+    "model",
+    [
+        "complete_failure",
+    ],
+    indirect=["model"],
+)
 def test_test_model_result(model):
     _, result = api.test_model(model, results=True)
     # TODO: Once introduced perform schema checks here.
@@ -73,7 +85,13 @@ def test_test_model_timeout(model):
     assert model.solver.configuration.timeout == 1
 
 
-@pytest.mark.parametrize("model", ["complete_failure",], indirect=["model"])
+@pytest.mark.parametrize(
+    "model",
+    [
+        "complete_failure",
+    ],
+    indirect=["model"],
+)
 def test_snapshot_report_file(model, tmpdir):
     filename = str(tmpdir.join("index.html"))
     _, results = api.test_model(model, results=True, pytest_args=["--tb", "no"])

--- a/tests/test_for_suite/test_for_reporting/test_for_history.py
+++ b/tests/test_for_suite/test_for_reporting/test_for_history.py
@@ -57,7 +57,10 @@ MOCK_CONFIG = {
         },
         "test_basic": {"cases": ["test_number"], "title": "Basic Information"},
     },
-    "weights": {"test_number": 1.0, "test_parametrized": 1.0,},
+    "weights": {
+        "test_number": 1.0,
+        "test_parametrized": 1.0,
+    },
 }
 
 

--- a/tests/test_for_support/test_for_basic.py
+++ b/tests/test_for_support/test_for_basic.py
@@ -714,7 +714,11 @@ def test_find_nonzero_constrained_reactions(model, num):
 
 @pytest.mark.parametrize(
     "model, num",
-    [("empty", 0), ("unconstrained_rxn", 0), ("zero_constrained_rxn", 1),],
+    [
+        ("empty", 0),
+        ("unconstrained_rxn", 0),
+        ("zero_constrained_rxn", 1),
+    ],
     indirect=["model"],
 )
 def test_find_zero_constrained_reactions(model, num):
@@ -725,7 +729,11 @@ def test_find_zero_constrained_reactions(model, num):
 
 @pytest.mark.parametrize(
     "model, num",
-    [("empty", 0), ("unconstrained_rxn", 0), ("irreversible_rxn", 1),],
+    [
+        ("empty", 0),
+        ("unconstrained_rxn", 0),
+        ("irreversible_rxn", 1),
+    ],
     indirect=["model"],
 )
 def test_find_irreversible_reactions(model, num):
@@ -736,7 +744,11 @@ def test_find_irreversible_reactions(model, num):
 
 @pytest.mark.parametrize(
     "model, num",
-    [("empty", 0), ("unconstrained_rxn", 1), ("zero_constrained_rxn", 0),],
+    [
+        ("empty", 0),
+        ("unconstrained_rxn", 1),
+        ("zero_constrained_rxn", 0),
+    ],
     indirect=["model"],
 )
 def test_find_unconstrained_reactions(model, num):

--- a/tests/test_for_support/test_for_biomass.py
+++ b/tests/test_for_support/test_for_biomass.py
@@ -82,7 +82,7 @@ def sum_within_deviation(base):
 
 @register_with(MODEL_REGISTRY)
 def sum_outside_of_deviation(base):
-    """ Same as above, yet here H2O is on the wrong side of the equation
+    """Same as above, yet here H2O is on the wrong side of the equation
     which will throw off the balance.
     """
     met_a = cobra.Metabolite("lipid_c", "H744")

--- a/tests/test_for_support/test_for_consistency.py
+++ b/tests/test_for_support/test_for_consistency.py
@@ -586,7 +586,16 @@ def test_find_unconserved_metabolites(model, inconsistent):
     "model, inconsistent",
     [
         ("textbook", []),
-        ("figure_1", [("A'", "B'", "C'",)]),
+        (
+            "figure_1",
+            [
+                (
+                    "A'",
+                    "B'",
+                    "C'",
+                )
+            ],
+        ),
         ("equation_8", [("A",), ("B",), ("C",)]),
         ("figure_2", [("X",)]),
     ],
@@ -670,7 +679,11 @@ def test_find_mass_unbalanced_reactions(model, num):
 
 @pytest.mark.parametrize(
     "model, num",
-    [("loopy_toy_model", 3), ("loopless_toy_model", 0), ("infeasible_toy_model", 0),],
+    [
+        ("loopy_toy_model", 3),
+        ("loopless_toy_model", 0),
+        ("infeasible_toy_model", 0),
+    ],
     indirect=["model"],
 )
 def test_find_stoichiometrically_balanced_cycles(model, num):
@@ -702,7 +715,12 @@ def test_find_deadends(model, num):
 
 
 @pytest.mark.parametrize(
-    "model, num", [("gap_model", 1), ("gapfilled_model", 0),], indirect=["model"]
+    "model, num",
+    [
+        ("gap_model", 1),
+        ("gapfilled_model", 0),
+    ],
+    indirect=["model"],
 )
 def test_find_disconnected(model, num):
     """Expect the appropriate amount of disconnected to be found."""
@@ -712,7 +730,11 @@ def test_find_disconnected(model, num):
 
 @pytest.mark.parametrize(
     "model, num",
-    [("gap_model", 4), ("gap_model_2", 1), ("gapfilled_model", 0),],
+    [
+        ("gap_model", 4),
+        ("gap_model_2", 1),
+        ("gapfilled_model", 0),
+    ],
     indirect=["model"],
 )
 def test_find_metabolites_not_produced_with_open_bounds(model, num):
@@ -723,7 +745,11 @@ def test_find_metabolites_not_produced_with_open_bounds(model, num):
 
 @pytest.mark.parametrize(
     "model, num",
-    [("gap_model", 4), ("gap_model_2", 1), ("gapfilled_model", 0),],
+    [
+        ("gap_model", 4),
+        ("gap_model_2", 1),
+        ("gapfilled_model", 0),
+    ],
     indirect=["model"],
 )
 def test_parallel_find_metabolites_not_produced_with_open_bounds(model, num):
@@ -735,7 +761,11 @@ def test_parallel_find_metabolites_not_produced_with_open_bounds(model, num):
 
 @pytest.mark.parametrize(
     "model, num",
-    [("gap_model", 4), ("gap_model_2", 1), ("gapfilled_model", 0),],
+    [
+        ("gap_model", 4),
+        ("gap_model_2", 1),
+        ("gapfilled_model", 0),
+    ],
     indirect=["model"],
 )
 def test_find_metabolites_not_consumed_with_open_bounds(model, num):
@@ -746,7 +776,11 @@ def test_find_metabolites_not_consumed_with_open_bounds(model, num):
 
 @pytest.mark.parametrize(
     "model, num",
-    [("gap_model", 4), ("gap_model_2", 1), ("gapfilled_model", 0),],
+    [
+        ("gap_model", 4),
+        ("gap_model_2", 1),
+        ("gapfilled_model", 0),
+    ],
     indirect=["model"],
 )
 def test_parallel_find_metabolites_not_consumed_with_open_bounds(model, num):

--- a/tests/test_for_support/test_for_helpers.py
+++ b/tests/test_for_support/test_for_helpers.py
@@ -564,7 +564,9 @@ def test_find_converting_reactions(model, met_pair, expected):
 
 @pytest.mark.parametrize(
     "model, reaction_id, bounds",
-    [("one_exchange", "EX_abc_e", (-1000, 1000)),],
+    [
+        ("one_exchange", "EX_abc_e", (-1000, 1000)),
+    ],
     indirect=["model"],
 )
 def test_open_boundaries(model, reaction_id, bounds):


### PR DESCRIPTION
* [x] fix #704 
`pytest` is failing because an essentially test is extracting the wrong information from [`cobra.flux_analysis.single_cell_deletion`](https://github.com/opencobra/cobrapy/blob/d9d3bf99198ee0a93346bd860fce4cf217297937/src/cobra/flux_analysis/deletion.py#L236), whose behavior has recently changed. 
* [x] description of feature/fix
Change index to column access. An if statement was added to the list comprehension because it made the error more clear, but feel free to remove it.
* [x] tests added/passed
* [x] add an entry to the [next release](../HISTORY.rst)
