### PR TITLE
Replace travis with github actions

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -20,7 +20,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest, macos-latest, windows-latest]
-        python-version: [3.6, 3.7, 3.8]
+        python-version: [3.8, 3.9, '3.10']
 
     steps:
     - uses: actions/checkout@v2

--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -4,6 +4,11 @@ History
 Next Release
 ------------
 
+* Fix ``memote online``, given breaking changes in Github Authentication.
+* Replace travis-CI with github actions.
+* (Cookiecutter) Add an action for comparing models in Pull
+  Requests (`#23 <https://github.com/opencobra/cookiecutter-memote/pull/23>`_).
+
 0.13.0 (2021-06-12)
 -------------------
 * Fix logic errors with orphan and dead-end metabolite detection. This problem

--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -8,6 +8,7 @@ Next Release
 * Replace travis-CI with github actions.
 * (Cookiecutter) Add an action for comparing models in Pull
   Requests (`#23 <https://github.com/opencobra/cookiecutter-memote/pull/23>`_).
+* Dropped support for python3.6 and python3.7 in favor of python3.9 and python3.10.
 
 0.13.0 (2021-06-12)
 -------------------

--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -8,7 +8,7 @@ Next Release
 * Replace travis-CI with github actions.
 * (Cookiecutter) Add an action for comparing models in Pull
   Requests (`#23 <https://github.com/opencobra/cookiecutter-memote/pull/23>`_).
-* Dropped support for python3.6 and python3.7 in favor of python3.9 and python3.10.
+* Dropped support for python3.6 and python3.7 in favor of python3.8 to python3.11.
 
 0.14.0 (2023-09-13)
 -------------------

--- a/docs/getting_started.rst
+++ b/docs/getting_started.rst
@@ -146,19 +146,18 @@ results and report are stored on the deployment branch (typically the
 ``gh-pages`` branch).
 
 
-In order to make your local git repository available online and enable continuous integration via Travis CI, you can run:
+In order to make your local git repository available online and enable continuous integration via Github Actions, you can run:
 
 .. code-block:: console
 
-    $ memote online
+    $ memote online --token "your-github-token"
 
-This will use require your GitHub password to create the repository, connect it
-with Travis CI, and generate a GitHub token to be used for continuous
-integration of the history report.
+This requires setting a token on Github (see `GitHub documentation`_) and providing it as 
+the ``--token`` argument. Alternatively, an environment variable ``GITHUB_TOKEN`` can be set to avoid writing the token in the command line.
 
 Now, after each edit to the model in the repository, the user can generate
 an update to the continuous model report shown at the project's gh-pages
-branch. That means each commit should be pushed to Travis individually.
+branch. That means each commit should be pushed individually.
 
 The continuous report will look like this:
 
@@ -227,6 +226,7 @@ history report in your repository, you can run ``memote report history`` from
 any branch at any time to generate it.
 
 .. _GitHub: https://github.com
+.. _GitHub documentation: https://docs.github.com/en/authentication/keeping-your-account-and-data-secure/creating-a-personal-access-token
 .. _GitLab: https://gitlab.com
 
 *******************************************************************************

--- a/setup.cfg
+++ b/setup.cfg
@@ -43,12 +43,12 @@ install_requires =
 	future
 	pytest >=4.0
 	gitpython
+	PyGithub ~= 1.55
 	pandas
 	Jinja2
 	cookiecutter
 	cobra >=0.17
 	ruamel.yaml >=0.15
-	travis-encrypt<1.2.0
 	sympy
 	sqlalchemy
 	requests

--- a/src/memote/suite/cli/callbacks.py
+++ b/src/memote/suite/cli/callbacks.py
@@ -66,12 +66,14 @@ def validate_repository(context, param, value):
         raise click.BadParameter("No GitHub repository slug provided or configured.")
 
 
-def validate_username(context, param, value):
-    """Load username from different locations."""
+def validate_token(context, param, value):
+    """Verify that a token was provided, pointing to documentation."""
     if value is not None:
         return value
     else:
-        raise click.BadParameter("No GitHub username provided or configured.")
+        raise click.BadParameter(
+            "No GitHub token provided. See https://memote.readthedocs.io/en/latest/getting_started.html#ci-tested-online-and-public-workflow for instructions on how to set it up."
+        )
 
 
 def probe_git():

--- a/src/memote/suite/cli/callbacks.py
+++ b/src/memote/suite/cli/callbacks.py
@@ -72,7 +72,9 @@ def validate_token(context, param, value):
         return value
     else:
         raise click.BadParameter(
-            "No GitHub token provided. See https://memote.readthedocs.io/en/latest/getting_started.html#ci-tested-online-and-public-workflow for instructions on how to set it up."
+            "No GitHub token provided. See https://memote.readthedocs.io/en/"
+            "latest/getting_started.html#ci-tested-online-and-public-workflow"
+            " for instructions on how to set it up."
         )
 
 

--- a/src/memote/suite/cli/runner.py
+++ b/src/memote/suite/cli/runner.py
@@ -587,6 +587,7 @@ def _setup_gh_repo(github_token, github_repository):
 @click.option(
     "--github-token",
     envvar="GITHUB_TOKEN",
+    callback=callbacks.validate_token,
     help="Personal access token on GitHub.",
 )
 @click.option(

--- a/src/memote/suite/cli/runner.py
+++ b/src/memote/suite/cli/runner.py
@@ -576,9 +576,8 @@ def history(
     LOGGER.info("Done.")
 
 
-def _setup_gh_repo(github_token, github_repository, github_username):
+def _setup_gh_repo(github_token, github_repository):
     g = Github(github_token)
-    # TODO: check `get_user(github_username)`
     user = g.get_user()
     _ = user.create_repo(github_repository)
 
@@ -596,15 +595,10 @@ def _setup_gh_repo(github_token, github_repository, github_username):
     help="The repository name on GitHub. Usually this is configured for you.",
 )
 @click.option(
-    "--github_username",
-    callback=callbacks.validate_username,
-    help="The GitHub username. Usually this is configured for you.",
-)
-@click.option(
     "--deployment",
     help="Deployment branch to be pushed. Usually this is configured for you.",
 )
-def online(github_token, github_repository, github_username, deployment):
+def online(github_token, github_repository, deployment):
     """Upload the repository to GitHub and create a gh-pages branch."""
     # Save the encrypted token in the travis config then commit and push
     try:
@@ -616,7 +610,7 @@ def online(github_token, github_repository, github_username, deployment):
         )
         sys.exit(1)
     LOGGER.info("Push changes to GitHub.")
-    _setup_gh_repo(github_token, github_repository, github_username)
+    _setup_gh_repo(github_token, github_repository)
     active_branch = repo.active_branch.name
     repo.git.push("--set-upstream", "origin", active_branch)
     repo.heads[deployment].checkout()

--- a/src/memote/suite/cli/runner.py
+++ b/src/memote/suite/cli/runner.py
@@ -314,11 +314,10 @@ def new(directory, replay):
     if directory is None:
         directory = os.getcwd()
     cookiecutter(
-        # TODO: update cookiecutter at opencobra
-        "gh:carrascomj/cookiecutter-memote",
+        "gh:opencobra/cookiecutter-memote",
         output_dir=directory,
         replay=replay,
-        checkout="refactor-gh-actions",
+        checkout="master",
     )
 
 

--- a/src/memote/suite/cli/runner.py
+++ b/src/memote/suite/cli/runner.py
@@ -578,6 +578,7 @@ def history(
 
 def _setup_gh_repo(github_token, github_repository, github_username):
     g = Github(github_token)
+    # TODO: check `get_user(github_username)`
     user = g.get_user()
     _ = user.create_repo(github_repository)
 
@@ -618,7 +619,7 @@ def online(github_token, github_repository, github_username, deployment):
     _setup_gh_repo(github_token, github_repository, github_username)
     active_branch = repo.active_branch.name
     repo.git.push("--set-upstream", "origin", active_branch)
-    repo.heads["gh-pages"].checkout()
+    repo.heads[deployment].checkout()
     repo.git.push("--set-upstream", "origin", deployment)
     repo.heads[active_branch].checkout()
 

--- a/src/memote/suite/cli/runner.py
+++ b/src/memote/suite/cli/runner.py
@@ -587,19 +587,23 @@ def _setup_gh_repo(github_token, github_repository, github_username):
 @click.option(
     "--github-token",
     envvar="GITHUB_TOKEN",
-    help="The repository name on GitHub. Usually this is configured " "for you.",
+    help="Personal access token on GitHub.",
 )
 @click.option(
     "--github_repository",
     callback=callbacks.validate_repository,
-    help="The repository name on GitHub. Usually this is configured " "for you.",
+    help="The repository name on GitHub. Usually this is configured for you.",
 )
 @click.option(
     "--github_username",
     callback=callbacks.validate_username,
     help="The GitHub username. Usually this is configured for you.",
 )
-def online(github_token, github_repository, github_username):
+@click.option(
+    "--deployment",
+    help="Deployment branch to be pushed. Usually this is configured for you.",
+)
+def online(github_token, github_repository, github_username, deployment):
     """Upload the repository to GitHub and create a gh-pages branch."""
     # Save the encrypted token in the travis config then commit and push
     try:
@@ -615,8 +619,7 @@ def online(github_token, github_repository, github_username):
     active_branch = repo.active_branch.name
     repo.git.push("--set-upstream", "origin", active_branch)
     repo.heads["gh-pages"].checkout()
-    # TODO: the name of the deployment branch should be taken form memote.ini
-    repo.git.push("--set-upstream", "origin", "gh-pages")
+    repo.git.push("--set-upstream", "origin", deployment)
     repo.heads[active_branch].checkout()
 
 

--- a/src/memote/suite/cli/runner.py
+++ b/src/memote/suite/cli/runner.py
@@ -23,21 +23,17 @@ import logging
 import os
 import sys
 import tempfile
-from getpass import getpass
 from gzip import GzipFile
 from multiprocessing import Process
 from os.path import isfile, join
 from shutil import copy2, move
 from tempfile import mkdtemp
-from time import sleep
 
 import click
 import click_log
 import git
-import requests
-import travis.encrypt as te
 from cookiecutter.main import cookiecutter, get_user_config
-from requests.exceptions import HTTPError
+from github import Github
 from sqlalchemy import create_engine
 from sqlalchemy.exc import ArgumentError
 
@@ -53,12 +49,6 @@ from memote.suite.results import (
     SQLResultManager,
 )
 from memote.utils import is_modified, stdout_notifications
-
-
-try:
-    from urllib.parse import quote_plus
-except ImportError:
-    from urllib import quote_plus
 
 
 LOGGER = logging.getLogger()
@@ -324,7 +314,11 @@ def new(directory, replay):
     if directory is None:
         directory = os.getcwd()
     cookiecutter(
-        "gh:opencobra/cookiecutter-memote", output_dir=directory, replay=replay
+        # TODO: update cookiecutter at opencobra
+        "gh:carrascomj/cookiecutter-memote",
+        output_dir=directory,
+        replay=replay,
+        checkout="refactor-gh-actions",
     )
 
 
@@ -582,312 +576,18 @@ def history(
     LOGGER.info("Done.")
 
 
-def _setup_gh_repo(github_repository, github_username, note):
-    password = getpass("GitHub Password: ")
-
-    headers = {"Accept": "application/vnd.github.v3+json", "User-Agent": "Memote Query"}
-    credentials = (github_username, password)
-
-    # Authenticate user on GitHub
-    try:
-        LOGGER.info("Using your credentials to authenticate you on GitHub.")
-        response = requests.get(
-            "https://api.github.com/user", auth=credentials, headers=headers
-        )
-        response.raise_for_status()
-    except HTTPError as error:
-        if error.response.status_code == 401:
-            LOGGER.critical("Authentication failed! " "Incorrect username or password?")
-            sys.exit(1)
-        else:
-            LOGGER.critical(
-                "Your account could not be authenticated. " "{}".format(str(error))
-            )
-            sys.exit(1)
-    else:
-        user = response.json()
-        when = user[u"created_at"]
-        LOGGER.info(
-            "Logged in to user '{}' created on '{}'.".format(user[u"login"], when)
-        )
-
-    # Get a user's repository or create the repository if it doesn't exist on
-    # GitHub.
-    try:
-        LOGGER.info("Retrieving repository {}".format(github_repository))
-        endpoint = "https://api.github.com/repos/{}/{}".format(
-            user["login"], github_repository
-        )
-        response = requests.get(endpoint, auth=credentials, headers=headers)
-        response.raise_for_status()
-        LOGGER.warning(
-            "Using existing repository '{}'. This may override previous "
-            "settings.".format(github_repository)
-        )
-        gh_repo = response.json()
-    except HTTPError as error:
-        if error.response.status_code == 404:
-            try:
-                LOGGER.info(
-                    "'{}' did not exist on GitHub yet."
-                    " Creating it for you now!".format(github_repository)
-                )
-                response = requests.post(
-                    "https://api.github.com/user/repos",
-                    auth=credentials,
-                    headers=headers,
-                    json={"name": github_repository},
-                )
-                response.raise_for_status()
-            except HTTPError as error:
-                LOGGER.critical(
-                    "The repository cannot be created on GitHub. "
-                    "{}".format(str(error))
-                )
-                sys.exit(1)
-            else:
-                gh_repo = response.json()
-        else:
-            LOGGER.critical(
-                "The repository cannot be found on GitHub. " "{}".format(str(error))
-            )
-            sys.exit(1)
-
-    # Create a personal access token on GitHub which is only used to generate
-    # the Travis APIv3 access token.
-    auth_note = "Travis APIv3 Auth for {}".format(github_repository)
-    payload = {
-        "scopes": [
-            "read:org",
-            "user:email",
-            "repo_deployment",
-            "repo:status",
-            "write:repo_hook",
-        ],
-        "note": auth_note,
-    }
-    try:
-        LOGGER.info("Creating Travis APIv3 authentication token for you now!")
-        response = requests.post(
-            "https://api.github.com/authorizations",
-            auth=credentials,
-            headers=headers,
-            json=payload,
-        )
-        response.raise_for_status()
-    except HTTPError as error:
-        LOGGER.info(
-            "An error occurred. Most likely an authentication token with the "
-            "note '{}' already exists. If so, please delete it and try again."
-            "If not, please refer to the following error code for "
-            "further information: {}".format(auth_note, str(error))
-        )
-        sys.exit(1)
-    else:
-        auth_response = response.json()
-        LOGGER.info("Success!")
-
-    # Create a personal access token that allows Travis to push to a repo.
-    payload = {"scopes": ["repo"], "note": note}
-    try:
-        LOGGER.info("Creating repo access token.")
-        response = requests.post(
-            "https://api.github.com/authorizations",
-            auth=credentials,
-            headers=headers,
-            json=payload,
-        )
-        response.raise_for_status()
-    except HTTPError as error:
-        LOGGER.critical(
-            "An error occurred. Most likely a repo access token with the "
-            "note '{}' already exists. "
-            "Either delete it or choose another note using the option "
-            "'--note'. If not, please refer to the following error code for "
-            "further information: {}".format(note, str(error))
-        )
-        sys.exit(1)
-    else:
-        repo_access_response = response.json()
-        LOGGER.info("Success!")
-    return gh_repo["full_name"], auth_response["token"], repo_access_response["token"]
-
-
-def _setup_travis_ci(gh_repo_name, auth_token, repo_access_token):
-    # travis-ci.org is the open source endpoint only! We will need to hit
-    # travis-ci.com for private projects!
-
-    # Headers for API v2. This is only necessary because generating a Travis
-    # API token from a GitHub Token isn't possible in the API v3 yet. This way
-    # is recommended as per:
-    # https://github.com/travis-ci/travis-ci/issues/9273
-    headers_v2_only = {
-        "User-Agent": "Memote",
-        "Accept": "application/vnd.travis-ci.2+json",
-    }
-
-    # Generate Travis API token:
-    try:
-        LOGGER.info("Generating Travis API token.")
-        response = requests.post(
-            "https://api.travis-ci.org/auth/github",
-            headers=headers_v2_only,
-            data={"github_token": auth_token},
-        )
-        response.raise_for_status()
-    except HTTPError as error:
-        LOGGER.critical(
-            "Something is wrong with the generated APIv3 authentication token "
-            "or you did not link your GitHub account on "
-            "'https://travis-ci.org/'? Please refer to the following error "
-            "message for further information: {}".format(str(error))
-        )
-        sys.exit(1)
-    else:
-        LOGGER.info("Success!")
-        travis_api_token = response.json()["access_token"]
-
-    # Headers for API v3!
-    headers = {
-        "Travis-API-Version": "3",
-        "Authorization": "token {}".format(travis_api_token),
-        "User-Agent": "Memote Query",
-    }
-
-    # Authenticate the User on Travis
-    try:
-        LOGGER.info("Authorizing with TravisCI.")
-        response = requests.get("https://api.travis-ci.org/user", headers=headers)
-        response.raise_for_status()
-    except HTTPError as error:
-        LOGGER.critical(
-            "Something is wrong with the generated token or you did not "
-            "link your GitHub account on 'https://travis-ci.org/'? Please "
-            "refer to the following error code for "
-            "further information: {}".format(str(error))
-        )
-        sys.exit(1)
-    else:
-        LOGGER.info("Success!")
-        t_user = response.json()
-
-    # Synchronize a User's projects between GitHub and Travis
-    LOGGER.info("Synchronizing user projects between GitHub and Travis.")
-    synced = False
-    for _ in range(60):
-        response = requests.post(
-            "https://api.travis-ci.org/user/{}/sync".format(t_user["id"]),
-            headers=headers,
-        )
-        if response.status_code == 200:
-            synced = True
-            LOGGER.info("Success!")
-            break
-        else:
-            LOGGER.info("Still synchronizing...")
-            sleep(0.5)
-    if not synced:
-        LOGGER.critical(
-            "Could not synchronize your projects between GitHub and Travis!"
-            "The latest response code is {}".format(response.status_code)
-        )
-        sys.exit(1)
-
-    # Make sure GitHub repo can be found on Travis CI.#
-    url_safe_repo_name = quote_plus(gh_repo_name)
-    try:
-        LOGGER.info("Find repository {} on Travis CI".format(gh_repo_name))
-        response = requests.get(
-            "https://api.travis-ci.org/repo/{}".format(url_safe_repo_name),
-            headers=headers,
-        )
-        response.raise_for_status()
-    except HTTPError as error:
-        if error.response.status_code == 404:
-            LOGGER.critical(
-                "Repository could not be found. Is it on GitHub already and "
-                "spelled correctly?"
-            )
-            sys.exit(1)
-        else:
-            LOGGER.critical(
-                "An error occurred. Please refer to the following error "
-                "message for further information: {}".format(str(error))
-            )
-            sys.exit(1)
-    else:
-        LOGGER.info("Success!")
-        t_repo = response.json()
-
-    # Use repo ID to activate Travis CI for this repo
-    try:
-        LOGGER.info("Activating automatic testing for you " "on Travis CI.")
-        endpoint = "https://api.travis-ci.org/repo/{}/activate".format(
-            url_safe_repo_name
-        )
-        response = requests.post(endpoint, headers=headers)
-        response.raise_for_status()
-    except HTTPError as error:
-        LOGGER.critical(
-            "Unable to enable automatic testing on Travis CI! "
-            "Please refer to the following error message for "
-            "further information: {}".format(str(error))
-        )
-        sys.exit(1)
-
-    # Check if activation was successful
-    activated = False
-    for _ in range(60):
-        try:
-            LOGGER.info(
-                "Check if activation {} on Travis CI "
-                "was successful".format(gh_repo_name)
-            )
-            response = requests.get(
-                "https://api.travis-ci.org/repo/{}".format(url_safe_repo_name),
-                headers=headers,
-            )
-        except HTTPError as error:
-            LOGGER.critical(
-                "An error occurred. Please refer to the following error "
-                "message for further information: {}".format(str(error))
-            )
-            sys.exit(1)
-        else:
-            t_repo = response.json()
-        if t_repo["active"]:
-            activated = True
-            LOGGER.info(
-                "Your repository is now on GitHub and automatic testing has "
-                "been enabled on Travis CI. Congrats!"
-            )
-            break
-        else:
-            LOGGER.info("Still activating...")
-            sleep(0.5)
-    if not activated:
-        LOGGER.critical(
-            "Unable to enable automatic testing on Travis CI! "
-            "Delete all tokens belonging to this repo at "
-            "https://github.com/settings/tokens then try running "
-            "`memote online` again. If this fails yet again, "
-            "please open an issue at "
-            "https://github.com/opencobra/memote/issues."
-        )
-        sys.exit(1)
-    LOGGER.info("Encrypting GitHub token for repo '{}'.".format(gh_repo_name))
-    key = te.retrieve_public_key(gh_repo_name)
-    secret = te.encrypt_key(key, "GITHUB_TOKEN={}".format(repo_access_token).encode())
-    return secret
+def _setup_gh_repo(github_token, github_repository, github_username):
+    g = Github(github_token)
+    user = g.get_user()
+    _ = user.create_repo(github_repository)
 
 
 @cli.command(context_settings=CONTEXT_SETTINGS)
 @click.help_option("--help", "-h")
 @click.option(
-    "--note",
-    default="memote-ci access",
-    show_default=True,
-    help="A note describing a personal access token on GitHub. " "Must be unique!",
+    "--github-token",
+    envvar="GITHUB_TOKEN",
+    help="The repository name on GitHub. Usually this is configured " "for you.",
 )
 @click.option(
     "--github_repository",
@@ -899,9 +599,9 @@ def _setup_travis_ci(gh_repo_name, auth_token, repo_access_token):
     callback=callbacks.validate_username,
     help="The GitHub username. Usually this is configured for you.",
 )
-def online(note, github_repository, github_username):
-    """Upload the repository to GitHub and enable testing on Travis CI."""
-    callbacks.git_installed()
+def online(github_token, github_repository, github_username):
+    """Upload the repository to GitHub and create a gh-pages branch."""
+    # Save the encrypted token in the travis config then commit and push
     try:
         repo = git.Repo()
     except git.InvalidGitRepositoryError:
@@ -910,34 +610,14 @@ def online(note, github_repository, github_username):
             "the current branch's commit history."
         )
         sys.exit(1)
-    if note == "memote-ci access":
-        note = "{} to {}".format(note, github_repository)
-
-    # Github API calls
-    # Set up the git repository on GitHub via API v3.
-    gh_repo_name, auth_token, repo_access_token = _setup_gh_repo(
-        github_repository, github_username, note
-    )
-
-    # Travis API calls
-    # Configure Travis CI to use Github auth token then return encrypted token.
-    secret = _setup_travis_ci(gh_repo_name, auth_token, repo_access_token)
-
-    # Save the encrypted token in the travis config then commit and push
-    LOGGER.info("Storing GitHub token in '.travis.yml'.")
-    config = te.load_travis_configuration(".travis.yml")
-    global_env = config.setdefault("env", {}).get("global")
-    if global_env is None:
-        config["env"]["global"] = global_env = {}
-    try:
-        global_env["secure"] = secret
-    except TypeError:
-        global_env.append({"secure": secret})
-    te.dump_travis_configuration(config, ".travis.yml")
-    LOGGER.info("Add, commit and push changes to '.travis.yml' to GitHub.")
-    repo.index.add([".travis.yml"])
-    repo.git.commit("--message", "chore: add encrypted GitHub access token")
-    repo.git.push("--set-upstream", "origin", repo.active_branch.name)
+    LOGGER.info("Push changes to GitHub.")
+    _setup_gh_repo(github_token, github_repository, github_username)
+    active_branch = repo.active_branch.name
+    repo.git.push("--set-upstream", "origin", active_branch)
+    repo.heads["gh-pages"].checkout()
+    # TODO: the name of the deployment branch should be taken form memote.ini
+    repo.git.push("--set-upstream", "origin", "gh-pages")
+    repo.heads[active_branch].checkout()
 
 
 cli.add_command(report)

--- a/src/memote/suite/cli/runner.py
+++ b/src/memote/suite/cli/runner.py
@@ -614,7 +614,11 @@ def online(github_token, github_repository, deployment):
     _setup_gh_repo(github_token, github_repository)
     active_branch = repo.active_branch.name
     repo.git.push("--set-upstream", "origin", active_branch)
-    repo.heads[deployment].checkout()
+    try:
+        repo.heads[deployment].checkout()
+    except IndexError:
+        # branch was not created
+        repo.heads[active_branch].checkout(b=deployment)
     repo.git.push("--set-upstream", "origin", deployment)
     repo.heads[active_branch].checkout()
 

--- a/tests/test_for_suite/test_for_cli/test_for_runner.py
+++ b/tests/test_for_suite/test_for_cli/test_for_runner.py
@@ -20,6 +20,8 @@ import os
 from builtins import str
 from os.path import basename, dirname, join
 
+from click.testing import CliRunner
+
 import memote.suite.cli.runner
 from memote.suite.cli.config import ConfigFileProcessor
 from memote.suite.cli.runner import cli
@@ -157,7 +159,7 @@ def test_new(runner, tmp_path):
     assert result.exit_code == 0
 
 
-def test_online(runner, mock_repo, monkeypatch, tmp_path):
+def test_online(runner: CliRunner, mock_repo, monkeypatch, tmp_path):
     # Build-up
     def mock_setup_gh_repo(*args, **kwargs):
         return "mock_repo_name", "mock_auth_token", "mock_repo_access_token"
@@ -203,6 +205,11 @@ def test_online(runner, mock_repo, monkeypatch, tmp_path):
         # Clean up changes to the git origin.
         local_repo.git.reset("--hard", "HEAD~")
         local_repo.git.push("--force", "origin", "master")
+    if result.exit_code != 0:
+        print(
+            f"Output -> {result.output}\nException: {result.exception}\n"
+            f"Exec info: {result.exc_info}\nStdout: {result.stdout}\n"
+        )
 
     assert result.exit_code == 0
 

--- a/tests/test_for_suite/test_for_cli/test_for_runner.py
+++ b/tests/test_for_suite/test_for_cli/test_for_runner.py
@@ -162,17 +162,11 @@ def test_online(runner, mock_repo, monkeypatch, tmp_path):
     def mock_setup_gh_repo(*args, **kwargs):
         return "mock_repo_name", "mock_auth_token", "mock_repo_access_token"
 
-    def mock_setup_travis_ci(*args, **kwargs):
-        return "mock_secret"
-
     # Use the Repository from the mock_repo fixture as the origin to clone from
     path2origin, origin_repo = mock_repo
     with monkeypatch.context() as monkey:
         monkey.chdir(path2origin)
         monkey.setattr(memote.suite.cli.runner, "_setup_gh_repo", mock_setup_gh_repo)
-        monkey.setattr(
-            memote.suite.cli.runner, "_setup_travis_ci", mock_setup_travis_ci
-        )
         # We have to allow pushing into the 'origin' repo.
         with origin_repo.config_writer() as writer:
             writer.set_value("receive", "denyCurrentBranch", "ignore").release()
@@ -194,6 +188,7 @@ def test_online(runner, mock_repo, monkeypatch, tmp_path):
         context_settings = ConfigFileProcessor.read_config()
         github_repository = context_settings["github_repository"]
         github_username = context_settings["github_username"]
+        deployment = context_settings["deployment"]
 
         result = runner.invoke(
             cli,
@@ -203,6 +198,8 @@ def test_online(runner, mock_repo, monkeypatch, tmp_path):
                 github_repository,
                 "--github_username",
                 github_username,
+                "--deployment",
+                deployment,
             ],
         )
 

--- a/tests/test_for_suite/test_for_cli/test_for_runner.py
+++ b/tests/test_for_suite/test_for_cli/test_for_runner.py
@@ -187,7 +187,6 @@ def test_online(runner, mock_repo, monkeypatch, tmp_path):
         # Build context_settings
         context_settings = ConfigFileProcessor.read_config()
         github_repository = context_settings["github_repository"]
-        github_username = context_settings["github_username"]
         deployment = context_settings["deployment"]
 
         result = runner.invoke(
@@ -196,8 +195,6 @@ def test_online(runner, mock_repo, monkeypatch, tmp_path):
                 "online",
                 "--github_repository",
                 github_repository,
-                "--github_username",
-                github_username,
                 "--deployment",
                 deployment,
             ],

--- a/tests/test_for_suite/test_for_cli/test_for_runner.py
+++ b/tests/test_for_suite/test_for_cli/test_for_runner.py
@@ -199,6 +199,8 @@ def test_online(runner: CliRunner, mock_repo, monkeypatch, tmp_path):
                 github_repository,
                 "--deployment",
                 deployment,
+                "--github-token",
+                "some_token",
             ],
         )
 


### PR DESCRIPTION
This is accompanied with a [PR to cookiecutter-memote](https://github.com/opencobra/cookiecutter-memote/pull/21). 

* [x] fix #706

Github changed the API for authentication (see [deprecation notice](https://developer.github.com/changes/2020-02-14-deprecating-oauth-auth-endpoint/)):
* Username+password authentication is no longer possible, it has to be done via a token. The [web application flow](https://docs.github.com/en/developers/apps/building-oauth-apps/authorizing-oauth-apps#web-application-flow) may be relevant for memote.
* The authorization endpoint does not exist anymore.

Thus, the command line option `memote online` has to be updated accordingly.

* [x] description of feature/fix

For the reasons outlined above, it is easier to replace travis with github actions than to figure out the new workflow; the difficulty lies in programmatically generating github's token, which does not seem to be possible anymore. Github actions does not need an user-created token since it has access to its own token via a secret.

As of now, the user has to create a token following [github documentation](https://docs.github.com/en/authentication/keeping-your-account-and-data-secure/creating-a-personal-access-token) to specify the token and add it as an argument:

```bash
memote online --token "your-github-token"
```

Or, alternatively, have an environment variable `GITHUB_TOKEN` set to the token.

```bash
GITHUB_TOKEN="your-github-token" memote online
```

It would be better to have a setup more similar to the [web application flow](https://docs.github.com/en/developers/apps/building-oauth-apps/authorizing-oauth-apps#web-application-flow), where the user would be pointed to create a token during `memote new`.
 
* [x] tests added/passed
* [x] add an entry to the [next release](../HISTORY.rst)
