### PR TITLE
feat: allow setting solver backend early

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -4,6 +4,8 @@ History
 Next Release
 ------------
 
+* Set the solver backend earlier in the process, before a COBRApy model is created.
+
 0.16.0 (2023-11-19)
 -------------------
 * Allow the hybrid interface as a solver.


### PR DESCRIPTION
Setting the solver backend before creating a model saves time (the model doesn't have to be recreated), and has other advantages, too.

* [x] description of feature/fix
* [x] tests added/passed
* [x] add an entry to the [next release](../HISTORY.rst)
