### PR TITLE
Add option to output json format reports

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -5,6 +5,7 @@ Next Release
 ------------
 * Replace ``goodtables`` with ``pandera`` for data validation. This change is not
   100% backwards compatible, although most data tables should be unaffected.
+* Add option to output json report files.
 
 0.16.1 (2023-11-21)
 -------------------

--- a/src/memote/suite/cli/reports.py
+++ b/src/memote/suite/cli/reports.py
@@ -63,6 +63,11 @@ def report():
     help="Path for the HTML report output.",
 )
 @click.option(
+    "--json",
+    is_flag=True,
+    help="Flag to generate a json report file with the same base filename as the html report.",
+)
+@click.option(
     "--pytest-args",
     "-a",
     callback=callbacks.validate_pytest_args,
@@ -129,6 +134,7 @@ def report():
 def snapshot(
     model,
     filename,
+    json,
     pytest_args,
     exclusive,
     skip,
@@ -177,6 +183,11 @@ def snapshot(
     with open(filename, "w", encoding="utf-8") as file_handle:
         LOGGER.info("Writing snapshot report to '%s'.", filename)
         file_handle.write(api.snapshot_report(results, config))
+    if json:
+        filename = filename[:-4] + "json"
+        with open(filename, "w", encoding="utf-8") as file_handle:
+            LOGGER.info("Writing additional snapshot report to '%s'.", filename)
+            file_handle.write(api.snapshot_report(results, config, False))
 
 
 @report.command(context_settings=CONTEXT_SETTINGS)


### PR DESCRIPTION
* [x] Does not fix an open issue: it adds functionality
* [x] description of feature/fix

Json files are easier to parse for automated high-throughput applications. Since this output option was silently supported in the API, I exposed it via a Boolean flag.

* [x] tests added/passed

All tests passed (`make qa`).

* [x] add an entry to the [next release](../HISTORY.rst)